### PR TITLE
feat(hareceiver): add Home Assistant log receiver

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 *.rwq binary
 *.hex text
 *.mp4 filter=lfs diff=lfs merge=lfs -text
+
+# Captured HTTP response bodies parsed byte-for-byte by tests and fuzzers.
+otelcolmod/hareceiver/_testdata/** text eol=lf

--- a/cmd/odbagent/components.go
+++ b/cmd/odbagent/components.go
@@ -55,6 +55,7 @@ import (
 	otelconftelemetry "go.opentelemetry.io/collector/service/telemetry/otelconftelemetry"
 
 	"github.com/oteldb/oteldb/otelcolmod/chreceiver"
+	"github.com/oteldb/oteldb/otelcolmod/hareceiver"
 	"github.com/oteldb/oteldb/otelcolmod/hubblereceiver"
 	_ "github.com/oteldb/oteldb/otelcolmod/odblogparser"
 	_ "github.com/oteldb/oteldb/otelcolmod/odbsafety"
@@ -98,6 +99,7 @@ func components() (otelcol.Factories, error) {
 
 		prometheusremotewritereceiver.NewFactory(),
 		chreceiver.NewFactory(),
+		hareceiver.NewFactory(),
 		hubblereceiver.NewFactory(),
 		tetragonreceiver.NewFactory(),
 	)

--- a/go.mod
+++ b/go.mod
@@ -540,7 +540,7 @@ require (
 	go.opentelemetry.io/collector/config/configauth v1.64.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.64.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v1.64.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.64.0 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.64.0
 	go.opentelemetry.io/collector/config/configretry v1.64.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.158.0 // indirect
 	go.opentelemetry.io/collector/confmap/xconfmap v0.158.0 // indirect
@@ -556,7 +556,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.158.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionmiddleware v0.158.0 // indirect
 	go.opentelemetry.io/collector/extension/extensiontest v0.158.0 // indirect
-	go.opentelemetry.io/collector/extension/xextension v0.158.0 // indirect
+	go.opentelemetry.io/collector/extension/xextension v0.158.0
 	go.opentelemetry.io/collector/featuregate v1.64.0
 	go.opentelemetry.io/collector/filter v0.158.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.158.0 // indirect

--- a/otelcolmod/hareceiver/README.md
+++ b/otelcolmod/hareceiver/README.md
@@ -41,14 +41,17 @@ receivers:
 | `poll_interval` | `10s` | Delay between cursor-advancing requests. |
 | `batch_size` | `1000` | Maximum journal entries per request. |
 | `parse_message` | `true` | Extract the level, thread and logger Core and Supervisor embed in the message, see below. |
+| `recombine_window` | `1s` | Join journal entries that are fragments of one multi-line message, see below. `0` disables. |
 | `severity_from_message` | `false` | Best-effort severity detection for messages `parse_message` does not recognize. |
 | `storage` | — | Storage extension holding cursors. Without it, every start begins at the tail. |
 
 The remaining settings come from `confighttp.ClientConfig` (TLS, timeouts, extra headers,
 compression).
 
-`kind` is one of `host`, `core`, `supervisor`, or `addon`; `addon` also requires the add-on
-`slug`.
+`kind` is one of `host`, `core`, `supervisor`, `dns`, `audio`, `multicast`, `cli`, `observer`,
+or `addon`; `addon` also requires the add-on `slug`. Everything but `addon` maps to a path
+Core allowlists at `/api/hassio/<kind>/logs`. Which plugins exist depends on the installation
+— `cli` and `observer` are absent on some, and return 404.
 
 ### Token
 
@@ -88,10 +91,20 @@ timestamp is discarded — it is the application's own, rendered in the instance
 timezone, so it disagrees with `Timestamp` by the UTC offset and is redundant besides.
 Nothing is lost: the prefix is fully described by the resulting fields.
 
+The format is the one Core and Supervisor both configure in their `bootstrap.py`
+(`%(asctime)s.%(msecs)03d %(levelname)s (%(threadName)s) [%(name)s] %(message)s`) — not
+Python's default, which is why this lives here rather than in `internal/logparser`. The level
+is mapped through `logparser.DeduceSeverity`, shared with the other parsers.
+
 This applies to `core` and `supervisor`, and to add-ons that log through the same formatter.
-Host logs are heterogeneous — systemd prose, `kernel`, and `containerd`/`dockerd` **logfmt** —
-and are left untouched. To structure those, put `odblogparser` downstream in the pipeline;
-this receiver deliberately does not reimplement logfmt.
+Host, `dns` and other plugin logs are heterogeneous — systemd prose, `kernel`, CoreDNS
+`[INFO]`, and `containerd`/`dockerd` **logfmt** — and are left untouched.
+
+`odblogparser` exposes oteldb's shared parsers (`logfmt`, `generic-json`, `klog`,
+`zap-development`) as a stanza operator, but stanza operators only run inside stanza-based
+receivers such as `filelog`. This receiver is not stanza-based, and odbagent does not register
+`logstransformprocessor`, so **`odblogparser` cannot currently be applied to this receiver's
+output**. Structuring the remaining host formats needs either that processor or support here.
 
 ### Severity fallback
 
@@ -114,11 +127,23 @@ The `2` matters: `entries=:-1:N` starts one entry *before* the last and returns 
 anchors on the second-to-last entry and the first poll re-emits the last one as if it were
 new. Supervisor clamps its own `lines` parameter to a minimum of 2 for the same reason.
 
-Because entries are counted, a multi-line `MESSAGE` must not be miscounted: a line that does
-not start with a valid timestamp is treated as a continuation of the previous entry. A
-continuation line that itself begins with a plausible `YYYY-MM-DD HH:MM:SS.mmm ` prefix and
-contains `: ` would be over-counted and cause a gap. No Home Assistant log format does this
-today.
+### Multi-line events
+
+journald splits a multi-line message at every newline, so a Python traceback arrives as one
+journal entry per line — each with a full envelope, the same identifier and PID, and
+near-identical timestamps. Emitted verbatim that is one severity-less record per stack frame.
+
+`recombine_window` joins them back: a fragment is appended to the preceding entry when it
+comes from the same process, does not itself start an application log line, and follows
+within the window. Only an application log line opens a block — otherwise sources that never
+use the format, like systemd and CoreDNS, would have runs of unrelated entries merged.
+
+In a 6000-entry sample the gap between fragments of one message was 7ms at p99, while
+unrelated entries from the same process sat minutes apart, so the 1s default separates them
+with a wide margin. Set it to `0` to disable and emit one record per journal entry.
+
+Recombination never changes the journal entry count the cursor arithmetic depends on. A block
+straddling a `batch_size` boundary is the one case it cannot join, and yields two records.
 
 ## Delivery
 
@@ -164,7 +189,23 @@ later.
 
 ## Not implemented
 
-Metrics — Home Assistant exposes `/api/prometheus`, which the stock `prometheusreceiver`
+**Metrics.** Home Assistant exposes `/api/prometheus`, which the stock `prometheusreceiver`
 scrapes with a bearer token.
 
-Automation traces — designed in §9 of the design doc, not built.
+**Host log formats.** CoreDNS `[INFO]`, NetworkManager `<info>`, and `containerd`/`dockerd`
+logfmt are passed through unparsed. `severity_from_message` does not catch them either — it
+wants a bare upper-case token. Measured on a live instance, this leaves roughly half of all
+records without a severity.
+
+**The WebSocket API.** `system_log/list` over `/api/websocket` returns Core log entries fully
+structured, with the whole traceback in one `exception` field and the source file and line —
+strictly better data than the journal text. It is not used because as a transport it is
+worse: `system_log` captures **WARNING and above only**, covers Core alone (Supervisor is a
+separate process), dedupes by (logger, source, root cause) so repeated occurrences collapse
+into a `count`, has no cursor so a dropped connection loses events, and live push needs
+`system_log: fire_event: true` set in `configuration.yaml` on the instance — a host-side
+change this receiver otherwise avoids. It is worth adding later as an optional enrichment
+stream alongside the journal, not as a replacement.
+
+**Automation traces.** Home Assistant's automation engine produces trace-shaped data
+(`run_id`, parent context, per-step timings) in a bounded ring buffer. Not built.

--- a/otelcolmod/hareceiver/README.md
+++ b/otelcolmod/hareceiver/README.md
@@ -1,0 +1,170 @@
+# hareceiver
+
+Pulls journal logs from a Home Assistant instance over its HTTP API and emits OTLP logs.
+
+Nothing is installed on the Home Assistant host — the receiver runs wherever odbagent runs.
+See [`docs/home-assistant.md`](../../docs/home-assistant.md) for the design.
+
+> [!WARNING]
+> `/api/hassio/...` is an internal, admin-only, undocumented Home Assistant Core path. It is
+> an allowlist in `homeassistant/components/hassio/http.py` with no compatibility promise; a
+> refactor can move or reshape it without notice. The response format this receiver parses is
+> likewise a frontend rendering, not an API.
+
+## Configuration
+
+```yaml
+extensions:
+  file_storage:
+    directory: /var/lib/otelcol
+
+receivers:
+  hareceiver:
+    endpoint: https://homeassistant.example:8123
+    token: ${env:HA_TOKEN}
+    poll_interval: 10s
+    storage: file_storage
+    severity_from_message: true
+    sources:
+      - kind: host
+      - kind: core
+      - kind: supervisor
+      - kind: addon
+        addon: core_ssh
+```
+
+| Setting | Default | Description |
+|---|---|---|
+| `endpoint` | — | Home Assistant base URL. Required. |
+| `token` | — | Long-lived access token. Required, see below. |
+| `sources` | — | Log streams to ingest. At least one required. |
+| `poll_interval` | `10s` | Delay between cursor-advancing requests. |
+| `batch_size` | `1000` | Maximum journal entries per request. |
+| `parse_message` | `true` | Extract the level, thread and logger Core and Supervisor embed in the message, see below. |
+| `severity_from_message` | `false` | Best-effort severity detection for messages `parse_message` does not recognize. |
+| `storage` | — | Storage extension holding cursors. Without it, every start begins at the tail. |
+
+The remaining settings come from `confighttp.ClientConfig` (TLS, timeouts, extra headers,
+compression).
+
+`kind` is one of `host`, `core`, `supervisor`, or `addon`; `addon` also requires the add-on
+`slug`.
+
+### Token
+
+The token must be a long-lived access token **belonging to an admin user**. The Core proxy
+gates every path in this receiver on `is_admin`, and a non-admin token gets 401 on all of
+them. An existing token that works for `/api/prometheus` is not evidence: that endpoint does
+not require admin. A 401 or 403 is treated as permanent and stops the receiver rather than
+retrying.
+
+## What Home Assistant actually returns
+
+Two constraints shape this receiver, both verified against Core and Supervisor source:
+
+**Journal fields are not available.** Supervisor requests
+`application/vnd.fdo.journal` from `systemd-journal-gatewayd`, parses it, and renders each
+entry to **text** using a formatter that keeps only `__CURSOR`, `__REALTIME_TIMESTAMP`,
+`_HOSTNAME`, `SYSLOG_IDENTIFIER`, `_PID` and `MESSAGE` — every other field is dropped before
+the response is written. Requesting `application/json` does not help: Core's proxy never
+forwards `Accept`, and Supervisor rejects any `Accept` other than `text/plain`/`text/x-log`
+with a 400.
+
+Consequently there is **no `PRIORITY`**, and therefore no faithful syslog severity mapping.
+Severity is recovered from the message instead, in two ways.
+
+### Application log structure
+
+Core and Supervisor write a fixed format into `MESSAGE`, from their Python logging formatter:
+
+```
+2026-08-09 15:26:04.893 INFO (SyncWorker_2) [supervisor.backups.backup] Backing up folder ssl
+└──── application ts ───┘ └level┘ └─ thread ─┘ └────── logger ──────┘ └───── message ─────┘
+```
+
+`parse_message` lifts that apart: the level becomes an **exact** severity (not a guess), the
+logger and thread become attributes, and the body is reduced to the message. The leading
+timestamp is discarded — it is the application's own, rendered in the instance's local
+timezone, so it disagrees with `Timestamp` by the UTC offset and is redundant besides.
+Nothing is lost: the prefix is fully described by the resulting fields.
+
+This applies to `core` and `supervisor`, and to add-ons that log through the same formatter.
+Host logs are heterogeneous — systemd prose, `kernel`, and `containerd`/`dockerd` **logfmt** —
+and are left untouched. To structure those, put `odblogparser` downstream in the pipeline;
+this receiver deliberately does not reimplement logfmt.
+
+### Severity fallback
+
+`severity_from_message` covers what the above does not recognize, by looking for an exact
+upper-case level token (`ERROR`, `WARNING`, …) among the first few tokens. It is a heuristic,
+off by default, and will not label logs that use another convention. Note that it does not
+catch logfmt's `level=error`, which is lower-case and not a bare token.
+
+The receiver sends `?verbose` to select the formatter that carries the timestamp, hostname
+and identifier, and `?no_colors` so Supervisor strips ANSI escapes server-side.
+
+**Only the first cursor of a response is returned.** Home Assistant exposes
+`X-First-Cursor` and nothing else, so the read position cannot be a single cursor. It is
+instead an anchor cursor plus the number of entries already consumed after it, sent as
+`Range: entries=<anchor>:<skip>:<batch>`. Each response re-anchors on its own first entry, so
+`skip` stays bounded by `batch_size`. A source with no stored cursor anchors at the tail with
+`entries=:-1:2` and emits nothing.
+
+The `2` matters: `entries=:-1:N` starts one entry *before* the last and returns N, so `:-1:1`
+anchors on the second-to-last entry and the first poll re-emits the last one as if it were
+new. Supervisor clamps its own `lines` parameter to a minimum of 2 for the same reason.
+
+Because entries are counted, a multi-line `MESSAGE` must not be miscounted: a line that does
+not start with a valid timestamp is treated as a continuation of the previous entry. A
+continuation line that itself begins with a plausible `YYYY-MM-DD HH:MM:SS.mmm ` prefix and
+contains `: ` would be over-counted and cause a gap. No Home Assistant log format does this
+today.
+
+## Delivery
+
+At-least-once. The cursor advances only after `ConsumeLogs` returns nil, and is persisted to
+the storage extension in the same step. A failure re-reads the same window, so duplicates are
+possible after a crash or a downstream error; gaps are not.
+
+Without a `storage` extension, cursors live only in memory and every restart re-anchors at
+the tail, losing everything in between.
+
+## Emitted data
+
+Resource attributes:
+
+| Attribute | Source |
+|---|---|
+| `service.namespace` | always `homeassistant` |
+| `service.name` | `SYSLOG_IDENTIFIER`, falling back to the configured source name |
+| `host.name` | `_HOSTNAME`, omitted when absent |
+
+Record fields:
+
+| Field | Source |
+|---|---|
+| `Timestamp` | `__REALTIME_TIMESTAMP`, millisecond precision |
+| `ObservedTimestamp` | receive time |
+| `Body` | `MESSAGE`, with continuation lines rejoined and the application prefix removed when `parse_message` applies |
+| `SeverityNumber`/`SeverityText` | the application level, else the `severity_from_message` heuristic |
+
+Record attributes:
+
+| Attribute | Description |
+|---|---|
+| `ha.source` | configured source kind |
+| `ha.addon` | add-on slug, only for `addon` sources |
+| `ha.logger` | application logger name, when `parse_message` applies |
+| `ha.thread` | application thread name, when `parse_message` applies and it is non-empty |
+| `process.pid` | `_PID`, omitted when absent |
+
+No OpenTelemetry semantic convention exists for home automation, so `ha.*` is defined here.
+Keep it internally consistent so it can be proposed upstream rather than reverse-engineered
+later.
+
+## Not implemented
+
+Metrics — Home Assistant exposes `/api/prometheus`, which the stock `prometheusreceiver`
+scrapes with a bearer token.
+
+Automation traces — designed in §9 of the design doc, not built.

--- a/otelcolmod/hareceiver/README.md
+++ b/otelcolmod/hareceiver/README.md
@@ -138,9 +138,12 @@ comes from the same process, does not itself start an application log line, and 
 within the window. Only an application log line opens a block — otherwise sources that never
 use the format, like systemd and CoreDNS, would have runs of unrelated entries merged.
 
-In a 6000-entry sample the gap between fragments of one message was 7ms at p99, while
-unrelated entries from the same process sat minutes apart, so the 1s default separates them
-with a wide margin. Set it to `0` to disable and emit one record per journal entry.
+The exact value barely matters. Measured over 11.5k captured entries the gap between fragments
+was **58ms at p99**, and every window from 100ms to 1s produced byte-identical output; 10s
+differed by a single record in 2529. Only 4 of 491 fragments exceeded 1s, and those were lines
+that merely followed an unrelated entry from the same process — ending the block there is the
+wanted outcome, not a lost fragment. Set it to `0` to disable and emit one record per journal
+entry.
 
 Recombination never changes the journal entry count the cursor arithmetic depends on. A block
 straddling a `batch_size` boundary is the one case it cannot join, and yields two records.

--- a/otelcolmod/hareceiver/_golden/journal_core.json
+++ b/otelcolmod/hareceiver/_golden/journal_core.json
@@ -1,0 +1,37 @@
+[
+  {
+    "timestamp": "2026-08-09T12:00:05.952Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "2026-08-09 15:00:05.950 WARNING (MainThread) [homeassistant.helpers.service] Referenced entities switch.example_led are missing or not currently available"
+  },
+  {
+    "timestamp": "2026-08-09T12:00:06.101Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "2026-08-09 15:00:06.100 INFO (MainThread) [homeassistant.setup] Setting up recorder"
+  },
+  {
+    "timestamp": "2026-08-09T12:00:07.004Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "2026-08-09 15:00:07.003 DEBUG (SyncWorker_0) [homeassistant.components.sensor] Updating sensor.example_temperature"
+  },
+  {
+    "timestamp": "2026-08-09T12:00:08.5Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "2026-08-09 15:00:08.499 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved\nTraceback (most recent call last):\n  File \"/usr/src/homeassistant/homeassistant/core.py\", line 1, in _run\n    raise ValueError(\"example\")\nValueError: example"
+  },
+  {
+    "timestamp": "2026-08-09T12:00:09.01Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "2026-08-09 15:00:09.009 CRITICAL (MainThread) [homeassistant.bootstrap] Error doing job"
+  }
+]

--- a/otelcolmod/hareceiver/_golden/journal_edge.json
+++ b/otelcolmod/hareceiver/_golden/journal_edge.json
@@ -1,0 +1,33 @@
+[
+  {
+    "timestamp": "2026-08-09T12:00:00Z",
+    "identifier": "systemd",
+    "pid": 1,
+    "message": "entry without a hostname"
+  },
+  {
+    "timestamp": "2026-08-09T12:00:01Z",
+    "hostname": "homeassistant",
+    "message": "entry without a syslog identifier"
+  },
+  {
+    "timestamp": "2026-08-09T12:00:02Z",
+    "hostname": "homeassistant",
+    "identifier": "systemd",
+    "message": "entry without a pid"
+  },
+  {
+    "timestamp": "2026-08-09T12:00:03Z",
+    "hostname": "homeassistant",
+    "identifier": "app",
+    "pid": 7,
+    "message": ""
+  },
+  {
+    "timestamp": "2026-08-09T12:00:04Z",
+    "hostname": "homeassistant",
+    "identifier": "app",
+    "pid": 7,
+    "message": "message: containing: colons\n0001-01-01 00:00:00.000  : \n2026-13-45 99:00:00.000 homeassistant app[7]: malformed timestamp is a continuation"
+  }
+]

--- a/otelcolmod/hareceiver/_golden/journal_host.json
+++ b/otelcolmod/hareceiver/_golden/journal_host.json
@@ -1,0 +1,43 @@
+[
+  {
+    "timestamp": "2026-08-09T10:46:50.061Z",
+    "hostname": "homeassistant",
+    "identifier": "systemd",
+    "pid": 1,
+    "message": "var-lib-docker-overlay2-0000\\x2dinit-merged.mount: Deactivated successfully."
+  },
+  {
+    "timestamp": "2026-08-09T10:46:50.484Z",
+    "hostname": "homeassistant",
+    "identifier": "containerd",
+    "pid": 608,
+    "message": "time=\"2026-08-09T13:46:50.484602110+03:00\" level=info msg=\"connecting to shim 0000\" namespace=moby"
+  },
+  {
+    "timestamp": "2026-08-09T10:46:50.535Z",
+    "hostname": "homeassistant",
+    "identifier": "systemd",
+    "pid": 1,
+    "message": "Started libcontainer container 0000."
+  },
+  {
+    "timestamp": "2026-08-09T10:46:52.416Z",
+    "hostname": "homeassistant",
+    "identifier": "bluetoothd",
+    "pid": 564,
+    "message": "Path /org/bleak/00/000000000000 reserved for Adv Monitor app :1.508"
+  },
+  {
+    "timestamp": "2026-08-09T11:13:24.928Z",
+    "hostname": "homeassistant",
+    "identifier": "dockerd",
+    "pid": 655,
+    "message": "time=\"2026-08-09T14:13:24.928145542+03:00\" level=error msg=\"[resolver] failed to query external DNS server\""
+  },
+  {
+    "timestamp": "2026-08-09T11:13:25Z",
+    "hostname": "homeassistant",
+    "identifier": "kernel",
+    "message": "usb 1-1: new high-speed USB device number 4 using xhci_hcd"
+  }
+]

--- a/otelcolmod/hareceiver/_golden/journal_supervisor.json
+++ b/otelcolmod/hareceiver/_golden/journal_supervisor.json
@@ -1,0 +1,30 @@
+[
+  {
+    "timestamp": "2026-08-09T12:26:04.892Z",
+    "hostname": "homeassistant",
+    "identifier": "hassio_supervisor",
+    "pid": 655,
+    "message": "2026-08-09 15:26:04.892 INFO (MainThread) [supervisor.backups.manager] Backup 00000000 starting stage home_assistant"
+  },
+  {
+    "timestamp": "2026-08-09T12:26:04.893Z",
+    "hostname": "homeassistant",
+    "identifier": "hassio_supervisor",
+    "pid": 655,
+    "message": "2026-08-09 15:26:04.893 INFO (SyncWorker_2) [supervisor.backups.backup] Backing up folder ssl"
+  },
+  {
+    "timestamp": "2026-08-09T12:26:05.1Z",
+    "hostname": "homeassistant",
+    "identifier": "hassio_supervisor",
+    "pid": 655,
+    "message": "2026-08-09 15:26:05.099 WARNING (MainThread) [supervisor.resolution.check] Found issue reboot_required"
+  },
+  {
+    "timestamp": "2026-08-09T12:26:06.245Z",
+    "hostname": "homeassistant",
+    "identifier": "hassio_supervisor",
+    "pid": 655,
+    "message": "2026-08-09 15:26:06.245 VERBOSE (MainThread) [supervisor.api.backups] Unmapped level stays structured"
+  }
+]

--- a/otelcolmod/hareceiver/_golden/journal_traceback.json
+++ b/otelcolmod/hareceiver/_golden/journal_traceback.json
@@ -1,0 +1,100 @@
+[
+  {
+    "timestamp": "2026-08-09T08:52:32.482Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "2026-08-09 11:52:32.480 WARNING (MainThread) [homeassistant.helpers.service] Referenced entities switch.example_led are missing"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.745Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "--- Logging error ---"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.747Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "2026-08-09 11:52:37.744 ERROR (MainThread) [homeassistant.components.light] Error adding entity"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.749Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "Traceback (most recent call last):"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.75Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "  File \"/usr/src/homeassistant/homeassistant/components/light/__init__.py\", line 977, in __validate"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.75Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "    valid_supported_color_modes(supported_color_modes)"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.75Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "voluptuous.error.Error: Invalid supported_color_modes ['brightness', 'rgb']"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.751Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": ""
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.751Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "The above exception was the direct cause of the following exception:"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.752Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "Traceback (most recent call last):"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:37.752Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "  File \"/usr/src/homeassistant/homeassistant/helpers/entity_platform.py\", line 680, in _async_add"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:40Z",
+    "hostname": "homeassistant",
+    "identifier": "homeassistant",
+    "pid": 655,
+    "message": "2026-08-09 11:52:40.000 INFO (MainThread) [homeassistant.core] Recovered"
+  },
+  {
+    "timestamp": "2026-08-09T08:52:40.1Z",
+    "hostname": "homeassistant",
+    "identifier": "systemd",
+    "pid": 1,
+    "message": "Started something unrelated."
+  },
+  {
+    "timestamp": "2026-08-09T08:52:40.2Z",
+    "hostname": "homeassistant",
+    "identifier": "systemd",
+    "pid": 1,
+    "message": "Started another unrelated thing."
+  }
+]

--- a/otelcolmod/hareceiver/_golden/logs_core.json
+++ b/otelcolmod/hareceiver/_golden/logs_core.json
@@ -1,0 +1,210 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276805952000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 13,
+              "severityText": "WARNING",
+              "body": {
+                "stringValue": "Referenced entities switch.example_led are missing or not currently available"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.helpers.service"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276806101000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Setting up recorder"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.setup"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276807004000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 5,
+              "severityText": "DEBUG",
+              "body": {
+                "stringValue": "Updating sensor.example_temperature"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.components.sensor"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "SyncWorker_0"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276808500000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 17,
+              "severityText": "ERROR",
+              "body": {
+                "stringValue": "Error doing job: Task exception was never retrieved\nTraceback (most recent call last):\n  File \"/usr/src/homeassistant/homeassistant/core.py\", line 1, in _run\n    raise ValueError(\"example\")\nValueError: example"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.core"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276809010000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 21,
+              "severityText": "CRITICAL",
+              "body": {
+                "stringValue": "Error doing job"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.bootstrap"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/logs_edge.json
+++ b/otelcolmod/hareceiver/_golden/logs_edge.json
@@ -1,0 +1,215 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "systemd"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276800000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "entry without a hostname"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "host"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276801000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "entry without a syslog identifier"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "systemd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276802000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "entry without a pid"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "app"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276803000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": ""
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "7"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276804000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "message: containing: colons\n0001-01-01 00:00:00.000  : \n2026-13-45 99:00:00.000 homeassistant app[7]: malformed timestamp is a continuation"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "7"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/logs_host.json
+++ b/otelcolmod/hareceiver/_golden/logs_host.json
@@ -1,0 +1,279 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "systemd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786272410061000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "var-lib-docker-overlay2-0000\\x2dinit-merged.mount: Deactivated successfully."
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786272410535000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Started libcontainer container 0000."
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "containerd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786272410484000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "time=\"2026-08-09T13:46:50.484602110+03:00\" level=info msg=\"connecting to shim 0000\" namespace=moby"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "608"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "bluetoothd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786272412416000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Path /org/bleak/00/000000000000 reserved for Adv Monitor app :1.508"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "564"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "dockerd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786274004928000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "time=\"2026-08-09T14:13:24.928145542+03:00\" level=error msg=\"[resolver] failed to query external DNS server\""
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "kernel"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786274005000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "usb 1-1: new high-speed USB device number 4 using xhci_hcd"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/logs_supervisor.json
+++ b/otelcolmod/hareceiver/_golden/logs_supervisor.json
@@ -1,0 +1,174 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "hassio_supervisor"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786278364892000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Backup 00000000 starting stage home_assistant"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "supervisor.backups.manager"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "supervisor"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786278364893000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Backing up folder ssl"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "supervisor.backups.backup"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "SyncWorker_2"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "supervisor"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786278365100000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 13,
+              "severityText": "WARNING",
+              "body": {
+                "stringValue": "Found issue reboot_required"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "supervisor.resolution.check"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "supervisor"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786278366245000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityText": "VERBOSE",
+              "body": {
+                "stringValue": "Unmapped level stays structured"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "supervisor.api.backups"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "supervisor"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/logs_traceback.json
+++ b/otelcolmod/hareceiver/_golden/logs_traceback.json
@@ -1,0 +1,402 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786265552482000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 13,
+              "severityText": "WARNING",
+              "body": {
+                "stringValue": "Referenced entities switch.example_led are missing"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.helpers.service"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557745000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "--- Logging error ---"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557747000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 17,
+              "severityText": "ERROR",
+              "body": {
+                "stringValue": "Error adding entity"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.components.light"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557749000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Traceback (most recent call last):"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557750000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "  File \"/usr/src/homeassistant/homeassistant/components/light/__init__.py\", line 977, in __validate"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557750000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "    valid_supported_color_modes(supported_color_modes)"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557750000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "voluptuous.error.Error: Invalid supported_color_modes ['brightness', 'rgb']"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557751000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": ""
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557751000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "The above exception was the direct cause of the following exception:"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557752000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Traceback (most recent call last):"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557752000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "  File \"/usr/src/homeassistant/homeassistant/helpers/entity_platform.py\", line 680, in _async_add"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265560000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Recovered"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.core"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "systemd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786265560100000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Started something unrelated."
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265560200000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Started another unrelated thing."
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/recombined_core.json
+++ b/otelcolmod/hareceiver/_golden/recombined_core.json
@@ -1,0 +1,210 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276805952000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 13,
+              "severityText": "WARNING",
+              "body": {
+                "stringValue": "Referenced entities switch.example_led are missing or not currently available"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.helpers.service"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276806101000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Setting up recorder"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.setup"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276807004000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 5,
+              "severityText": "DEBUG",
+              "body": {
+                "stringValue": "Updating sensor.example_temperature"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.components.sensor"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "SyncWorker_0"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276808500000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 17,
+              "severityText": "ERROR",
+              "body": {
+                "stringValue": "Error doing job: Task exception was never retrieved\nTraceback (most recent call last):\n  File \"/usr/src/homeassistant/homeassistant/core.py\", line 1, in _run\n    raise ValueError(\"example\")\nValueError: example"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.core"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276809010000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 21,
+              "severityText": "CRITICAL",
+              "body": {
+                "stringValue": "Error doing job"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.bootstrap"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "core"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/recombined_edge.json
+++ b/otelcolmod/hareceiver/_golden/recombined_edge.json
@@ -1,0 +1,215 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "systemd"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276800000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "entry without a hostname"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "host"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276801000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "entry without a syslog identifier"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "systemd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276802000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "entry without a pid"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "app"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786276803000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": ""
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "7"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786276804000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "message: containing: colons\n0001-01-01 00:00:00.000  : \n2026-13-45 99:00:00.000 homeassistant app[7]: malformed timestamp is a continuation"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "7"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/recombined_host.json
+++ b/otelcolmod/hareceiver/_golden/recombined_host.json
@@ -1,0 +1,279 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "systemd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786272410061000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "var-lib-docker-overlay2-0000\\x2dinit-merged.mount: Deactivated successfully."
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786272410535000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Started libcontainer container 0000."
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "containerd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786272410484000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "time=\"2026-08-09T13:46:50.484602110+03:00\" level=info msg=\"connecting to shim 0000\" namespace=moby"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "608"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "bluetoothd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786272412416000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Path /org/bleak/00/000000000000 reserved for Adv Monitor app :1.508"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "564"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "dockerd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786274004928000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "time=\"2026-08-09T14:13:24.928145542+03:00\" level=error msg=\"[resolver] failed to query external DNS server\""
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "kernel"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786274005000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "usb 1-1: new high-speed USB device number 4 using xhci_hcd"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/recombined_supervisor.json
+++ b/otelcolmod/hareceiver/_golden/recombined_supervisor.json
@@ -1,0 +1,174 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "hassio_supervisor"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786278364892000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Backup 00000000 starting stage home_assistant"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "supervisor.backups.manager"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "supervisor"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786278364893000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Backing up folder ssl"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "supervisor.backups.backup"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "SyncWorker_2"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "supervisor"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786278365100000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 13,
+              "severityText": "WARNING",
+              "body": {
+                "stringValue": "Found issue reboot_required"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "supervisor.resolution.check"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "supervisor"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786278366245000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityText": "VERBOSE",
+              "body": {
+                "stringValue": "Unmapped level stays structured"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "supervisor.api.backups"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "supervisor"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_golden/recombined_traceback.json
+++ b/otelcolmod/hareceiver/_golden/recombined_traceback.json
@@ -1,0 +1,234 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786265552482000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 13,
+              "severityText": "WARNING",
+              "body": {
+                "stringValue": "Referenced entities switch.example_led are missing"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.helpers.service"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557745000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "--- Logging error ---"
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265557747000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 17,
+              "severityText": "ERROR",
+              "body": {
+                "stringValue": "Error adding entity\nTraceback (most recent call last):\n  File \"/usr/src/homeassistant/homeassistant/components/light/__init__.py\", line 977, in __validate\n    valid_supported_color_modes(supported_color_modes)\nvoluptuous.error.Error: Invalid supported_color_modes ['brightness', 'rgb']\n\nThe above exception was the direct cause of the following exception:\nTraceback (most recent call last):\n  File \"/usr/src/homeassistant/homeassistant/helpers/entity_platform.py\", line 680, in _async_add"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.components.light"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265560000000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": {
+                "stringValue": "Recovered"
+              },
+              "attributes": [
+                {
+                  "key": "ha.logger",
+                  "value": {
+                    "stringValue": "homeassistant.core"
+                  }
+                },
+                {
+                  "key": "ha.thread",
+                  "value": {
+                    "stringValue": "MainThread"
+                  }
+                },
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "655"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.namespace",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "systemd"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "homeassistant"
+            }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {},
+          "logRecords": [
+            {
+              "timeUnixNano": "1786265560100000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Started something unrelated."
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            },
+            {
+              "timeUnixNano": "1786265560200000000",
+              "observedTimeUnixNano": "1768870923000000004",
+              "body": {
+                "stringValue": "Started another unrelated thing."
+              },
+              "attributes": [
+                {
+                  "key": "ha.source",
+                  "value": {
+                    "stringValue": "host"
+                  }
+                },
+                {
+                  "key": "process.pid",
+                  "value": {
+                    "intValue": "1"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/otelcolmod/hareceiver/_testdata/journal/core.txt
+++ b/otelcolmod/hareceiver/_testdata/journal/core.txt
@@ -1,0 +1,9 @@
+2026-08-09 12:00:05.952 homeassistant homeassistant[655]: 2026-08-09 15:00:05.950 WARNING (MainThread) [homeassistant.helpers.service] Referenced entities switch.example_led are missing or not currently available
+2026-08-09 12:00:06.101 homeassistant homeassistant[655]: 2026-08-09 15:00:06.100 INFO (MainThread) [homeassistant.setup] Setting up recorder
+2026-08-09 12:00:07.004 homeassistant homeassistant[655]: 2026-08-09 15:00:07.003 DEBUG (SyncWorker_0) [homeassistant.components.sensor] Updating sensor.example_temperature
+2026-08-09 12:00:08.500 homeassistant homeassistant[655]: 2026-08-09 15:00:08.499 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
+Traceback (most recent call last):
+  File "/usr/src/homeassistant/homeassistant/core.py", line 1, in _run
+    raise ValueError("example")
+ValueError: example
+2026-08-09 12:00:09.010 homeassistant homeassistant[655]: 2026-08-09 15:00:09.009 CRITICAL (MainThread) [homeassistant.bootstrap] Error doing job

--- a/otelcolmod/hareceiver/_testdata/journal/edge.txt
+++ b/otelcolmod/hareceiver/_testdata/journal/edge.txt
@@ -1,0 +1,8 @@
+    orphan continuation with no entry to attach to
+2026-08-09 12:00:00.000  systemd[1]: entry without a hostname
+2026-08-09 12:00:01.000 homeassistant _UNKNOWN_: entry without a syslog identifier
+2026-08-09 12:00:02.000 homeassistant systemd: entry without a pid
+2026-08-09 12:00:03.000 homeassistant app[7]: 
+2026-08-09 12:00:04.000 homeassistant app[7]: message: containing: colons
+0001-01-01 00:00:00.000  : 
+2026-13-45 99:00:00.000 homeassistant app[7]: malformed timestamp is a continuation

--- a/otelcolmod/hareceiver/_testdata/journal/host.txt
+++ b/otelcolmod/hareceiver/_testdata/journal/host.txt
@@ -1,0 +1,6 @@
+2026-08-09 10:46:50.061 homeassistant systemd[1]: var-lib-docker-overlay2-0000\x2dinit-merged.mount: Deactivated successfully.
+2026-08-09 10:46:50.484 homeassistant containerd[608]: time="2026-08-09T13:46:50.484602110+03:00" level=info msg="connecting to shim 0000" namespace=moby
+2026-08-09 10:46:50.535 homeassistant systemd[1]: Started libcontainer container 0000.
+2026-08-09 10:46:52.416 homeassistant bluetoothd[564]: Path /org/bleak/00/000000000000 reserved for Adv Monitor app :1.508
+2026-08-09 11:13:24.928 homeassistant dockerd[655]: time="2026-08-09T14:13:24.928145542+03:00" level=error msg="[resolver] failed to query external DNS server"
+2026-08-09 11:13:25.000 homeassistant kernel: usb 1-1: new high-speed USB device number 4 using xhci_hcd

--- a/otelcolmod/hareceiver/_testdata/journal/supervisor.txt
+++ b/otelcolmod/hareceiver/_testdata/journal/supervisor.txt
@@ -1,0 +1,4 @@
+2026-08-09 12:26:04.892 homeassistant hassio_supervisor[655]: 2026-08-09 15:26:04.892 INFO (MainThread) [supervisor.backups.manager] Backup 00000000 starting stage home_assistant
+2026-08-09 12:26:04.893 homeassistant hassio_supervisor[655]: 2026-08-09 15:26:04.893 INFO (SyncWorker_2) [supervisor.backups.backup] Backing up folder ssl
+2026-08-09 12:26:05.100 homeassistant hassio_supervisor[655]: 2026-08-09 15:26:05.099 WARNING (MainThread) [supervisor.resolution.check] Found issue reboot_required
+2026-08-09 12:26:06.245 homeassistant hassio_supervisor[655]: 2026-08-09 15:26:06.245 VERBOSE (MainThread) [supervisor.api.backups] Unmapped level stays structured

--- a/otelcolmod/hareceiver/_testdata/journal/traceback.txt
+++ b/otelcolmod/hareceiver/_testdata/journal/traceback.txt
@@ -1,0 +1,14 @@
+2026-08-09 08:52:32.482 homeassistant homeassistant[655]: 2026-08-09 11:52:32.480 WARNING (MainThread) [homeassistant.helpers.service] Referenced entities switch.example_led are missing
+2026-08-09 08:52:37.745 homeassistant homeassistant[655]: --- Logging error ---
+2026-08-09 08:52:37.747 homeassistant homeassistant[655]: 2026-08-09 11:52:37.744 ERROR (MainThread) [homeassistant.components.light] Error adding entity
+2026-08-09 08:52:37.749 homeassistant homeassistant[655]: Traceback (most recent call last):
+2026-08-09 08:52:37.750 homeassistant homeassistant[655]:   File "/usr/src/homeassistant/homeassistant/components/light/__init__.py", line 977, in __validate
+2026-08-09 08:52:37.750 homeassistant homeassistant[655]:     valid_supported_color_modes(supported_color_modes)
+2026-08-09 08:52:37.750 homeassistant homeassistant[655]: voluptuous.error.Error: Invalid supported_color_modes ['brightness', 'rgb']
+2026-08-09 08:52:37.751 homeassistant homeassistant[655]: 
+2026-08-09 08:52:37.751 homeassistant homeassistant[655]: The above exception was the direct cause of the following exception:
+2026-08-09 08:52:37.752 homeassistant homeassistant[655]: Traceback (most recent call last):
+2026-08-09 08:52:37.752 homeassistant homeassistant[655]:   File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 680, in _async_add
+2026-08-09 08:52:40.000 homeassistant homeassistant[655]: 2026-08-09 11:52:40.000 INFO (MainThread) [homeassistant.core] Recovered
+2026-08-09 08:52:40.100 homeassistant systemd[1]: Started something unrelated.
+2026-08-09 08:52:40.200 homeassistant systemd[1]: Started another unrelated thing.

--- a/otelcolmod/hareceiver/appmessage.go
+++ b/otelcolmod/hareceiver/appmessage.go
@@ -1,0 +1,40 @@
+package hareceiver
+
+import "regexp"
+
+// appMessage is the structure Home Assistant Core and Supervisor put inside a
+// journal MESSAGE, as produced by their Python logging formatter:
+//
+//	2026-08-09 15:26:04.893 INFO (SyncWorker_2) [supervisor.backups.backup] Backing up folder ssl
+//
+// The leading timestamp is the application's own, rendered in the instance's
+// local timezone, and duplicates the journal timestamp — it is dropped in
+// favor of __REALTIME_TIMESTAMP, which is unambiguous.
+type appMessage struct {
+	Level   string
+	Thread  string
+	Logger  string
+	Message string
+}
+
+// (?s) so that a multi-line message, such as a traceback, stays in Message.
+var appMessageLine = regexp.MustCompile(
+	`(?s)^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} ([A-Z]+) \(([^)\n]*)\) \[([^\]\n]*)\] (.*)$`,
+)
+
+// parseAppMessage splits a Home Assistant application log line into its parts.
+//
+// Unlike [detectSeverity], this is an exact match on a fixed format rather than
+// a guess, so the level it yields is authoritative.
+func parseAppMessage(msg string) (appMessage, bool) {
+	m := appMessageLine.FindStringSubmatch(msg)
+	if m == nil {
+		return appMessage{}, false
+	}
+	return appMessage{
+		Level:   m[1],
+		Thread:  m[2],
+		Logger:  m[3],
+		Message: m[4],
+	}, true
+}

--- a/otelcolmod/hareceiver/appmessage_test.go
+++ b/otelcolmod/hareceiver/appmessage_test.go
@@ -1,0 +1,58 @@
+package hareceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The accepted shapes are pinned by the logs_*.json golden files; this covers
+// what must not be mistaken for an application log line.
+func TestParseAppMessageRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+	}{
+		{name: "Empty", msg: ""},
+		{name: "Systemd", msg: "Started libcontainer container 0000."},
+		{name: "Logfmt", msg: `time="2026-08-09T13:46:50+03:00" level=info msg="connecting to shim"`},
+		{name: "NoTimestamp", msg: "INFO (MainThread) [a.b] hi"},
+		{name: "LowerCaseLevel", msg: "2026-08-09 15:00:05.950 info (MainThread) [a.b] hi"},
+		{name: "NoLogger", msg: "2026-08-09 15:00:05.950 INFO (MainThread) hi"},
+		{name: "NoThread", msg: "2026-08-09 15:00:05.950 INFO [a.b] hi"},
+		{name: "NewlineInThread", msg: "2026-08-09 15:00:05.950 INFO (Main\nThread) [a.b] hi"},
+		{
+			name: "SecondLineOnly",
+			msg:  "plain\n2026-08-09 15:00:05.950 INFO (MainThread) [a.b] hi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ok := parseAppMessage(tt.msg)
+			require.False(t, ok)
+		})
+	}
+}
+
+func FuzzParseAppMessage(f *testing.F) {
+	for file := range readTestData(f) {
+		for _, e := range ParseEntries(file.Body) {
+			f.Add(e.Message)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, msg string) {
+		app, ok := parseAppMessage(msg)
+		if !ok {
+			return
+		}
+		// The parts must come out of the original, or the body would silently
+		// gain content that was never logged.
+		require.NotEmpty(t, app.Level)
+		require.NotContains(t, app.Level, "\n")
+		require.NotContains(t, app.Thread, "\n")
+		require.NotContains(t, app.Logger, "\n")
+		require.LessOrEqual(t, len(app.Message), len(msg))
+	})
+}

--- a/otelcolmod/hareceiver/config.go
+++ b/otelcolmod/hareceiver/config.go
@@ -14,10 +14,19 @@ import (
 type SourceKind string
 
 // Supported [SourceKind] values.
+//
+// Everything except addon maps to a Supervisor plugin or component that Home
+// Assistant Core allowlists at /api/hassio/<kind>/logs. Which of them exist
+// depends on the installation: cli and observer are absent on some.
 const (
 	SourceKindHost       SourceKind = "host"
 	SourceKindCore       SourceKind = "core"
 	SourceKindSupervisor SourceKind = "supervisor"
+	SourceKindDNS        SourceKind = "dns"
+	SourceKindAudio      SourceKind = "audio"
+	SourceKindMulticast  SourceKind = "multicast"
+	SourceKindCLI        SourceKind = "cli"
+	SourceKindObserver   SourceKind = "observer"
 	SourceKindAddon      SourceKind = "addon"
 )
 
@@ -53,7 +62,9 @@ func (s Source) StorageKey() string {
 
 func (s Source) validate() error {
 	switch s.Kind {
-	case SourceKindHost, SourceKindCore, SourceKindSupervisor:
+	case SourceKindHost, SourceKindCore, SourceKindSupervisor,
+		SourceKindDNS, SourceKindAudio, SourceKindMulticast,
+		SourceKindCLI, SourceKindObserver:
 		if s.Addon != "" {
 			return errors.Errorf("addon is only allowed for %q kind", SourceKindAddon)
 		}
@@ -91,6 +102,11 @@ type Config struct {
 	// itself. Enabled by default; nothing is lost, since the prefix is fully
 	// described by the resulting fields.
 	ParseMessage bool `mapstructure:"parse_message"`
+
+	// RecombineWindow is how long a fragment of a multi-line message may lag
+	// the previous one and still be joined to it. Zero disables recombination
+	// and emits one record per journal entry.
+	RecombineWindow time.Duration `mapstructure:"recombine_window"`
 
 	// SeverityFromMessage enables best-effort severity detection for messages
 	// that ParseMessage does not recognize, such as host logs. Home Assistant
@@ -130,6 +146,9 @@ func (c *Config) Validate() error {
 	}
 	if c.BatchSize <= 0 {
 		return errors.New("batch_size must be positive")
+	}
+	if c.RecombineWindow < 0 {
+		return errors.New("recombine_window must not be negative")
 	}
 	return nil
 }

--- a/otelcolmod/hareceiver/config.go
+++ b/otelcolmod/hareceiver/config.go
@@ -1,0 +1,135 @@
+package hareceiver
+
+import (
+	"path"
+	"time"
+
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
+)
+
+// SourceKind selects a Home Assistant log stream.
+type SourceKind string
+
+// Supported [SourceKind] values.
+const (
+	SourceKindHost       SourceKind = "host"
+	SourceKindCore       SourceKind = "core"
+	SourceKindSupervisor SourceKind = "supervisor"
+	SourceKindAddon      SourceKind = "addon"
+)
+
+// Source is a single log stream to ingest.
+type Source struct {
+	Kind SourceKind `mapstructure:"kind"`
+
+	// Addon is the add-on slug, required when Kind is [SourceKindAddon].
+	Addon string `mapstructure:"addon"`
+}
+
+// Name returns a stable human-readable identifier of the source.
+func (s Source) Name() string {
+	if s.Kind == SourceKindAddon {
+		return string(s.Kind) + "/" + s.Addon
+	}
+	return string(s.Kind)
+}
+
+// Path returns the Supervisor API path of the log stream, relative to the
+// Home Assistant instance root.
+func (s Source) Path() string {
+	if s.Kind == SourceKindAddon {
+		return path.Join("api/hassio/addons", s.Addon, "logs")
+	}
+	return path.Join("api/hassio", string(s.Kind), "logs")
+}
+
+// StorageKey returns the storage extension key holding the source cursor.
+func (s Source) StorageKey() string {
+	return "cursor/" + s.Name()
+}
+
+func (s Source) validate() error {
+	switch s.Kind {
+	case SourceKindHost, SourceKindCore, SourceKindSupervisor:
+		if s.Addon != "" {
+			return errors.Errorf("addon is only allowed for %q kind", SourceKindAddon)
+		}
+		return nil
+	case SourceKindAddon:
+		if s.Addon == "" {
+			return errors.Errorf("addon is required for %q kind", SourceKindAddon)
+		}
+		return nil
+	case "":
+		return errors.New("kind is required")
+	default:
+		return errors.Errorf("unknown kind %q", s.Kind)
+	}
+}
+
+// Config defines config for [Receiver].
+type Config struct {
+	confighttp.ClientConfig `mapstructure:",squash"`
+
+	// Token is a long-lived access token belonging to an admin user.
+	Token configopaque.String `mapstructure:"token"`
+
+	// Sources selects which log streams to ingest.
+	Sources []Source `mapstructure:"sources"`
+
+	// PollInterval between cursor-advancing requests.
+	PollInterval time.Duration `mapstructure:"poll_interval"`
+
+	// BatchSize limits how many journal entries a single request may return.
+	BatchSize int `mapstructure:"batch_size"`
+
+	// ParseMessage extracts the level, thread and logger that Core and
+	// Supervisor embed in the message, and reduces the body to the message
+	// itself. Enabled by default; nothing is lost, since the prefix is fully
+	// described by the resulting fields.
+	ParseMessage bool `mapstructure:"parse_message"`
+
+	// SeverityFromMessage enables best-effort severity detection for messages
+	// that ParseMessage does not recognize, such as host logs. Home Assistant
+	// does not expose the journal PRIORITY field through its API, see the
+	// package README.
+	SeverityFromMessage bool `mapstructure:"severity_from_message"`
+
+	// StorageID references a storage extension used to persist cursors across
+	// restarts. Without it the receiver starts at the tail on every start.
+	StorageID *component.ID `mapstructure:"storage"`
+}
+
+// Validate validates receiver config.
+func (c *Config) Validate() error {
+	if c.Endpoint == "" {
+		return errors.New("endpoint is required")
+	}
+	if c.Token == "" {
+		return errors.New("token is required")
+	}
+	if len(c.Sources) == 0 {
+		return errors.New("at least one source is required")
+	}
+	seen := make(map[string]struct{}, len(c.Sources))
+	for i, s := range c.Sources {
+		if err := s.validate(); err != nil {
+			return errors.Wrapf(err, "source %d", i)
+		}
+		name := s.Name()
+		if _, ok := seen[name]; ok {
+			return errors.Errorf("duplicate source %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	if c.PollInterval <= 0 {
+		return errors.New("poll_interval must be positive")
+	}
+	if c.BatchSize <= 0 {
+		return errors.New("batch_size must be positive")
+	}
+	return nil
+}

--- a/otelcolmod/hareceiver/config_test.go
+++ b/otelcolmod/hareceiver/config_test.go
@@ -1,0 +1,205 @@
+package hareceiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+)
+
+func testConfig(modify func(*Config)) *Config {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Endpoint = "https://homeassistant.example:8123"
+	cfg.Token = "token"
+	cfg.Sources = []Source{{Kind: SourceKindHost}}
+	if modify != nil {
+		modify(cfg)
+	}
+	return cfg
+}
+
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(*Config)
+		wantErr string
+	}{
+		{name: "Valid"},
+		{
+			name: "AllSources",
+			modify: func(c *Config) {
+				c.Sources = []Source{
+					{Kind: SourceKindHost},
+					{Kind: SourceKindCore},
+					{Kind: SourceKindSupervisor},
+					{Kind: SourceKindAddon, Addon: "core_ssh"},
+				}
+			},
+		},
+		{
+			name:    "NoEndpoint",
+			modify:  func(c *Config) { c.Endpoint = "" },
+			wantErr: "endpoint is required",
+		},
+		{
+			name:    "NoToken",
+			modify:  func(c *Config) { c.Token = "" },
+			wantErr: "token is required",
+		},
+		{
+			name:    "NoSources",
+			modify:  func(c *Config) { c.Sources = nil },
+			wantErr: "at least one source is required",
+		},
+		{
+			name:    "EmptyKind",
+			modify:  func(c *Config) { c.Sources = []Source{{}} },
+			wantErr: "kind is required",
+		},
+		{
+			name:    "UnknownKind",
+			modify:  func(c *Config) { c.Sources = []Source{{Kind: "hass"}} },
+			wantErr: `unknown kind "hass"`,
+		},
+		{
+			name:    "AddonWithoutSlug",
+			modify:  func(c *Config) { c.Sources = []Source{{Kind: SourceKindAddon}} },
+			wantErr: "addon is required",
+		},
+		{
+			name: "SlugOnNonAddon",
+			modify: func(c *Config) {
+				c.Sources = []Source{{Kind: SourceKindHost, Addon: "core_ssh"}}
+			},
+			wantErr: "addon is only allowed",
+		},
+		{
+			name: "DuplicateSource",
+			modify: func(c *Config) {
+				c.Sources = []Source{{Kind: SourceKindHost}, {Kind: SourceKindHost}}
+			},
+			wantErr: `duplicate source "host"`,
+		},
+		{
+			name: "DistinctAddons",
+			modify: func(c *Config) {
+				c.Sources = []Source{
+					{Kind: SourceKindAddon, Addon: "a"},
+					{Kind: SourceKindAddon, Addon: "b"},
+				}
+			},
+		},
+		{
+			name: "DuplicateAddon",
+			modify: func(c *Config) {
+				c.Sources = []Source{
+					{Kind: SourceKindAddon, Addon: "a"},
+					{Kind: SourceKindAddon, Addon: "a"},
+				}
+			},
+			wantErr: `duplicate source "addon/a"`,
+		},
+		{
+			name:    "ZeroPollInterval",
+			modify:  func(c *Config) { c.PollInterval = 0 },
+			wantErr: "poll_interval must be positive",
+		},
+		{
+			name:    "NegativePollInterval",
+			modify:  func(c *Config) { c.PollInterval = -time.Second },
+			wantErr: "poll_interval must be positive",
+		},
+		{
+			name:    "ZeroBatchSize",
+			modify:  func(c *Config) { c.BatchSize = 0 },
+			wantErr: "batch_size must be positive",
+		},
+		{
+			name: "WithStorage",
+			modify: func(c *Config) {
+				id := component.MustNewID("file_storage")
+				c.StorageID = &id
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testConfig(tt.modify).Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestSourcePath(t *testing.T) {
+	tests := []struct {
+		src      Source
+		wantPath string
+		wantName string
+		wantKey  string
+	}{
+		{
+			src:      Source{Kind: SourceKindHost},
+			wantPath: "api/hassio/host/logs",
+			wantName: "host",
+			wantKey:  "cursor/host",
+		},
+		{
+			src:      Source{Kind: SourceKindCore},
+			wantPath: "api/hassio/core/logs",
+			wantName: "core",
+			wantKey:  "cursor/core",
+		},
+		{
+			src:      Source{Kind: SourceKindSupervisor},
+			wantPath: "api/hassio/supervisor/logs",
+			wantName: "supervisor",
+			wantKey:  "cursor/supervisor",
+		},
+		{
+			src:      Source{Kind: SourceKindAddon, Addon: "core_ssh"},
+			wantPath: "api/hassio/addons/core_ssh/logs",
+			wantName: "addon/core_ssh",
+			wantKey:  "cursor/addon/core_ssh",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.wantName, func(t *testing.T) {
+			require.Equal(t, tt.wantPath, tt.src.Path())
+			require.Equal(t, tt.wantName, tt.src.Name())
+			require.Equal(t, tt.wantKey, tt.src.StorageKey())
+		})
+	}
+}
+
+func TestCursorStateRangeHeader(t *testing.T) {
+	tests := []struct {
+		state cursorState
+		batch int
+		want  string
+	}{
+		{cursorState{Anchor: "s=abc", Skip: 1}, 100, "entries=s=abc:1:100"},
+		{cursorState{Anchor: "s=abc", Skip: 0}, 1, "entries=s=abc:0:1"},
+		{cursorState{Anchor: "s=abc", Skip: 500}, 500, "entries=s=abc:500:500"},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, tt.state.rangeHeader(tt.batch))
+	}
+}
+
+func TestCursorStateAdvance(t *testing.T) {
+	t.Run("ReAnchors", func(t *testing.T) {
+		s := cursorState{Anchor: "s=a", Skip: 1}.advance("s=b", 10)
+		require.Equal(t, cursorState{Anchor: "s=b", Skip: 10}, s)
+	})
+	t.Run("KeepsAnchorWithoutCursor", func(t *testing.T) {
+		s := cursorState{Anchor: "s=a", Skip: 1}.advance("", 10)
+		require.Equal(t, cursorState{Anchor: "s=a", Skip: 11}, s)
+	})
+}

--- a/otelcolmod/hareceiver/cursor.go
+++ b/otelcolmod/hareceiver/cursor.go
@@ -1,0 +1,74 @@
+package hareceiver
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+)
+
+// cursorState locates the next journal entry to read.
+//
+// Home Assistant returns only the cursor of the first entry of a response, in
+// the X-First-Cursor header, so the position cannot be expressed as a single
+// cursor. Instead it is an anchor cursor plus the number of entries already
+// consumed after it: the next request skips Skip entries past Anchor. Every
+// response re-anchors on its own first entry, so Skip stays bounded by the
+// batch size.
+type cursorState struct {
+	Anchor string `json:"anchor"`
+	Skip   int    `json:"skip"`
+}
+
+// rangeHeader renders the state as a systemd-journal-gatewayd Range header.
+func (s cursorState) rangeHeader(batch int) string {
+	return "entries=" + s.Anchor + ":" + strconv.Itoa(s.Skip) + ":" + strconv.Itoa(batch)
+}
+
+// tailRangeHeader anchors a source that has no stored cursor at the end of the
+// journal.
+//
+// "entries=:-1:N" starts one entry before the last and returns N, so N must be
+// 2 to cover the last entry: "entries=:-1:1" would anchor on the second-to-last
+// one and the first poll would re-emit the last as if it were new. Supervisor
+// avoids the same trap by clamping its own "lines" parameter to 2.
+const tailRangeHeader = "entries=:-1:2"
+
+// advance moves the state past the n entries of a response whose first entry
+// had the given cursor.
+func (s cursorState) advance(firstCursor string, n int) cursorState {
+	if firstCursor == "" {
+		// Should not happen while a response has entries, but staying on the
+		// old anchor is still correct.
+		return cursorState{Anchor: s.Anchor, Skip: s.Skip + n}
+	}
+	return cursorState{Anchor: firstCursor, Skip: n}
+}
+
+func loadCursor(ctx context.Context, client storage.Client, key string) (cursorState, error) {
+	data, err := client.Get(ctx, key)
+	if err != nil {
+		return cursorState{}, errors.Wrap(err, "get")
+	}
+	if len(data) == 0 {
+		return cursorState{}, nil
+	}
+	var s cursorState
+	if err := json.Unmarshal(data, &s); err != nil {
+		return cursorState{}, errors.Wrap(err, "unmarshal")
+	}
+	return s, nil
+}
+
+func saveCursor(ctx context.Context, client storage.Client, key string, s cursorState) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return errors.Wrap(err, "marshal")
+	}
+	if err := client.Set(ctx, key, data); err != nil {
+		return errors.Wrap(err, "set")
+	}
+	return nil
+}

--- a/otelcolmod/hareceiver/factory.go
+++ b/otelcolmod/hareceiver/factory.go
@@ -1,0 +1,47 @@
+// Package hareceiver implements an OpenTelemetry Collector receiver that polls
+// journal logs from a Home Assistant instance and emits OTLP logs.
+package hareceiver
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/receiver"
+)
+
+const (
+	typeStr   = "hareceiver"
+	stability = component.StabilityLevelDevelopment
+
+	defaultPollInterval = 10 * time.Second
+	defaultBatchSize    = 1000
+)
+
+var typ = component.MustNewType(typeStr)
+
+// NewFactory creates new factory of [Receiver].
+func NewFactory() receiver.Factory {
+	return receiver.NewFactory(typ, createDefaultConfig,
+		receiver.WithLogs(createLogsReceiver, stability))
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{
+		ClientConfig: confighttp.NewDefaultClientConfig(),
+		PollInterval: defaultPollInterval,
+		BatchSize:    defaultBatchSize,
+		ParseMessage: true,
+	}
+}
+
+func createLogsReceiver(
+	_ context.Context,
+	params receiver.Settings,
+	cfg component.Config,
+	lc consumer.Logs,
+) (receiver.Logs, error) {
+	return NewReceiver(params, cfg.(*Config), lc)
+}

--- a/otelcolmod/hareceiver/factory.go
+++ b/otelcolmod/hareceiver/factory.go
@@ -18,6 +18,11 @@ const (
 
 	defaultPollInterval = 10 * time.Second
 	defaultBatchSize    = 1000
+
+	// defaultRecombineWindow is far above the observed p99 gap between
+	// fragments of one message, and far below the gap between unrelated
+	// entries from the same process.
+	defaultRecombineWindow = time.Second
 )
 
 var typ = component.MustNewType(typeStr)
@@ -30,10 +35,11 @@ func NewFactory() receiver.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		ClientConfig: confighttp.NewDefaultClientConfig(),
-		PollInterval: defaultPollInterval,
-		BatchSize:    defaultBatchSize,
-		ParseMessage: true,
+		ClientConfig:    confighttp.NewDefaultClientConfig(),
+		PollInterval:    defaultPollInterval,
+		BatchSize:       defaultBatchSize,
+		ParseMessage:    true,
+		RecombineWindow: defaultRecombineWindow,
 	}
 }
 

--- a/otelcolmod/hareceiver/factory_test.go
+++ b/otelcolmod/hareceiver/factory_test.go
@@ -1,0 +1,49 @@
+package hareceiver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+func TestNewFactory(t *testing.T) {
+	f := NewFactory()
+	require.Equal(t, typ, f.Type())
+	require.Equal(t, stability, f.LogsStability())
+}
+
+func TestCreateDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	require.Equal(t, defaultPollInterval, cfg.PollInterval)
+	require.Equal(t, defaultBatchSize, cfg.BatchSize)
+	require.False(t, cfg.SeverityFromMessage)
+	require.Nil(t, cfg.StorageID)
+	require.Error(t, cfg.Validate(), "default config is incomplete")
+}
+
+func TestCreateLogsReceiver(t *testing.T) {
+	f := NewFactory()
+
+	t.Run("Valid", func(t *testing.T) {
+		r, err := f.CreateLogs(
+			context.Background(),
+			receivertest.NewNopSettings(typ),
+			testConfig(nil),
+			consumertest.NewNop(),
+		)
+		require.NoError(t, err)
+		require.IsType(t, (*Receiver)(nil), r)
+	})
+	t.Run("Invalid", func(t *testing.T) {
+		_, err := f.CreateLogs(
+			context.Background(),
+			receivertest.NewNopSettings(typ),
+			testConfig(func(c *Config) { c.Token = "" }),
+			consumertest.NewNop(),
+		)
+		require.ErrorContains(t, err, "token is required")
+	})
+}

--- a/otelcolmod/hareceiver/gold_test.go
+++ b/otelcolmod/hareceiver/gold_test.go
@@ -1,0 +1,15 @@
+package hareceiver
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-faster/sdk/gold"
+)
+
+func TestMain(m *testing.M) {
+	// Explicitly registering flags for golden files.
+	gold.Init()
+
+	os.Exit(m.Run())
+}

--- a/otelcolmod/hareceiver/parser.go
+++ b/otelcolmod/hareceiver/parser.go
@@ -1,0 +1,83 @@
+package hareceiver
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Entry is a journal entry recovered from the Home Assistant log API.
+//
+// Home Assistant renders journal entries to text before returning them, so only
+// the fields of the verbose formatter survive. See the package README.
+type Entry struct {
+	Timestamp  time.Time
+	Hostname   string
+	Identifier string
+	PID        int64
+	HasPID     bool
+	Message    string
+}
+
+// unknownIdentifier is what Home Assistant emits for entries without a
+// SYSLOG_IDENTIFIER.
+const unknownIdentifier = "_UNKNOWN_"
+
+// entryLine matches a line produced by Home Assistant's verbose journal
+// formatter: "<ts> <hostname> <identifier>[<pid>]: <message>", where the
+// timestamp is UTC with millisecond precision.
+var entryLine = regexp.MustCompile(
+	`^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) (\S*) (.*?)(?:\[(\d+)\])?: (.*)$`,
+)
+
+const entryTimeLayout = "2006-01-02 15:04:05.000"
+
+var epoch = time.Unix(0, 0).UTC()
+
+// ParseEntries parses a verbose log response body into journal entries.
+//
+// A line that does not start a new entry is a continuation of the previous
+// entry's message, since a journal MESSAGE may span multiple lines. Leading
+// continuation lines have no entry to attach to and are dropped: the response
+// may begin in the middle of a multi-line message.
+func ParseEntries(body string) []Entry {
+	var entries []Entry
+	for line := range strings.SplitSeq(strings.TrimSuffix(body, "\n"), "\n") {
+		m := entryLine.FindStringSubmatch(line)
+		if m == nil {
+			if n := len(entries); n > 0 {
+				entries[n-1].Message += "\n" + line
+			}
+			continue
+		}
+
+		// A journal __REALTIME_TIMESTAMP is an unsigned microsecond count, so a
+		// pre-epoch timestamp cannot start an entry, only look like one.
+		ts, err := time.ParseInLocation(entryTimeLayout, m[1], time.UTC)
+		if err != nil || ts.Before(epoch) {
+			if n := len(entries); n > 0 {
+				entries[n-1].Message += "\n" + line
+			}
+			continue
+		}
+
+		e := Entry{
+			Timestamp:  ts,
+			Hostname:   m[2],
+			Identifier: m[3],
+			Message:    m[5],
+		}
+		if e.Identifier == unknownIdentifier {
+			e.Identifier = ""
+		}
+		if m[4] != "" {
+			// Regexp guarantees digits, overflow is the only failure mode.
+			if pid, err := strconv.ParseInt(m[4], 10, 64); err == nil {
+				e.PID, e.HasPID = pid, true
+			}
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}

--- a/otelcolmod/hareceiver/parser_test.go
+++ b/otelcolmod/hareceiver/parser_test.go
@@ -120,6 +120,12 @@ func TestParseEntries(t *testing.T) {
 					"every entry must produce exactly one record")
 				gold.Str(t, encodeLogs(t, logs), file.GoldenFile("logs"))
 			})
+			t.Run("Recombined", func(t *testing.T) {
+				joined := recombineEntries(entries, defaultRecombineWindow)
+				require.LessOrEqual(t, len(joined), len(entries))
+				logs := translateEntries(joined, file.Source(), cfg, observedAt)
+				gold.Str(t, encodeLogs(t, logs), file.GoldenFile("recombined"))
+			})
 		})
 	}
 }

--- a/otelcolmod/hareceiver/parser_test.go
+++ b/otelcolmod/hareceiver/parser_test.go
@@ -1,0 +1,137 @@
+package hareceiver
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-faster/jx"
+	"github.com/go-faster/sdk/gold"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// observedAt is fixed so that ObservedTimestamp is reproducible in golden files.
+var observedAt = time.Date(2026, time.January, 20, 1, 2, 3, 4, time.UTC)
+
+// testDataFile is one captured log API response.
+type testDataFile struct {
+	Name string
+	Body string
+}
+
+// GoldenFile returns the golden file name for the given prefix.
+func (f testDataFile) GoldenFile(prefix string) string {
+	name := strings.TrimSuffix(f.Name, filepath.Ext(f.Name))
+	return fmt.Sprintf("%s_%s.json", prefix, name)
+}
+
+// Source returns the source a response was captured from, taken from its name.
+func (f testDataFile) Source() Source {
+	switch strings.TrimSuffix(f.Name, filepath.Ext(f.Name)) {
+	case "core":
+		return Source{Kind: SourceKindCore}
+	case "supervisor":
+		return Source{Kind: SourceKindSupervisor}
+	case "addon":
+		return Source{Kind: SourceKindAddon, Addon: "core_ssh"}
+	default:
+		return Source{Kind: SourceKindHost}
+	}
+}
+
+func readTestData(t require.TestingT) iter.Seq[testDataFile] {
+	return func(yield func(testDataFile) bool) {
+		dir := filepath.Join("_testdata", "journal")
+
+		files, err := os.ReadDir(dir)
+		require.NoError(t, err, "read testdata directory")
+
+		for _, file := range files {
+			data, err := os.ReadFile(filepath.Join(dir, file.Name()))
+			require.NoError(t, err, "read testdata file")
+
+			if !yield(testDataFile{Name: file.Name(), Body: string(data)}) {
+				return
+			}
+		}
+	}
+}
+
+// encodeEntries renders parsed entries as stable JSON.
+func encodeEntries(entries []Entry) string {
+	e := &jx.Encoder{}
+	e.SetIdent(2)
+	e.Arr(func(e *jx.Encoder) {
+		for _, entry := range entries {
+			e.Obj(func(e *jx.Encoder) {
+				e.Field("timestamp", func(e *jx.Encoder) {
+					e.Str(entry.Timestamp.Format(time.RFC3339Nano))
+				})
+				if entry.Hostname != "" {
+					e.Field("hostname", func(e *jx.Encoder) { e.Str(entry.Hostname) })
+				}
+				if entry.Identifier != "" {
+					e.Field("identifier", func(e *jx.Encoder) { e.Str(entry.Identifier) })
+				}
+				if entry.HasPID {
+					e.Field("pid", func(e *jx.Encoder) { e.Int64(entry.PID) })
+				}
+				e.Field("message", func(e *jx.Encoder) { e.Str(entry.Message) })
+			})
+		}
+	})
+	return e.String() + "\n"
+}
+
+// encodeLogs renders translated logs as indented OTLP JSON.
+func encodeLogs(t *testing.T, logs plog.Logs) string {
+	t.Helper()
+	data, err := (&plog.JSONMarshaler{}).MarshalLogs(logs)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, json.Indent(&buf, data, "", "  "))
+	return buf.String() + "\n"
+}
+
+func TestParseEntries(t *testing.T) {
+	cfg := &Config{ParseMessage: true, SeverityFromMessage: true}
+
+	for file := range readTestData(t) {
+		t.Run(file.Name, func(t *testing.T) {
+			entries := ParseEntries(file.Body)
+
+			t.Run("Entries", func(t *testing.T) {
+				for _, e := range entries {
+					require.False(t, e.Timestamp.IsZero(), "entry must have a timestamp")
+				}
+				gold.Str(t, encodeEntries(entries), file.GoldenFile("journal"))
+			})
+			t.Run("Logs", func(t *testing.T) {
+				logs := translateEntries(entries, file.Source(), cfg, observedAt)
+				require.Equal(t, len(entries), logs.LogRecordCount(),
+					"every entry must produce exactly one record")
+				gold.Str(t, encodeLogs(t, logs), file.GoldenFile("logs"))
+			})
+		})
+	}
+}
+
+func FuzzParseEntries(f *testing.F) {
+	for file := range readTestData(f) {
+		f.Add(file.Body)
+	}
+
+	f.Fuzz(func(t *testing.T, body string) {
+		for _, e := range ParseEntries(body) {
+			require.False(t, e.Timestamp.IsZero(), "entry must have a timestamp")
+		}
+	})
+}

--- a/otelcolmod/hareceiver/poller.go
+++ b/otelcolmod/hareceiver/poller.go
@@ -126,13 +126,19 @@ func (p *poller) poll(ctx context.Context) error {
 	if len(entries) == 0 {
 		return nil
 	}
+	// The cursor counts journal entries, so it must advance by the number of
+	// entries the response held, not by the number of records they produce.
+	count := len(entries)
+	if p.cfg.RecombineWindow > 0 {
+		entries = recombineEntries(entries, p.cfg.RecombineWindow)
+	}
 
 	logs := translateEntries(entries, p.src, p.cfg, p.now())
 	if err := p.consumer.ConsumeLogs(ctx, logs); err != nil {
 		return errors.Wrap(err, "consume logs")
 	}
 
-	state := p.state.advance(firstCursor, len(entries))
+	state := p.state.advance(firstCursor, count)
 	if err := saveCursor(ctx, p.storage, p.src.StorageKey(), state); err != nil {
 		return errors.Wrap(err, "save cursor")
 	}

--- a/otelcolmod/hareceiver/poller.go
+++ b/otelcolmod/hareceiver/poller.go
@@ -1,0 +1,196 @@
+package hareceiver
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+	"go.uber.org/zap"
+)
+
+// firstCursorHeader is set by Home Assistant to the journal cursor of the first
+// entry of the response.
+const firstCursorHeader = "X-First-Cursor"
+
+// maxErrorBody bounds how much of an error response is kept for the message.
+const maxErrorBody = 1024
+
+// poller ingests a single [Source].
+type poller struct {
+	src      Source
+	cfg      *Config
+	url      string
+	client   *http.Client
+	consumer consumer.Logs
+	storage  storage.Client
+	logger   *zap.Logger
+	now      func() time.Time
+
+	state  cursorState
+	loaded bool
+}
+
+func newPoller(
+	src Source,
+	cfg *Config,
+	client *http.Client,
+	lc consumer.Logs,
+	st storage.Client,
+	logger *zap.Logger,
+) (*poller, error) {
+	u, err := url.JoinPath(cfg.Endpoint, src.Path())
+	if err != nil {
+		return nil, errors.Wrap(err, "build url")
+	}
+	// Home Assistant renders journal entries to text; "verbose" selects the
+	// format that carries the timestamp, hostname and identifier, and
+	// "no_colors" makes it strip ANSI escapes server-side.
+	u += "?verbose&no_colors"
+	return &poller{
+		src:      src,
+		cfg:      cfg,
+		url:      u,
+		client:   client,
+		consumer: lc,
+		storage:  st,
+		logger:   logger.With(zap.String("source", src.Name())),
+		now:      time.Now,
+	}, nil
+}
+
+func (p *poller) run(ctx context.Context) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 0
+	bo.MaxInterval = p.cfg.PollInterval * 10
+
+	ticker := time.NewTicker(p.cfg.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		if err := p.poll(ctx); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			var permanent *backoff.PermanentError
+			if errors.As(err, &permanent) {
+				return permanent.Err
+			}
+			d := bo.NextBackOff()
+			p.logger.Warn("Poll failed, retrying", zap.Error(err), zap.Duration("delay", d))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(d):
+			}
+			continue
+		}
+		bo.Reset()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// poll performs one cursor-advancing request.
+//
+// The cursor advances only after [consumer.Logs.ConsumeLogs] returns nil, which
+// makes delivery at-least-once: a failure re-reads the same window rather than
+// skipping it.
+func (p *poller) poll(ctx context.Context) error {
+	if !p.loaded {
+		state, err := loadCursor(ctx, p.storage, p.src.StorageKey())
+		if err != nil {
+			return errors.Wrap(err, "load cursor")
+		}
+		p.state, p.loaded = state, true
+	}
+	if p.state.Anchor == "" {
+		return p.anchorAtTail(ctx)
+	}
+
+	body, firstCursor, err := p.fetch(ctx, p.state.rangeHeader(p.cfg.BatchSize))
+	if err != nil {
+		return err
+	}
+	entries := ParseEntries(body)
+	if len(entries) == 0 {
+		return nil
+	}
+
+	logs := translateEntries(entries, p.src, p.cfg, p.now())
+	if err := p.consumer.ConsumeLogs(ctx, logs); err != nil {
+		return errors.Wrap(err, "consume logs")
+	}
+
+	state := p.state.advance(firstCursor, len(entries))
+	if err := saveCursor(ctx, p.storage, p.src.StorageKey(), state); err != nil {
+		return errors.Wrap(err, "save cursor")
+	}
+	p.state = state
+	return nil
+}
+
+// anchorAtTail positions a source with no stored cursor at the most recent
+// entry without emitting it.
+func (p *poller) anchorAtTail(ctx context.Context) error {
+	body, firstCursor, err := p.fetch(ctx, tailRangeHeader)
+	if err != nil {
+		return err
+	}
+	if firstCursor == "" {
+		p.logger.Debug("Journal is empty, retrying")
+		return nil
+	}
+
+	state := cursorState{Anchor: firstCursor, Skip: len(ParseEntries(body))}
+	if err := saveCursor(ctx, p.storage, p.src.StorageKey(), state); err != nil {
+		return errors.Wrap(err, "save cursor")
+	}
+	p.state = state
+	return nil
+}
+
+func (p *poller) fetch(ctx context.Context, rangeHeader string) (body, firstCursor string, _ error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.url, http.NoBody)
+	if err != nil {
+		return "", "", errors.Wrap(err, "create request")
+	}
+	req.Header.Set("Authorization", "Bearer "+string(p.cfg.Token))
+	req.Header.Set("Range", rangeHeader)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return "", "", errors.Wrap(err, "do request")
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+		err := errors.Errorf("unexpected status %s: %s", resp.Status, strings.TrimSpace(string(data)))
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			// The token is either invalid or does not belong to an admin user;
+			// retrying will not fix either.
+			return "", "", backoff.Permanent(err)
+		}
+		return "", "", err
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", errors.Wrap(err, "read body")
+	}
+	return string(data), resp.Header.Get(firstCursorHeader), nil
+}

--- a/otelcolmod/hareceiver/poller_test.go
+++ b/otelcolmod/hareceiver/poller_test.go
@@ -213,6 +213,31 @@ func TestPollerMultilineCountsOneEntry(t *testing.T) {
 		"a continuation line is not a journal entry and must not be skipped over")
 }
 
+func TestPollerRecombineKeepsCursorOnEntries(t *testing.T) {
+	// Four journal entries collapse into two records; the cursor must advance
+	// by four, or the next poll would re-read the fragments it already emitted.
+	ha := newFakeHA(t,
+		response{firstCursor: "s=2", body: "" +
+			"2026-08-09 12:00:01.000 ha app[1]: 2026-08-09 12:00:01.000 ERROR (MainThread) [a.b] boom\n" +
+			"2026-08-09 12:00:01.001 ha app[1]: Traceback (most recent call last):\n" +
+			"2026-08-09 12:00:01.002 ha app[1]:   File \"x.py\", line 1\n" +
+			"2026-08-09 12:00:01.003 ha app[1]: 2026-08-09 12:00:01.003 INFO (MainThread) [a.b] done\n"},
+		response{firstCursor: "s=6", body: "2026-08-09 12:00:02.000 ha app[1]: next\n"},
+	)
+	sink := new(consumertest.LogsSink)
+	st := newMemStorage()
+	require.NoError(t, st.Set(context.Background(), "cursor/host", []byte(`{"anchor":"s=1","skip":1}`)))
+	p := newTestPoller(t, ha, sink, st)
+
+	require.NoError(t, p.poll(context.Background()))
+	require.Equal(t, 2, sink.LogRecordCount(), "the traceback joins the error record")
+	require.JSONEq(t, `{"anchor":"s=2","skip":4}`, storedCursor(t, st),
+		"skip counts journal entries, not emitted records")
+
+	require.NoError(t, p.poll(context.Background()))
+	require.Equal(t, []string{"entries=s=1:1:100", "entries=s=2:4:100"}, ha.ranges())
+}
+
 func TestPollerEmptyResponseKeepsCursor(t *testing.T) {
 	ha := newFakeHA(t,
 		response{body: ""},

--- a/otelcolmod/hareceiver/poller_test.go
+++ b/otelcolmod/hareceiver/poller_test.go
@@ -1,0 +1,295 @@
+package hareceiver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+	"go.uber.org/zap/zaptest"
+)
+
+// memStorage is an in-memory [storage.Client].
+type memStorage struct {
+	data map[string][]byte
+}
+
+func newMemStorage() *memStorage {
+	return &memStorage{data: map[string][]byte{}}
+}
+
+func (s *memStorage) Get(_ context.Context, key string) ([]byte, error) {
+	return s.data[key], nil
+}
+
+func (s *memStorage) Set(_ context.Context, key string, value []byte) error {
+	s.data[key] = value
+	return nil
+}
+
+func (s *memStorage) Delete(_ context.Context, key string) error {
+	delete(s.data, key)
+	return nil
+}
+
+func (s *memStorage) Batch(context.Context, ...*storage.Operation) error {
+	return errors.New("not implemented")
+}
+
+func (*memStorage) Close(context.Context) error { return nil }
+
+// response is a canned reply of the fake Home Assistant instance.
+type response struct {
+	status      int
+	firstCursor string
+	body        string
+}
+
+type fakeHA struct {
+	t         *testing.T
+	responses []response
+	requests  []*http.Request
+	server    *httptest.Server
+}
+
+func newFakeHA(t *testing.T, responses ...response) *fakeHA {
+	ha := &fakeHA{t: t, responses: responses}
+	ha.server = httptest.NewServer(http.HandlerFunc(ha.handle))
+	t.Cleanup(ha.server.Close)
+	return ha
+}
+
+func (ha *fakeHA) handle(w http.ResponseWriter, r *http.Request) {
+	ha.requests = append(ha.requests, r)
+	if len(ha.requests) > len(ha.responses) {
+		ha.t.Errorf("unexpected request %d: %s", len(ha.requests), r.Header.Get("Range"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	resp := ha.responses[len(ha.requests)-1]
+	if resp.firstCursor != "" {
+		w.Header().Set(firstCursorHeader, resp.firstCursor)
+	}
+	status := resp.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(resp.body))
+}
+
+// ranges returns the Range header of every request received so far.
+func (ha *fakeHA) ranges() []string {
+	out := make([]string, 0, len(ha.requests))
+	for _, r := range ha.requests {
+		out = append(out, r.Header.Get("Range"))
+	}
+	return out
+}
+
+func newTestPoller(t *testing.T, ha *fakeHA, lc consumer.Logs, st storage.Client) *poller {
+	t.Helper()
+	cfg := testConfig(func(c *Config) {
+		c.Endpoint = ha.server.URL
+		c.BatchSize = 100
+	})
+	p, err := newPoller(
+		Source{Kind: SourceKindHost}, cfg,
+		ha.server.Client(), lc, st, zaptest.NewLogger(t),
+	)
+	require.NoError(t, err)
+	return p
+}
+
+func storedCursor(t *testing.T, st *memStorage) string {
+	t.Helper()
+	return string(st.data["cursor/host"])
+}
+
+func TestPollerRequest(t *testing.T) {
+	ha := newFakeHA(t, response{firstCursor: "s=1", body: "2026-08-09 12:00:00.000 ha x[1]: a\n"})
+	p := newTestPoller(t, ha, consumertest.NewNop(), newMemStorage())
+	require.NoError(t, p.poll(context.Background()))
+
+	require.Len(t, ha.requests, 1)
+	req := ha.requests[0]
+	require.Equal(t, "/api/hassio/host/logs", req.URL.Path)
+	require.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+	require.Equal(t, tailRangeHeader, req.Header.Get("Range"))
+
+	q, err := url.ParseQuery(req.URL.RawQuery)
+	require.NoError(t, err)
+	require.Contains(t, q, "verbose")
+	require.Contains(t, q, "no_colors")
+	require.NotContains(t, q, "lines", "lines would override the Range header")
+}
+
+func TestPollerColdStartDoesNotEmit(t *testing.T) {
+	// "entries=:-1:2" returns the last two entries; anchoring on the first of
+	// them with skip=2 puts the next read past the last, so neither is emitted.
+	ha := newFakeHA(t,
+		response{firstCursor: "s=1", body: "" +
+			"2026-08-09 12:00:00.000 ha x[1]: second to last\n" +
+			"2026-08-09 12:00:01.000 ha x[1]: last\n"},
+		response{firstCursor: "s=3", body: "2026-08-09 12:00:02.000 ha x[1]: new\n"},
+	)
+	sink := new(consumertest.LogsSink)
+	st := newMemStorage()
+	p := newTestPoller(t, ha, sink, st)
+
+	require.NoError(t, p.poll(context.Background()))
+	require.Zero(t, sink.LogRecordCount(), "tail anchoring must not emit pre-existing entries")
+	require.JSONEq(t, `{"anchor":"s=1","skip":2}`, storedCursor(t, st))
+
+	require.NoError(t, p.poll(context.Background()))
+	require.Equal(t, 1, sink.LogRecordCount())
+	require.Equal(t, "new", sink.AllLogs()[0].
+		ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Str())
+	require.Equal(t, []string{tailRangeHeader, "entries=s=1:2:100"}, ha.ranges())
+	require.JSONEq(t, `{"anchor":"s=3","skip":1}`, storedCursor(t, st))
+}
+
+func TestPollerColdStartShortJournal(t *testing.T) {
+	// A journal holding a single entry returns one line instead of two; the
+	// skip must follow the response, not the requested count.
+	ha := newFakeHA(t,
+		response{firstCursor: "s=1", body: "2026-08-09 12:00:00.000 ha x[1]: only\n"},
+	)
+	sink := new(consumertest.LogsSink)
+	st := newMemStorage()
+	p := newTestPoller(t, ha, sink, st)
+
+	require.NoError(t, p.poll(context.Background()))
+	require.Zero(t, sink.LogRecordCount())
+	require.JSONEq(t, `{"anchor":"s=1","skip":1}`, storedCursor(t, st))
+}
+
+func TestPollerAdvancesCursor(t *testing.T) {
+	ha := newFakeHA(t,
+		response{firstCursor: "s=2", body: "" +
+			"2026-08-09 12:00:01.000 ha x[1]: a\n" +
+			"2026-08-09 12:00:02.000 ha x[1]: b\n" +
+			"2026-08-09 12:00:03.000 ha x[1]: c\n"},
+		response{firstCursor: "s=5", body: "2026-08-09 12:00:04.000 ha x[1]: d\n"},
+	)
+	sink := new(consumertest.LogsSink)
+	st := newMemStorage()
+	require.NoError(t, st.Set(context.Background(), "cursor/host", []byte(`{"anchor":"s=1","skip":1}`)))
+	p := newTestPoller(t, ha, sink, st)
+
+	require.NoError(t, p.poll(context.Background()))
+	require.NoError(t, p.poll(context.Background()))
+
+	require.Equal(t, []string{"entries=s=1:1:100", "entries=s=2:3:100"}, ha.ranges(),
+		"skip must equal the number of entries of the anchoring response")
+	require.Equal(t, 4, sink.LogRecordCount())
+	require.JSONEq(t, `{"anchor":"s=5","skip":1}`, storedCursor(t, st))
+}
+
+func TestPollerMultilineCountsOneEntry(t *testing.T) {
+	ha := newFakeHA(t,
+		response{firstCursor: "s=2", body: "" +
+			"2026-08-09 12:00:01.000 ha x[1]: Traceback:\n" +
+			"    raise Error\n" +
+			"2026-08-09 12:00:02.000 ha x[1]: b\n"},
+		response{firstCursor: "s=4", body: "2026-08-09 12:00:03.000 ha x[1]: c\n"},
+	)
+	st := newMemStorage()
+	require.NoError(t, st.Set(context.Background(), "cursor/host", []byte(`{"anchor":"s=1","skip":1}`)))
+	p := newTestPoller(t, ha, consumertest.NewNop(), st)
+
+	require.NoError(t, p.poll(context.Background()))
+	require.NoError(t, p.poll(context.Background()))
+
+	require.Equal(t, []string{"entries=s=1:1:100", "entries=s=2:2:100"}, ha.ranges(),
+		"a continuation line is not a journal entry and must not be skipped over")
+}
+
+func TestPollerEmptyResponseKeepsCursor(t *testing.T) {
+	ha := newFakeHA(t,
+		response{body: ""},
+		response{body: ""},
+	)
+	st := newMemStorage()
+	require.NoError(t, st.Set(context.Background(), "cursor/host", []byte(`{"anchor":"s=1","skip":1}`)))
+	p := newTestPoller(t, ha, consumertest.NewNop(), st)
+
+	require.NoError(t, p.poll(context.Background()))
+	require.NoError(t, p.poll(context.Background()))
+
+	require.Equal(t, []string{"entries=s=1:1:100", "entries=s=1:1:100"}, ha.ranges())
+	require.JSONEq(t, `{"anchor":"s=1","skip":1}`, storedCursor(t, st))
+}
+
+func TestPollerEmptyJournalRetriesAnchoring(t *testing.T) {
+	ha := newFakeHA(t,
+		response{body: ""},
+		response{firstCursor: "s=1", body: "2026-08-09 12:00:00.000 ha x[1]: a\n"},
+	)
+	st := newMemStorage()
+	p := newTestPoller(t, ha, consumertest.NewNop(), st)
+
+	require.NoError(t, p.poll(context.Background()))
+	require.Empty(t, storedCursor(t, st), "nothing to anchor on yet")
+
+	require.NoError(t, p.poll(context.Background()))
+	require.Equal(t, []string{tailRangeHeader, tailRangeHeader}, ha.ranges())
+	require.JSONEq(t, `{"anchor":"s=1","skip":1}`, storedCursor(t, st))
+}
+
+func TestPollerConsumeErrorDoesNotAdvance(t *testing.T) {
+	ha := newFakeHA(t,
+		response{firstCursor: "s=2", body: "2026-08-09 12:00:01.000 ha x[1]: a\n"},
+		response{firstCursor: "s=2", body: "2026-08-09 12:00:01.000 ha x[1]: a\n"},
+	)
+	st := newMemStorage()
+	require.NoError(t, st.Set(context.Background(), "cursor/host", []byte(`{"anchor":"s=1","skip":1}`)))
+	p := newTestPoller(t, ha, consumertest.NewErr(errors.New("downstream")), st)
+
+	require.ErrorContains(t, p.poll(context.Background()), "downstream")
+	require.JSONEq(t, `{"anchor":"s=1","skip":1}`, storedCursor(t, st),
+		"cursor must not advance past entries that were never delivered")
+
+	require.ErrorContains(t, p.poll(context.Background()), "downstream")
+	require.Equal(t, []string{"entries=s=1:1:100", "entries=s=1:1:100"}, ha.ranges(),
+		"the same window must be re-read")
+}
+
+func TestPollerResumesFromStoredCursor(t *testing.T) {
+	ha := newFakeHA(t, response{firstCursor: "s=9", body: "2026-08-09 12:00:01.000 ha x[1]: a\n"})
+	st := newMemStorage()
+	require.NoError(t, st.Set(context.Background(), "cursor/host", []byte(`{"anchor":"s=7","skip":4}`)))
+
+	p := newTestPoller(t, ha, consumertest.NewNop(), st)
+	require.NoError(t, p.poll(context.Background()))
+	require.Equal(t, []string{"entries=s=7:4:100"}, ha.ranges())
+}
+
+func TestPollerUnauthorizedIsPermanent(t *testing.T) {
+	ha := newFakeHA(t, response{status: http.StatusUnauthorized, body: "unauthorized"})
+	p := newTestPoller(t, ha, consumertest.NewNop(), newMemStorage())
+
+	err := p.poll(context.Background())
+	require.Error(t, err)
+	var permanent *backoff.PermanentError
+	require.ErrorAs(t, err, &permanent, "a non-admin token is not worth retrying")
+	require.ErrorContains(t, err, "401")
+}
+
+func TestPollerServerErrorIsRetryable(t *testing.T) {
+	ha := newFakeHA(t, response{status: http.StatusBadGateway, body: "bad gateway"})
+	p := newTestPoller(t, ha, consumertest.NewNop(), newMemStorage())
+
+	err := p.poll(context.Background())
+	require.Error(t, err)
+	var permanent *backoff.PermanentError
+	require.NotErrorAs(t, err, &permanent)
+}

--- a/otelcolmod/hareceiver/receiver.go
+++ b/otelcolmod/hareceiver/receiver.go
@@ -1,0 +1,122 @@
+package hareceiver
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componentstatus"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
+)
+
+// Receiver polls journal logs from a Home Assistant instance.
+type Receiver struct {
+	cfg      *Config
+	params   receiver.Settings
+	consumer consumer.Logs
+	logger   *zap.Logger
+
+	mu        sync.Mutex
+	storage   storage.Client
+	cancel    context.CancelFunc
+	wg        sync.WaitGroup
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+// NewReceiver creates a new Receiver.
+func NewReceiver(params receiver.Settings, cfg *Config, lc consumer.Logs) (*Receiver, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &Receiver{cfg: cfg, params: params, consumer: lc, logger: params.Logger}, nil
+}
+
+var _ component.Component = (*Receiver)(nil)
+
+// Start implements [component.Component].
+func (r *Receiver) Start(ctx context.Context, host component.Host) error {
+	var err error
+	r.startOnce.Do(func() {
+		err = r.start(ctx, host)
+	})
+	return err
+}
+
+func (r *Receiver) start(ctx context.Context, host component.Host) error {
+	client, err := r.cfg.ClientConfig.ToClient(ctx, host.GetExtensions(), r.params.TelemetrySettings)
+	if err != nil {
+		return errors.Wrap(err, "create client")
+	}
+	st, err := r.storageClient(ctx, host)
+	if err != nil {
+		return errors.Wrap(err, "create storage client")
+	}
+
+	pollers := make([]*poller, 0, len(r.cfg.Sources))
+	for _, src := range r.cfg.Sources {
+		p, err := newPoller(src, r.cfg, client, r.consumer, st, r.logger)
+		if err != nil {
+			return errors.Wrapf(err, "source %q", src.Name())
+		}
+		pollers = append(pollers, p)
+	}
+
+	r.mu.Lock()
+	r.storage = st
+	runCtx, cancel := context.WithCancel(context.Background())
+	r.cancel = cancel
+	r.mu.Unlock()
+
+	for _, p := range pollers {
+		r.wg.Go(func() {
+			if err := p.run(runCtx); err != nil && !errors.Is(err, context.Canceled) {
+				componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
+			}
+		})
+	}
+	return nil
+}
+
+func (r *Receiver) storageClient(ctx context.Context, host component.Host) (storage.Client, error) {
+	if r.cfg.StorageID == nil {
+		r.logger.Warn("No storage extension configured, cursors are lost on restart")
+		return storage.NewNopClient(), nil
+	}
+	ext, ok := host.GetExtensions()[*r.cfg.StorageID]
+	if !ok {
+		return nil, errors.Errorf("extension %q not found", r.cfg.StorageID)
+	}
+	se, ok := ext.(storage.Extension)
+	if !ok {
+		return nil, errors.Errorf("extension %q is not a storage extension", r.cfg.StorageID)
+	}
+	return se.GetClient(ctx, component.KindReceiver, r.params.ID, "")
+}
+
+// Shutdown implements [component.Component].
+func (r *Receiver) Shutdown(ctx context.Context) error {
+	var err error
+	r.stopOnce.Do(func() {
+		r.mu.Lock()
+		cancel, st := r.cancel, r.storage
+		r.mu.Unlock()
+		if cancel != nil {
+			cancel()
+		}
+		done := make(chan struct{})
+		go func() { r.wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-ctx.Done():
+		}
+		if st != nil {
+			err = st.Close(ctx)
+		}
+	})
+	return err
+}

--- a/otelcolmod/hareceiver/receiver_test.go
+++ b/otelcolmod/hareceiver/receiver_test.go
@@ -1,0 +1,114 @@
+package hareceiver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/extension/xextension/storage"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+// storageExtension is a [storage.Extension] backed by [memStorage].
+type storageExtension struct {
+	component.StartFunc
+	component.ShutdownFunc
+	client *memStorage
+}
+
+func (e *storageExtension) GetClient(
+	context.Context, component.Kind, component.ID, string,
+) (storage.Client, error) {
+	return e.client, nil
+}
+
+type testHost struct {
+	extensions map[component.ID]component.Component
+}
+
+func (h testHost) GetExtensions() map[component.ID]component.Component {
+	return h.extensions
+}
+
+func newReceiver(t *testing.T, cfg *Config) *Receiver {
+	t.Helper()
+	r, err := NewReceiver(receivertest.NewNopSettings(typ), cfg, consumertest.NewNop())
+	require.NoError(t, err)
+	return r
+}
+
+// idleEndpoint serves an empty journal, so that a started poller makes no
+// progress and needs no canned responses.
+func idleEndpoint(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestReceiverLifecycle(t *testing.T) {
+	cfg := testConfig(func(c *Config) {
+		c.Endpoint = idleEndpoint(t)
+		c.Sources = []Source{
+			{Kind: SourceKindHost},
+			{Kind: SourceKindAddon, Addon: "core_ssh"},
+		}
+	})
+	r := newReceiver(t, cfg)
+
+	require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, r.Shutdown(context.Background()))
+	require.NoError(t, r.Shutdown(context.Background()), "shutdown is idempotent")
+}
+
+func TestReceiverStorageExtension(t *testing.T) {
+	id := component.MustNewID("file_storage")
+	cfg := testConfig(func(c *Config) {
+		c.Endpoint = idleEndpoint(t)
+		c.StorageID = &id
+	})
+
+	t.Run("Found", func(t *testing.T) {
+		ext := &storageExtension{client: newMemStorage()}
+		host := testHost{extensions: map[component.ID]component.Component{id: ext}}
+
+		r := newReceiver(t, cfg)
+		require.NoError(t, r.Start(context.Background(), host))
+		require.NoError(t, r.Shutdown(context.Background()))
+	})
+	t.Run("Missing", func(t *testing.T) {
+		r := newReceiver(t, cfg)
+		err := r.Start(context.Background(), componenttest.NewNopHost())
+		require.ErrorContains(t, err, "not found")
+	})
+	t.Run("NotStorage", func(t *testing.T) {
+		host := testHost{extensions: map[component.ID]component.Component{
+			id: extension.Extension(nopExtension{}),
+		}}
+		r := newReceiver(t, cfg)
+		err := r.Start(context.Background(), host)
+		require.ErrorContains(t, err, "not a storage extension")
+	})
+}
+
+type nopExtension struct {
+	component.StartFunc
+	component.ShutdownFunc
+}
+
+func TestReceiverInvalidConfig(t *testing.T) {
+	_, err := NewReceiver(
+		receivertest.NewNopSettings(typ),
+		testConfig(func(c *Config) { c.Sources = nil }),
+		consumertest.NewNop(),
+	)
+	require.ErrorContains(t, err, "at least one source is required")
+}

--- a/otelcolmod/hareceiver/recombine.go
+++ b/otelcolmod/hareceiver/recombine.go
@@ -14,9 +14,12 @@ import "time"
 // CoreDNS — would have entire runs of unrelated entries merged, since none of
 // them starts a new application log line.
 //
-// A fragment must also come from the same process and follow within window. In a
-// captured sample the gap between fragments of one message was 7ms at p99, while
-// unrelated entries from the same process sat minutes apart.
+// A fragment must also come from the same process and follow within window. The
+// exact window barely matters: measured over 11.5k captured entries the gap
+// between fragments was 58ms at p99, and anything from 100ms to 1s produced
+// byte-identical output. Only 4 of 491 fragments exceeded 1s, all of them lines
+// that merely followed an unrelated entry from the same process, so ending the
+// block there is the wanted outcome rather than a loss.
 //
 // Fragments are only ever appended to an entry already in the batch, so the
 // journal entry count — which the cursor arithmetic depends on — is unchanged.

--- a/otelcolmod/hareceiver/recombine.go
+++ b/otelcolmod/hareceiver/recombine.go
@@ -1,0 +1,61 @@
+package hareceiver
+
+import "time"
+
+// recombineEntries joins entries that are fragments of one logical event.
+//
+// journald splits a multi-line message at every newline, so a Python traceback
+// arrives as one entry per line, each with a full envelope, the same identifier
+// and PID, and near-identical timestamps. Emitted as-is that is one severity-less
+// record per stack frame.
+//
+// Only an application log line opens a block that can absorb fragments. Without
+// that restriction every source that never uses the format — systemd, kernel,
+// CoreDNS — would have entire runs of unrelated entries merged, since none of
+// them starts a new application log line.
+//
+// A fragment must also come from the same process and follow within window. In a
+// captured sample the gap between fragments of one message was 7ms at p99, while
+// unrelated entries from the same process sat minutes apart.
+//
+// Fragments are only ever appended to an entry already in the batch, so the
+// journal entry count — which the cursor arithmetic depends on — is unchanged.
+func recombineEntries(entries []Entry, window time.Duration) []Entry {
+	if len(entries) < 2 {
+		return entries
+	}
+
+	var (
+		out = entries[:0:0]
+		// open indexes the entry fragments are being appended to, or -1 when
+		// the previous entry cannot absorb any.
+		open = -1
+		last time.Time
+	)
+	for _, e := range entries {
+		_, isApp := parseAppMessage(e.Message)
+		if !isApp && open >= 0 && continuesEntry(out[open], e, last, window) {
+			out[open].Message += "\n" + e.Message
+			last = e.Timestamp
+			continue
+		}
+
+		out = append(out, e)
+		if isApp {
+			open, last = len(out)-1, e.Timestamp
+		} else {
+			open = -1
+		}
+	}
+	return out
+}
+
+// continuesEntry reports whether cur is a fragment of the block opened by prev,
+// whose newest fragment arrived at last.
+func continuesEntry(prev, cur Entry, last time.Time, window time.Duration) bool {
+	if prev.Identifier != cur.Identifier || prev.HasPID != cur.HasPID || prev.PID != cur.PID {
+		return false
+	}
+	d := cur.Timestamp.Sub(last)
+	return d >= 0 && d <= window
+}

--- a/otelcolmod/hareceiver/severity.go
+++ b/otelcolmod/hareceiver/severity.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/logparser"
 )
 
 // severityScanTokens is how many leading whitespace-separated tokens of a
@@ -11,17 +13,15 @@ import (
 // prefix their messages with a timestamp before the level.
 const severityScanTokens = 4
 
-var severityLevels = map[string]plog.SeverityNumber{
-	"CRITICAL": plog.SeverityNumberFatal,
-	"FATAL":    plog.SeverityNumberFatal,
-	"ERROR":    plog.SeverityNumberError,
-	"ERR":      plog.SeverityNumberError,
-	"WARNING":  plog.SeverityNumberWarn,
-	"WARN":     plog.SeverityNumberWarn,
-	"NOTICE":   plog.SeverityNumberInfo2,
-	"INFO":     plog.SeverityNumberInfo,
-	"DEBUG":    plog.SeverityNumberDebug,
-	"TRACE":    plog.SeverityNumberTrace,
+// isLevel reports whether token is a level, requiring upper case so that
+// ordinary prose is not mistaken for one. [logparser.DeduceSeverity] itself is
+// case-insensitive and accepts single letters, which is too permissive here.
+func isLevel(token string) (plog.SeverityNumber, bool) {
+	if len(token) < 3 || token != strings.ToUpper(token) {
+		return plog.SeverityNumberUnspecified, false
+	}
+	sev := logparser.DeduceSeverity(token)
+	return sev, sev != plog.SeverityNumberUnspecified
 }
 
 // detectSeverity looks for a level in the leading tokens of msg.
@@ -37,7 +37,7 @@ func detectSeverity(msg string) (plog.SeverityNumber, string, bool) {
 		if token == "" {
 			return plog.SeverityNumberUnspecified, "", false
 		}
-		if sev, ok := severityLevels[token]; ok {
+		if sev, ok := isLevel(token); ok {
 			return sev, token, true
 		}
 	}

--- a/otelcolmod/hareceiver/severity.go
+++ b/otelcolmod/hareceiver/severity.go
@@ -1,0 +1,45 @@
+package hareceiver
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// severityScanTokens is how many leading whitespace-separated tokens of a
+// message are examined for a level. Home Assistant Core and Supervisor both
+// prefix their messages with a timestamp before the level.
+const severityScanTokens = 4
+
+var severityLevels = map[string]plog.SeverityNumber{
+	"CRITICAL": plog.SeverityNumberFatal,
+	"FATAL":    plog.SeverityNumberFatal,
+	"ERROR":    plog.SeverityNumberError,
+	"ERR":      plog.SeverityNumberError,
+	"WARNING":  plog.SeverityNumberWarn,
+	"WARN":     plog.SeverityNumberWarn,
+	"NOTICE":   plog.SeverityNumberInfo2,
+	"INFO":     plog.SeverityNumberInfo,
+	"DEBUG":    plog.SeverityNumberDebug,
+	"TRACE":    plog.SeverityNumberTrace,
+}
+
+// detectSeverity looks for a level in the leading tokens of msg.
+//
+// Home Assistant does not expose the journal PRIORITY field through its API, so
+// severity can only be recovered from the message text. The match is
+// deliberately narrow — an exact, upper-case, whole token — to keep add-on logs
+// that do not follow the convention from being mislabelled.
+func detectSeverity(msg string) (plog.SeverityNumber, string, bool) {
+	for range severityScanTokens {
+		var token string
+		token, msg, _ = strings.Cut(strings.TrimLeft(msg, " \t"), " ")
+		if token == "" {
+			return plog.SeverityNumberUnspecified, "", false
+		}
+		if sev, ok := severityLevels[token]; ok {
+			return sev, token, true
+		}
+	}
+	return plog.SeverityNumberUnspecified, "", false
+}

--- a/otelcolmod/hareceiver/severity_test.go
+++ b/otelcolmod/hareceiver/severity_test.go
@@ -1,0 +1,51 @@
+package hareceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestDetectSeverity(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     string
+		wantSev plog.SeverityNumber
+		wantTxt string
+	}{
+		{
+			name:    "CoreFormat",
+			msg:     "2026-08-09 12:00:00.099 WARNING (MainThread) [homeassistant.core] slow",
+			wantSev: plog.SeverityNumberWarn,
+			wantTxt: "WARNING",
+		},
+		{
+			name:    "SupervisorFormat",
+			msg:     "26-08-09 12:00:00 ERROR (MainThread) [supervisor.jobs] failed",
+			wantSev: plog.SeverityNumberError,
+			wantTxt: "ERROR",
+		},
+		{
+			name:    "LeadingLevel",
+			msg:     "CRITICAL boom",
+			wantSev: plog.SeverityNumberFatal,
+			wantTxt: "CRITICAL",
+		},
+		{name: "TooLate", msg: "a b c d ERROR nope"},
+		{name: "LowerCase", msg: "error: something"},
+		{name: "Substring", msg: "ERRORS happened"},
+		{name: "NoLevel", msg: "just a message"},
+		{name: "Empty", msg: ""},
+		{name: "OnlySpaces", msg: "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sev, text, ok := detectSeverity(tt.msg)
+			require.Equal(t, tt.wantTxt != "", ok)
+			require.Equal(t, tt.wantSev, sev)
+			require.Equal(t, tt.wantTxt, text)
+		})
+	}
+}

--- a/otelcolmod/hareceiver/translator.go
+++ b/otelcolmod/hareceiver/translator.go
@@ -6,6 +6,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+
+	"github.com/oteldb/oteldb/internal/logparser"
 )
 
 // serviceNamespace is set on every resource emitted by this receiver.
@@ -61,9 +63,7 @@ func translateEntries(entries []Entry, src Source, cfg *Config, observed time.Ti
 				attrs.PutStr("ha.thread", app.Thread)
 			}
 			r.SetSeverityText(app.Level)
-			if sev, ok := severityLevels[app.Level]; ok {
-				r.SetSeverityNumber(sev)
-			}
+			r.SetSeverityNumber(logparser.DeduceSeverity(app.Level))
 		case cfg.SeverityFromMessage:
 			if sev, text, ok := detectSeverity(e.Message); ok {
 				r.SetSeverityNumber(sev)

--- a/otelcolmod/hareceiver/translator.go
+++ b/otelcolmod/hareceiver/translator.go
@@ -1,0 +1,93 @@
+package hareceiver
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// serviceNamespace is set on every resource emitted by this receiver.
+const serviceNamespace = "homeassistant"
+
+type resourceKey struct {
+	hostname   string
+	identifier string
+}
+
+// translateEntries converts journal entries of a single source into OTLP logs,
+// grouping records into one ResourceLogs per distinct resource.
+func translateEntries(entries []Entry, src Source, cfg *Config, observed time.Time) plog.Logs {
+	logs := plog.NewLogs()
+	if len(entries) == 0 {
+		return logs
+	}
+
+	scopes := make(map[resourceKey]plog.LogRecordSlice, 1)
+	for _, e := range entries {
+		key := resourceKey{hostname: e.Hostname, identifier: e.Identifier}
+		records, ok := scopes[key]
+		if !ok {
+			rl := logs.ResourceLogs().AppendEmpty()
+			res := rl.Resource().Attributes()
+			res.PutStr(string(semconv.ServiceNamespaceKey), serviceNamespace)
+			res.PutStr(string(semconv.ServiceNameKey), serviceName(key, src))
+			if key.hostname != "" {
+				res.PutStr(string(semconv.HostNameKey), key.hostname)
+			}
+			records = rl.ScopeLogs().AppendEmpty().LogRecords()
+			scopes[key] = records
+		}
+
+		r := records.AppendEmpty()
+		r.SetTimestamp(pcommon.NewTimestampFromTime(e.Timestamp))
+		r.SetObservedTimestamp(pcommon.NewTimestampFromTime(observed))
+		attrs := r.Attributes()
+
+		body := e.Message
+		app, isApp := appMessage{}, false
+		if cfg.ParseMessage {
+			app, isApp = parseAppMessage(e.Message)
+		}
+		switch {
+		case isApp:
+			// Core and Supervisor embed their own structure in MESSAGE; lifting
+			// it out gives an exact level and a queryable logger name, and
+			// leaves the body as just the message.
+			body = app.Message
+			attrs.PutStr("ha.logger", app.Logger)
+			if app.Thread != "" {
+				attrs.PutStr("ha.thread", app.Thread)
+			}
+			r.SetSeverityText(app.Level)
+			if sev, ok := severityLevels[app.Level]; ok {
+				r.SetSeverityNumber(sev)
+			}
+		case cfg.SeverityFromMessage:
+			if sev, text, ok := detectSeverity(e.Message); ok {
+				r.SetSeverityNumber(sev)
+				r.SetSeverityText(text)
+			}
+		}
+		r.Body().SetStr(body)
+
+		attrs.PutStr("ha.source", string(src.Kind))
+		if src.Addon != "" {
+			attrs.PutStr("ha.addon", src.Addon)
+		}
+		if e.HasPID {
+			attrs.PutInt(string(semconv.ProcessPIDKey), e.PID)
+		}
+	}
+	return logs
+}
+
+// serviceName falls back to the source name when the entry carries no syslog
+// identifier, so that records are never emitted without a service.
+func serviceName(key resourceKey, src Source) string {
+	if key.identifier != "" {
+		return key.identifier
+	}
+	return src.Name()
+}

--- a/otelcolmod/hareceiver/translator_test.go
+++ b/otelcolmod/hareceiver/translator_test.go
@@ -1,0 +1,179 @@
+package hareceiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestTranslateEntriesEmpty(t *testing.T) {
+	logs := translateEntries(nil, Source{Kind: SourceKindHost}, &Config{}, observedAt)
+	require.Equal(t, 0, logs.LogRecordCount())
+	require.Equal(t, 0, logs.ResourceLogs().Len())
+}
+
+func TestTranslateEntriesResource(t *testing.T) {
+	entries := ParseEntries(
+		"2026-08-09 12:00:00.000 ha kernel[1]: a\n" +
+			"2026-08-09 12:00:01.000 ha systemd[2]: b\n" +
+			"2026-08-09 12:00:02.000 ha kernel[3]: c\n",
+	)
+	logs := translateEntries(entries, Source{Kind: SourceKindHost}, &Config{}, observedAt)
+
+	require.Equal(t, 2, logs.ResourceLogs().Len(), "one ResourceLogs per identifier")
+	require.Equal(t, 3, logs.LogRecordCount())
+
+	rl := logs.ResourceLogs().At(0)
+	attrs := rl.Resource().Attributes()
+	requireStr(t, attrs, "service.namespace", "homeassistant")
+	requireStr(t, attrs, "service.name", "kernel")
+	requireStr(t, attrs, "host.name", "ha")
+	require.Equal(t, 2, rl.ScopeLogs().At(0).LogRecords().Len())
+}
+
+func TestTranslateEntriesRecord(t *testing.T) {
+	entries := ParseEntries("2026-08-09 12:00:00.500 ha kernel[42]: hello\n")
+	logs := translateEntries(entries, Source{Kind: SourceKindHost}, &Config{}, observedAt)
+
+	r := onlyRecord(t, logs)
+	require.Equal(t, "hello", r.Body().Str())
+	require.Equal(t,
+		pcommon.NewTimestampFromTime(time.Date(2026, 8, 9, 12, 0, 0, 5e8, time.UTC)),
+		r.Timestamp(),
+	)
+	require.Equal(t, pcommon.NewTimestampFromTime(observedAt), r.ObservedTimestamp())
+	require.Equal(t, plog.SeverityNumberUnspecified, r.SeverityNumber())
+
+	requireStr(t, r.Attributes(), "ha.source", "host")
+	pid, ok := r.Attributes().Get("process.pid")
+	require.True(t, ok)
+	require.Equal(t, int64(42), pid.Int())
+	_, ok = r.Attributes().Get("ha.addon")
+	require.False(t, ok)
+}
+
+func TestTranslateEntriesAddon(t *testing.T) {
+	entries := ParseEntries("2026-08-09 12:00:00.000 ha addon_ssh: up\n")
+	src := Source{Kind: SourceKindAddon, Addon: "core_ssh"}
+	logs := translateEntries(entries, src, &Config{}, observedAt)
+
+	r := onlyRecord(t, logs)
+	requireStr(t, r.Attributes(), "ha.source", "addon")
+	requireStr(t, r.Attributes(), "ha.addon", "core_ssh")
+	_, ok := r.Attributes().Get("process.pid")
+	require.False(t, ok, "no PID attribute when the entry has none")
+}
+
+func TestTranslateEntriesIdentifierFallback(t *testing.T) {
+	entries := ParseEntries("2026-08-09 12:00:00.000 ha _UNKNOWN_: orphan\n")
+	src := Source{Kind: SourceKindAddon, Addon: "core_ssh"}
+	logs := translateEntries(entries, src, &Config{}, observedAt)
+
+	attrs := logs.ResourceLogs().At(0).Resource().Attributes()
+	requireStr(t, attrs, "service.name", "addon/core_ssh")
+}
+
+func TestTranslateEntriesNoHostname(t *testing.T) {
+	entries := ParseEntries("2026-08-09 12:00:00.000  systemd[1]: up\n")
+	logs := translateEntries(entries, Source{Kind: SourceKindHost}, &Config{}, observedAt)
+
+	_, ok := logs.ResourceLogs().At(0).Resource().Attributes().Get("host.name")
+	require.False(t, ok)
+}
+
+func TestTranslateEntriesSeverity(t *testing.T) {
+	body := "2026-08-09 12:00:00.000 ha homeassistant[7]: " +
+		"2026-08-09 12:00:00.000 WARNING (MainThread) [x] slow\n"
+	entries := ParseEntries(body)
+
+	t.Run("Disabled", func(t *testing.T) {
+		logs := translateEntries(entries, Source{Kind: SourceKindCore}, &Config{}, observedAt)
+		r := onlyRecord(t, logs)
+		require.Equal(t, plog.SeverityNumberUnspecified, r.SeverityNumber())
+		require.Empty(t, r.SeverityText())
+	})
+	t.Run("Enabled", func(t *testing.T) {
+		cfg := &Config{SeverityFromMessage: true}
+		logs := translateEntries(entries, Source{Kind: SourceKindCore}, cfg, observedAt)
+		r := onlyRecord(t, logs)
+		require.Equal(t, plog.SeverityNumberWarn, r.SeverityNumber())
+		require.Equal(t, "WARNING", r.SeverityText())
+	})
+}
+
+func TestTranslateEntriesParseMessage(t *testing.T) {
+	body := "2026-08-09 12:00:00.000 ha hassio_supervisor[655]: " +
+		"2026-08-09 15:26:04.893 INFO (SyncWorker_2) [supervisor.backups.backup] Backing up folder ssl\n"
+	entries := ParseEntries(body)
+	cfg := &Config{ParseMessage: true}
+	logs := translateEntries(entries, Source{Kind: SourceKindSupervisor}, cfg, observedAt)
+
+	r := onlyRecord(t, logs)
+	require.Equal(t, "Backing up folder ssl", r.Body().Str(),
+		"the redundant timestamp, level, thread and logger must leave the body")
+	require.Equal(t, plog.SeverityNumberInfo, r.SeverityNumber())
+	require.Equal(t, "INFO", r.SeverityText())
+	requireStr(t, r.Attributes(), "ha.logger", "supervisor.backups.backup")
+	requireStr(t, r.Attributes(), "ha.thread", "SyncWorker_2")
+}
+
+func TestTranslateEntriesParseMessageUnknownLevel(t *testing.T) {
+	body := "2026-08-09 12:00:00.000 ha homeassistant[7]: " +
+		"2026-08-09 15:26:04.893 VERBOSE (MainThread) [a.b] hi\n"
+	cfg := &Config{ParseMessage: true}
+	logs := translateEntries(ParseEntries(body), Source{Kind: SourceKindCore}, cfg, observedAt)
+
+	r := onlyRecord(t, logs)
+	require.Equal(t, "VERBOSE", r.SeverityText(), "the level is reported even when unmapped")
+	require.Equal(t, plog.SeverityNumberUnspecified, r.SeverityNumber())
+}
+
+func TestTranslateEntriesParseMessageFallsBack(t *testing.T) {
+	// Host logs are not in the application format; the body must survive intact
+	// and the heuristic still applies when enabled.
+	body := "2026-08-09 12:00:00.000 ha systemd[1]: Started libcontainer container 617dc0c8.\n"
+	cfg := &Config{ParseMessage: true, SeverityFromMessage: true}
+	logs := translateEntries(ParseEntries(body), Source{Kind: SourceKindHost}, cfg, observedAt)
+
+	r := onlyRecord(t, logs)
+	require.Equal(t, "Started libcontainer container 617dc0c8.", r.Body().Str())
+	require.Equal(t, plog.SeverityNumberUnspecified, r.SeverityNumber())
+	_, ok := r.Attributes().Get("ha.logger")
+	require.False(t, ok)
+}
+
+func TestTranslateEntriesParseMessageDisabled(t *testing.T) {
+	raw := "2026-08-09 15:26:04.893 INFO (SyncWorker_2) [supervisor.backups.backup] Backing up folder ssl"
+	body := "2026-08-09 12:00:00.000 ha hassio_supervisor[655]: " + raw + "\n"
+	logs := translateEntries(ParseEntries(body), Source{Kind: SourceKindSupervisor}, &Config{}, observedAt)
+
+	r := onlyRecord(t, logs)
+	require.Equal(t, raw, r.Body().Str())
+	_, ok := r.Attributes().Get("ha.logger")
+	require.False(t, ok)
+}
+
+func TestTranslateEntriesMultiline(t *testing.T) {
+	body := "2026-08-09 12:00:00.000 ha homeassistant[7]: Traceback:\n" +
+		"    raise Error\n"
+	logs := translateEntries(ParseEntries(body), Source{Kind: SourceKindCore}, &Config{}, observedAt)
+
+	require.Equal(t, 1, logs.LogRecordCount())
+	require.Equal(t, "Traceback:\n    raise Error", onlyRecord(t, logs).Body().Str())
+}
+
+func onlyRecord(t *testing.T, logs plog.Logs) plog.LogRecord {
+	t.Helper()
+	require.Equal(t, 1, logs.LogRecordCount())
+	return logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+}
+
+func requireStr(t *testing.T, m pcommon.Map, key, want string) {
+	t.Helper()
+	v, ok := m.Get(key)
+	require.Truef(t, ok, "attribute %q is missing", key)
+	require.Equal(t, want, v.Str())
+}


### PR DESCRIPTION
Adds `otelcolmod/hareceiver`, a receiver that pulls journal logs from a Home Assistant
instance over its HTTP API and emits OTLP logs, resumable across restarts via journal
cursors. Registered in odbagent. Nothing is installed on the Home Assistant host.

Verified end-to-end against a live HAOS instance, not just unit tests.

## Transport

Every design assumption was checked against Core and Supervisor source and then against a
live instance. Two of them were wrong, and both shape the implementation:

**No structured output.** Supervisor asks `systemd-journal-gatewayd` for
`application/vnd.fdo.journal`, parses it, and re-renders each entry to **text**, keeping only
the fields its formatter uses. Requesting JSON does not help: Core's proxy never forwards
`Accept`, so Supervisor never sees it. There is therefore **no `PRIORITY`**, and no faithful
syslog severity mapping — severity is recovered from the message instead.

**Only the first cursor is returned.** The response exposes `X-First-Cursor` and nothing
else, so the read position cannot be a single cursor. It is an anchor plus a consumed count,
sent as `Range: entries=<anchor>:<skip>:<batch>`; each response re-anchors on its own first
entry, so `skip` stays bounded by `batch_size`. Confirmed live that `skip=0` re-reads the
window, `skip=1` shifts by one, and `skip=n` starts past it with no overlap and no gap.

Cold start uses `entries=:-1:2`. The `2` matters — `entries=:-1:N` starts one entry *before*
the last, so `:-1:1` anchors on the second-to-last and re-emits the last one as if it were
new. Supervisor clamps its own `lines` parameter to 2 for the same reason.

## Multi-line events

journald splits a multi-line message at every newline, so a Python traceback arrives as one
journal entry per stack frame, each with a full envelope. Emitted verbatim that is one
severity-less record per frame. Fragments are rejoined onto the entry that opened the block.

Only an application log line opens a block. Without that restriction, sources that never use
the format — systemd, kernel, CoreDNS — would have entire runs of unrelated entries merged.
Measured over 11.5k captured entries the fragment gap is 58ms at p99, and every window from
100ms to 1s produces byte-identical output. Recombination never changes the journal entry
count the cursor depends on.

## Verification

- 137 tests under `-race`; parser covered by `_testdata` + `_golden` via `go-faster/sdk/gold`,
  fuzzers seeded from the corpus. The fuzzer found a real bug (an entry parsing to a zero
  timestamp); the test suite found another (recombination merging unrelated systemd runs).
- Against a live instance: cold start emits nothing, and a restart across a downtime gap
  delivers messages written while stopped exactly once, without re-delivering earlier ones.

## Known limitations

- Roughly half of records still carry no severity: CoreDNS `[INFO]`, NetworkManager `<info>`
  and containerd/dockerd logfmt are passed through unparsed.
- `odblogparser` is a stanza operator, and this receiver is not stanza-based; odbagent does
  not register `logstransformprocessor`, so it cannot be applied to this receiver's output.
- Add-on sources have unit coverage only — none were installed on the test instance.
- A block straddling a `batch_size` boundary yields two records.
- `/api/hassio/...` is an internal, admin-only, undocumented Core path with no compatibility
  promise. Documented in the package README.

## Not included

The WebSocket API (`system_log/list`) returns Core logs fully structured, with the whole
traceback in one field. It is not used because as a transport it is worse: WARNING and above
only, Core alone, dedupes repeated occurrences, no cursor, and live push requires editing
`configuration.yaml` on the instance. Recorded in the README as a possible enrichment stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
