### PR TITLE
perf(hareceiver): do not drain response body

### DIFF
--- a/otelcolmod/hareceiver/poller.go
+++ b/otelcolmod/hareceiver/poller.go
@@ -178,10 +178,10 @@ func (p *poller) fetch(ctx context.Context, rangeHeader string) (body, firstCurs
 	if err != nil {
 		return "", "", errors.Wrap(err, "do request")
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
+	// Do not drain the body to reuse the connection: the log endpoint returns
+	// arbitrarily large responses, so draining costs as much as reading them.
+	// Dropping the connection is cheaper.
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))


### PR DESCRIPTION
`fetch` drained `resp.Body` into `io.Discard` before closing, to keep the connection reusable.

On the success path `io.ReadAll` has already consumed the body, so the drain is a no-op. It only ever fires on the paths where we deliberately stop early — non-2xx (capped at `maxErrorBody`) or a mid-read error — and there the remainder is unbounded. So the drain bought nothing on success and paid full body cost (network, TCP/TLS/HTTP CPU, goroutine held until EOF) on failure.

Now it just closes and lets the transport drop the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)