### PR TITLE
feat(ch2storagebackend): schedulable, resumable, faster backfill

### DIFF
--- a/cmd/ch2storagebackend/main.go
+++ b/cmd/ch2storagebackend/main.go
@@ -1,6 +1,6 @@
 // Command ch2storagebackend migrates data from chstorage's ClickHouse tables into the
-// embedded storagebackend engine, by scanning ClickHouse directly and re-ingesting the
-// decoded records as OTLP pdata. Logs, traces, and metrics are supported.
+// embedded storagebackend engine, by scanning ClickHouse directly and re-ingesting the decoded
+// rows into the engine's native types. Logs, traces, and metrics are supported.
 //
 // A migration runs one UTC day at a time. Use -estimate first to size the window, -from/-to to
 // select it, and -checkpoint to make the run resumable.
@@ -66,7 +66,7 @@ func run(ctx context.Context) error {
 		// flushes (the head has no blocking backpressure; MaxInFlightBytes would *shed* records, which a
 		// migration must not do). With a throttle the head stays small and the merge (bounded by
 		// max-part-bytes) is the only sizable transient.
-		throttle = flag.Duration("throttle", 0, "Sleep this long after every ConsumeLogs/ConsumeTraces batch, to keep ingestion from outpacing the storage engine's flush loop")
+		throttle = flag.Duration("throttle", 0, "Sleep this long after every ingested batch, to keep ingestion from outpacing the storage engine's flush loop")
 	)
 	flag.Parse()
 

--- a/cmd/ch2storagebackend/main.go
+++ b/cmd/ch2storagebackend/main.go
@@ -1,6 +1,9 @@
 // Command ch2storagebackend migrates data from chstorage's ClickHouse tables into the
 // embedded storagebackend engine, by scanning ClickHouse directly and re-ingesting the
 // decoded records as OTLP pdata. Logs, traces, and metrics are supported.
+//
+// A migration runs one UTC day at a time. Use -estimate first to size the window, -from/-to to
+// select it, and -checkpoint to make the run resumable.
 package main
 
 import (
@@ -32,8 +35,23 @@ func run(ctx context.Context) error {
 		dsn        = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL")
 		storageDir = flag.String("storage-dir", "", "Directory for the embedded storage engine's file backend (empty uses an ephemeral in-memory backend)")
 		batchSize  = flag.Int("batch", 5_000, "Number of records/spans to convert and ingest per batch")
-		since      = flag.Duration("since", 0, "If positive, only migrate the last since of data (relative to the most recent record), instead of the full table")
 		signals    = flag.String("signals", "logs,traces,metrics", "Comma-separated list of signals to migrate (logs, traces, metrics)")
+
+		// Window selection. -from/-to are absolute and are what make a large migration schedulable:
+		// the job can be split into ranges that are run separately, and re-run without redoing the
+		// rest. -since remains as the "last N of data" shorthand.
+		from  = flag.String("from", "", "Migrate data at or after this time (RFC3339 or YYYY-MM-DD, UTC); empty starts at the source's oldest")
+		to    = flag.String("to", "", "Migrate data before this time (RFC3339 or YYYY-MM-DD, UTC); empty ends at the source's newest")
+		since = flag.Duration("since", 0, "If positive and -from is unset, only migrate the last since of data, relative to the window's upper bound")
+
+		// Pre-flight sizing: row counts per day and the source's compressed/uncompressed footprint,
+		// without ingesting anything.
+		estimate = flag.Bool("estimate", false, "Print a per-day sizing report for the selected window and exit without migrating")
+
+		// Resumability. Days are journalled only after the target has been synced, so an interrupted
+		// run resumes at a day boundary rather than restarting.
+		checkpointPath = flag.String("checkpoint", "", "Path to a resumable migration journal; completed UTC days are skipped on a re-run")
+
 		// A bulk migration writes orders of magnitude faster than steady production ingestion, so
 		// the engine's default flush cadence (tuned for the latter) leaves the head/WAL growing
 		// unbounded in RAM for the lifetime of this process. Flush aggressively instead.
@@ -52,6 +70,11 @@ func run(ctx context.Context) error {
 	)
 	flag.Parse()
 
+	window, err := parseWindow(*from, *to, *since)
+	if err != nil {
+		return err
+	}
+
 	lg, err := zap.NewDevelopment()
 	if err != nil {
 		return errors.Wrap(err, "create logger")
@@ -66,6 +89,25 @@ func run(ctx context.Context) error {
 		return errors.Wrap(err, "dial clickhouse")
 	}
 
+	var checkpoint *ch2storagebackend.Checkpoint
+	if *checkpointPath != "" {
+		if checkpoint, err = ch2storagebackend.OpenCheckpoint(*checkpointPath); err != nil {
+			return errors.Wrap(err, "open checkpoint")
+		}
+		defer func() {
+			_ = checkpoint.Close()
+		}()
+	}
+
+	// An estimate reads only ClickHouse metadata, so it must not open (and thereby lock or dirty)
+	// the target storage directory.
+	if *estimate {
+		m := ch2storagebackend.NewMigrator(client, chstorage.DefaultTables(), nil, zap.NewNop(),
+			ch2storagebackend.WithCheckpoint(checkpoint),
+		)
+		return printEstimates(ctx, m, *signals, window)
+	}
+
 	store, err := openStore(ctx, *storageDir, *flushInterval, *maxPartBytes, lg)
 	if err != nil {
 		return errors.Wrap(err, "open storage engine")
@@ -75,24 +117,38 @@ func run(ctx context.Context) error {
 	}()
 	back := storagebackend.New(store)
 
-	m := ch2storagebackend.NewMigrator(client, chstorage.DefaultTables(), back, lg, ch2storagebackend.WithThrottle(*throttle))
+	m := ch2storagebackend.NewMigrator(client, chstorage.DefaultTables(), back, lg,
+		ch2storagebackend.WithThrottle(*throttle),
+		ch2storagebackend.WithCheckpoint(checkpoint),
+		ch2storagebackend.WithSync(syncStore(store)),
+	)
 
 	for sig := range strings.SplitSeq(*signals, ",") {
 		switch sig {
 		case "logs":
-			stats, err := m.MigrateLogs(ctx, *since, *batchSize)
+			stats, err := m.MigrateLogs(ctx, window, *batchSize)
 			if err != nil {
 				return errors.Wrap(err, "migrate logs")
 			}
-			lg.Info("Migrated logs", zap.Int("records", stats.Records), zap.Int("batches", stats.Batches))
+			lg.Info("Migrated logs",
+				zap.Int("records", stats.Records),
+				zap.Int("batches", stats.Batches),
+				zap.Int("days", stats.DaysDone),
+				zap.Int("days_skipped", stats.DaysSkipped),
+			)
 		case "traces":
-			stats, err := m.MigrateTraces(ctx, *since, *batchSize)
+			stats, err := m.MigrateTraces(ctx, window, *batchSize)
 			if err != nil {
 				return errors.Wrap(err, "migrate traces")
 			}
-			lg.Info("Migrated traces", zap.Int("spans", stats.Spans), zap.Int("batches", stats.Batches))
+			lg.Info("Migrated traces",
+				zap.Int("spans", stats.Spans),
+				zap.Int("batches", stats.Batches),
+				zap.Int("days", stats.DaysDone),
+				zap.Int("days_skipped", stats.DaysSkipped),
+			)
 		case "metrics":
-			stats, err := m.MigrateMetrics(ctx, *since, *batchSize)
+			stats, err := m.MigrateMetrics(ctx, window, *batchSize)
 			if err != nil {
 				return errors.Wrap(err, "migrate metrics")
 			}
@@ -100,6 +156,8 @@ func run(ctx context.Context) error {
 				zap.Int("points", stats.Points),
 				zap.Int("exp_histograms", stats.ExpHistograms),
 				zap.Int("batches", stats.Batches),
+				zap.Int("days", stats.DaysDone),
+				zap.Int("days_skipped", stats.DaysSkipped),
 			)
 		default:
 			return errors.Errorf("unknown signal %q", sig)
@@ -108,6 +166,77 @@ func run(ctx context.Context) error {
 
 	lg.Info("Done")
 	return nil
+}
+
+// parseWindow builds the scan window from the time flags. Bare dates are accepted (and are the
+// common case for a day-granular backfill) alongside full RFC3339 timestamps.
+func parseWindow(from, to string, since time.Duration) (chstorage.Window, error) {
+	parse := func(name, v string) (time.Time, error) {
+		if v == "" {
+			return time.Time{}, nil
+		}
+		for _, layout := range []string{time.RFC3339, time.DateTime, time.DateOnly} {
+			if t, err := time.ParseInLocation(layout, v, time.UTC); err == nil {
+				return t.UTC(), nil
+			}
+		}
+		return time.Time{}, errors.Errorf("parse -%s %q: want RFC3339 or YYYY-MM-DD", name, v)
+	}
+
+	w := chstorage.Window{Since: since}
+
+	var err error
+	if w.From, err = parse("from", from); err != nil {
+		return w, err
+	}
+	if w.To, err = parse("to", to); err != nil {
+		return w, err
+	}
+	if !w.From.IsZero() && !w.To.IsZero() && !w.From.Before(w.To) {
+		return w, errors.Errorf("-from %s must be before -to %s", w.From, w.To)
+	}
+	return w, nil
+}
+
+func printEstimates(ctx context.Context, m *ch2storagebackend.Migrator, signals string, w chstorage.Window) error {
+	for sig := range strings.SplitSeq(signals, ",") {
+		var (
+			est ch2storagebackend.Estimate
+			err error
+		)
+		switch sig {
+		case "logs":
+			est, err = m.EstimateLogs(ctx, w)
+		case "traces":
+			est, err = m.EstimateTraces(ctx, w)
+		case "metrics":
+			est, err = m.EstimateMetrics(ctx, w)
+		default:
+			return errors.Errorf("unknown signal %q", sig)
+		}
+		if err != nil {
+			return errors.Wrapf(err, "estimate %s", sig)
+		}
+		_, _ = fmt.Fprint(os.Stdout, est)
+	}
+	return nil
+}
+
+// syncStore returns the per-day durability barrier: flush every tenant/signal head that has
+// buffered data to an immutable part. Running it before a day is checkpointed is what makes the
+// checkpoint safe to resume from — and it caps the head at one day's ingest rather than letting it
+// grow for the whole migration.
+func syncStore(store *storage.Storage) func(context.Context) error {
+	return func(ctx context.Context) error {
+		for _, t := range store.Inspect().Tenants {
+			for _, sig := range t.Signals {
+				if err := store.Admin().Flush(ctx, t.Tenant, sig.Signal); err != nil {
+					return errors.Wrapf(err, "flush %s/%s", t.Tenant, sig.Signal)
+				}
+			}
+		}
+		return nil
+	}
 }
 
 func openStore(ctx context.Context, dir string, flushInterval time.Duration, maxPartBytes int64, lg *zap.Logger) (*storage.Storage, error) {

--- a/integration/ch2storagebackende2e/migrate_metrics_test.go
+++ b/integration/ch2storagebackende2e/migrate_metrics_test.go
@@ -106,7 +106,7 @@ func TestMigrateMetrics(t *testing.T) {
 	back := storagebackend.New(store)
 
 	m := ch2storagebackend.NewMigrator(client, tables, back, integration.Logger(t))
-	stats, err := m.MigrateMetrics(ctx, 0, 1000)
+	stats, err := m.MigrateMetrics(ctx, chstorage.Window{}, 1000)
 	require.NoError(t, err)
 	// Number points: gauge(1) + hist _count/_sum/_bucket(le=1,5,10,+Inf) = 1 + 1 + 1 + 4 = 7.
 	require.Equal(t, 7, stats.Points)

--- a/integration/ch2storagebackende2e/migrate_test.go
+++ b/integration/ch2storagebackende2e/migrate_test.go
@@ -105,7 +105,7 @@ func TestMigrateLogs(t *testing.T) {
 	m := ch2storagebackend.NewMigrator(client, tables, back, integration.Logger(t))
 	// Use a batch size smaller than the record count so the migration exercises more than
 	// one ConsumeLogs call.
-	stats, err := m.MigrateLogs(ctx, 0, 2)
+	stats, err := m.MigrateLogs(ctx, chstorage.Window{}, 2)
 	require.NoError(t, err)
 	require.Equal(t, 4, stats.Records)
 	require.Equal(t, 2, stats.Batches)
@@ -237,7 +237,7 @@ func TestMigrateTraces(t *testing.T) {
 	m := ch2storagebackend.NewMigrator(client, tables, back, integration.Logger(t))
 	// Use a batch size smaller than the span count so the migration exercises more than one
 	// ConsumeTraces call.
-	stats, err := m.MigrateTraces(ctx, 0, 1)
+	stats, err := m.MigrateTraces(ctx, chstorage.Window{}, 1)
 	require.NoError(t, err)
 	require.Equal(t, 2, stats.Spans)
 	require.Equal(t, 2, stats.Batches)

--- a/internal/ch2storagebackend/checkpoint.go
+++ b/internal/ch2storagebackend/checkpoint.go
@@ -1,0 +1,150 @@
+package ch2storagebackend
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/go-faster/errors"
+)
+
+// Checkpoint records which (signal, UTC day) slices of a migration have been fully ingested *and*
+// made durable in the target engine, so an interrupted run resumes instead of restarting.
+//
+// It is a line-delimited JSON journal, appended and fsynced one line per completed day. Append-only
+// is what makes it crash-safe without a write-ahead protocol of its own: a torn trailing line is
+// simply a day that was not confirmed, and re-migrating a day is harmless — the target engine is
+// keyed by series identity and timestamp, so a replayed day overwrites rather than duplicates.
+type Checkpoint struct {
+	mu   sync.Mutex
+	f    *os.File
+	done map[checkpointKey]struct{}
+}
+
+type checkpointKey struct {
+	signal string
+	day    int64
+}
+
+// checkpointEntry is one journal line.
+type checkpointEntry struct {
+	Signal string    `json:"signal"`
+	Day    time.Time `json:"day"`
+	Rows   int       `json:"rows"`
+	At     time.Time `json:"at"`
+}
+
+// OpenCheckpoint opens (creating if absent) the journal at path and replays it into memory.
+func OpenCheckpoint(path string) (*Checkpoint, error) {
+	done, err := readCheckpoint(path)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644) //nolint:gosec // operator-supplied journal path
+	if err != nil {
+		return nil, errors.Wrap(err, "open checkpoint")
+	}
+	return &Checkpoint{f: f, done: done}, nil
+}
+
+// readCheckpoint replays the journal. A malformed trailing line is treated as an interrupted
+// append and ignored; a malformed line anywhere else is a real corruption and is reported.
+func readCheckpoint(path string) (map[checkpointKey]struct{}, error) {
+	done := map[checkpointKey]struct{}{}
+
+	f, err := os.Open(path) //nolint:gosec // operator-supplied journal path
+	if err != nil {
+		if os.IsNotExist(err) {
+			return done, nil
+		}
+		return nil, errors.Wrap(err, "open checkpoint")
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	var lines [][]byte
+	sc := bufio.NewScanner(f)
+	sc.Buffer(nil, 1<<20)
+	for sc.Scan() {
+		if line := sc.Bytes(); len(line) > 0 {
+			lines = append(lines, append([]byte(nil), line...))
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, errors.Wrap(err, "read checkpoint")
+	}
+
+	for i, line := range lines {
+		var e checkpointEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			// Only the final line can be a torn append. Anywhere else it is real corruption, and
+			// silently skipping it would resume the migration from a wrong position.
+			if i == len(lines)-1 {
+				break
+			}
+			return nil, errors.Wrapf(err, "parse checkpoint %s line %d", path, i+1)
+		}
+		done[checkpointKey{signal: e.Signal, day: e.Day.UTC().Unix()}] = struct{}{}
+	}
+	return done, nil
+}
+
+// Done reports whether the (signal, day) slice has already been migrated.
+func (c *Checkpoint) Done(signal string, day time.Time) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	_, ok := c.done[checkpointKey{signal: signal, day: day.UTC().Unix()}]
+	return ok
+}
+
+// Mark durably records the (signal, day) slice as migrated. The caller must have already made the
+// slice's data durable in the target engine — marking first would turn a crash into silent data
+// loss on resume.
+func (c *Checkpoint) Mark(signal string, day time.Time, rows int) error {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	line, err := json.Marshal(checkpointEntry{
+		Signal: signal,
+		Day:    day.UTC(),
+		Rows:   rows,
+		At:     time.Now().UTC(),
+	})
+	if err != nil {
+		return errors.Wrap(err, "encode checkpoint entry")
+	}
+	if _, err := c.f.Write(append(line, '\n')); err != nil {
+		return errors.Wrap(err, "append checkpoint")
+	}
+	if err := c.f.Sync(); err != nil {
+		return errors.Wrap(err, "sync checkpoint")
+	}
+
+	c.done[checkpointKey{signal: signal, day: day.UTC().Unix()}] = struct{}{}
+	return nil
+}
+
+// Close releases the journal file.
+func (c *Checkpoint) Close() error {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := c.f.Close(); err != nil {
+		return errors.Wrap(err, "close checkpoint")
+	}
+	return nil
+}

--- a/internal/ch2storagebackend/checkpoint_test.go
+++ b/internal/ch2storagebackend/checkpoint_test.go
@@ -1,0 +1,118 @@
+package ch2storagebackend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func day(s string) time.Time {
+	t, err := time.ParseInLocation(time.DateOnly, s, time.UTC)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func tempCheckpoint(t *testing.T) (c *Checkpoint, path string) {
+	t.Helper()
+
+	path = filepath.Join(t.TempDir(), "checkpoint.jsonl")
+	c, err := OpenCheckpoint(path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = c.Close()
+	})
+	return c, path
+}
+
+func TestCheckpointMarkAndDone(t *testing.T) {
+	c, _ := tempCheckpoint(t)
+
+	assert.False(t, c.Done(SignalMetrics, day("2026-08-05")))
+	require.NoError(t, c.Mark(SignalMetrics, day("2026-08-05"), 2_740_237_809))
+
+	assert.True(t, c.Done(SignalMetrics, day("2026-08-05")))
+	assert.False(t, c.Done(SignalMetrics, day("2026-08-06")), "a different day")
+	assert.False(t, c.Done(SignalLogs, day("2026-08-05")), "a different signal, same day")
+}
+
+func TestCheckpointResumes(t *testing.T) {
+	c, path := tempCheckpoint(t)
+	require.NoError(t, c.Mark(SignalMetrics, day("2026-08-05"), 1))
+	require.NoError(t, c.Mark(SignalLogs, day("2026-08-06"), 2))
+	require.NoError(t, c.Close())
+
+	reopened, err := OpenCheckpoint(path)
+	require.NoError(t, err)
+	defer func() {
+		_ = reopened.Close()
+	}()
+
+	assert.True(t, reopened.Done(SignalMetrics, day("2026-08-05")))
+	assert.True(t, reopened.Done(SignalLogs, day("2026-08-06")))
+	assert.False(t, reopened.Done(SignalLogs, day("2026-08-05")))
+
+	// Re-marking an already-done day is idempotent from the reader's side.
+	require.NoError(t, reopened.Mark(SignalMetrics, day("2026-08-05"), 1))
+	assert.True(t, reopened.Done(SignalMetrics, day("2026-08-05")))
+}
+
+func TestCheckpointNormalizesDayToUTC(t *testing.T) {
+	c, _ := tempCheckpoint(t)
+
+	// Same instant, different location: the journal keys on the UTC day, so a caller passing a
+	// zoned time must not produce a second, unmatched entry.
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
+
+	require.NoError(t, c.Mark(SignalTraces, day("2026-08-05"), 1))
+	assert.True(t, c.Done(SignalTraces, day("2026-08-05").In(tokyo)))
+}
+
+func TestCheckpointTornTrailingLine(t *testing.T) {
+	c, path := tempCheckpoint(t)
+	require.NoError(t, c.Mark(SignalMetrics, day("2026-08-05"), 1))
+	require.NoError(t, c.Mark(SignalMetrics, day("2026-08-06"), 2))
+	require.NoError(t, c.Close())
+
+	// Simulate a crash mid-append: truncate the last line to a partial record.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, raw[:len(raw)-12], 0o644))
+
+	reopened, err := OpenCheckpoint(path)
+	require.NoError(t, err, "a torn trailing line is an interrupted append, not a corruption")
+	defer func() {
+		_ = reopened.Close()
+	}()
+
+	assert.True(t, reopened.Done(SignalMetrics, day("2026-08-05")), "the complete line survives")
+	assert.False(t, reopened.Done(SignalMetrics, day("2026-08-06")), "the torn day is re-migrated")
+}
+
+func TestCheckpointCorruptInteriorLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "checkpoint.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{not json}\n{\"signal\":\"logs\"}\n"), 0o644))
+
+	_, err := OpenCheckpoint(path)
+	require.Error(t, err, "a malformed line that is not the last one is a real corruption")
+}
+
+func TestCheckpointMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "checkpoint.jsonl")
+	_, err := OpenCheckpoint(path)
+	require.Error(t, err, "a missing parent directory is reported, not silently ignored")
+}
+
+func TestNilCheckpointIsInert(t *testing.T) {
+	var c *Checkpoint
+
+	assert.False(t, c.Done(SignalMetrics, day("2026-08-05")))
+	assert.NoError(t, c.Mark(SignalMetrics, day("2026-08-05"), 1))
+	assert.NoError(t, c.Close())
+}

--- a/internal/ch2storagebackend/convert.go
+++ b/internal/ch2storagebackend/convert.go
@@ -1,0 +1,315 @@
+package ch2storagebackend
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/metricstorage"
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// attrConv projects pcommon-backed attribute maps into the engine's [signal.Attributes],
+// memoizing by the map's content hash.
+//
+// chstorage hands out the *same* resource, scope, and series attribute maps for every row of a
+// series, so without memoization the projection cost scales with rows rather than with distinct
+// attribute sets. The cache is scoped to one migration and bounded by the source's distinct
+// resource/scope/series cardinality.
+type attrConv struct {
+	cache map[otelstorage.Hash]signal.Attributes
+}
+
+func newAttrConv() *attrConv {
+	return &attrConv{cache: map[otelstorage.Hash]signal.Attributes{}}
+}
+
+// convert projects a, reusing a previously converted result for an identical attribute set. Use it
+// for resource, scope, and series attributes — the sets shared across many rows. Per-row attributes
+// go through [convertAttrs], since caching a set seen once costs more than it saves.
+func (c *attrConv) convert(a otelstorage.Attrs) signal.Attributes {
+	if a.Len() == 0 {
+		return nil
+	}
+
+	key := a.Hash()
+	if attrs, ok := c.cache[key]; ok {
+		return attrs
+	}
+
+	attrs := convertMap(a.AsMap())
+	c.cache[key] = attrs
+	return attrs
+}
+
+// convertAttrs projects an attribute set, tolerating the zero [otelstorage.Attrs] (a nil-backed
+// map) that a row carries when the column held no attributes.
+func convertAttrs(a otelstorage.Attrs) signal.Attributes {
+	if a.Len() == 0 {
+		return nil
+	}
+	return convertMap(a.AsMap())
+}
+
+// convertMap projects an OTLP attribute map to internal typed [signal.Attributes]. Byte values are
+// copied out of the pdata buffers so the internal model owns them.
+func convertMap(m pcommon.Map) signal.Attributes {
+	if m.Len() == 0 {
+		return nil
+	}
+
+	kvs := make([]signal.KeyValue, 0, m.Len())
+	for k, v := range m.All() {
+		kvs = append(kvs, signal.KeyValue{Key: []byte(k), Value: convertValue(v)})
+	}
+	return signal.NewAttributes(kvs...)
+}
+
+// convertValue projects an OTLP AnyValue to the internal typed [signal.Value], preserving type
+// (and recursing into slices/maps).
+func convertValue(v pcommon.Value) signal.Value {
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		return signal.StringValue([]byte(v.Str()))
+	case pcommon.ValueTypeBool:
+		return signal.BoolValue(v.Bool())
+	case pcommon.ValueTypeInt:
+		return signal.IntValue(v.Int())
+	case pcommon.ValueTypeDouble:
+		return signal.DoubleValue(v.Double())
+	case pcommon.ValueTypeBytes:
+		return signal.BytesValue(v.Bytes().AsRaw())
+	case pcommon.ValueTypeSlice:
+		s := v.Slice()
+		vs := make([]signal.Value, s.Len())
+		for i := range s.Len() {
+			vs[i] = convertValue(s.At(i))
+		}
+		return signal.SliceValue(vs...)
+	case pcommon.ValueTypeMap:
+		return signal.MapValue(convertMap(v.Map())...)
+	default: // ValueTypeEmpty
+		return signal.EmptyValue()
+	}
+}
+
+// traceIDBytes copies a 16-byte trace id into an owned slice, returning nil when unset.
+func traceIDBytes(id otelstorage.TraceID) []byte {
+	if id.IsEmpty() {
+		return nil
+	}
+	return append([]byte(nil), id[:]...)
+}
+
+// spanIDBytes copies an 8-byte span id into an owned slice, returning nil when unset.
+func spanIDBytes(id otelstorage.SpanID) []byte {
+	if id.IsEmpty() {
+		return nil
+	}
+	return append([]byte(nil), id[:]...)
+}
+
+// streamKey groups rows into one (resource, scope) stream. Resource and scope attribute sets are
+// identified by content hash; logs and traces additionally carry a scope name/version, which
+// chstorage stores separately from the scope attribute map.
+type streamKey struct {
+	resource     otelstorage.Hash
+	scope        otelstorage.Hash
+	scopeName    string
+	scopeVersion string
+}
+
+// streamPos locates a stream's scope slot inside a batch by index rather than by pointer.
+//
+// The engine's Add* builders append into retained backing arrays, so appending a later resource or
+// scope can reallocate an earlier one's slice — a pointer cached across the batch would then be
+// writing into an abandoned array. Indices survive the reallocation; pointers do not.
+type streamPos struct {
+	resource int
+	scope    int
+}
+
+// ConvertLogs projects chstorage log records into the engine's log batch, grouping them into one
+// stream per (resource, scope) — the same grouping [logstorage.RecordsToLogs] applies when building
+// the equivalent OTLP payload.
+func ConvertLogs(records []logstorage.Record, c *attrConv) siglog.Logs {
+	var (
+		dst     siglog.Logs
+		streams = map[streamKey]streamPos{}
+	)
+
+	for _, r := range records {
+		key := streamKey{
+			resource:     r.ResourceAttrs.Hash(),
+			scope:        r.ScopeAttrs.Hash(),
+			scopeName:    r.ScopeName,
+			scopeVersion: r.ScopeVersion,
+		}
+
+		pos, ok := streams[key]
+		if !ok {
+			rl := dst.AddResource()
+			rl.Resource = signal.Resource{Attributes: c.convert(r.ResourceAttrs)}
+
+			sl := rl.AddScope()
+			sl.Scope = signal.Scope{
+				Name:       []byte(r.ScopeName),
+				Version:    []byte(r.ScopeVersion),
+				Attributes: c.convert(r.ScopeAttrs),
+			}
+
+			pos = streamPos{resource: len(dst.Resources) - 1, scope: len(rl.Scopes) - 1}
+			streams[key] = pos
+		}
+
+		rec := dst.Resources[pos.resource].Scopes[pos.scope].AddRecord()
+		rec.Timestamp = int64(r.Timestamp)
+		rec.ObservedTimestamp = int64(r.ObservedTimestamp)
+		rec.SeverityNumber = int32(r.SeverityNumber)
+		rec.SeverityText = []byte(r.SeverityText)
+		rec.Body = []byte(r.Body)
+		rec.TraceID = traceIDBytes(r.TraceID)
+		rec.SpanID = spanIDBytes(r.SpanID)
+		rec.Flags = uint32(r.Flags)
+		rec.Dropped = 0
+		rec.Attributes = convertAttrs(r.Attrs)
+	}
+
+	return dst
+}
+
+// ConvertTraces projects chstorage spans into the engine's trace batch, grouping them into one
+// stream per (resource, scope) — the same grouping [tracestorage.SpansToTraces] applies when
+// building the equivalent OTLP payload.
+func ConvertTraces(spans []tracestorage.Span, c *attrConv) sigtrace.Traces {
+	var (
+		dst     sigtrace.Traces
+		streams = map[streamKey]streamPos{}
+	)
+
+	for _, s := range spans {
+		key := streamKey{
+			resource:     s.ResourceAttrs.Hash(),
+			scope:        s.ScopeAttrs.Hash(),
+			scopeName:    s.ScopeName,
+			scopeVersion: s.ScopeVersion,
+		}
+
+		pos, ok := streams[key]
+		if !ok {
+			rs := dst.AddResource()
+			rs.Resource = signal.Resource{Attributes: c.convert(s.ResourceAttrs)}
+
+			ss := rs.AddScope()
+			ss.Scope = signal.Scope{
+				Name:       []byte(s.ScopeName),
+				Version:    []byte(s.ScopeVersion),
+				Attributes: c.convert(s.ScopeAttrs),
+			}
+
+			pos = streamPos{resource: len(dst.Resources) - 1, scope: len(rs.Scopes) - 1}
+			streams[key] = pos
+		}
+
+		sp := dst.Resources[pos.resource].Scopes[pos.scope].AddSpan()
+		sp.Attributes = convertAttrs(s.Attrs)
+		sp.TraceID = traceIDBytes(s.TraceID)
+		sp.SpanID = spanIDBytes(s.SpanID)
+		sp.ParentSpanID = spanIDBytes(s.ParentSpanID)
+		sp.Name = []byte(s.Name)
+		sp.StatusMessage = []byte(s.StatusMessage)
+		sp.TraceState = []byte(s.TraceState)
+		sp.Start = int64(s.Start)
+		sp.End = int64(s.End)
+		sp.Kind = s.Kind
+		sp.StatusCode = s.StatusCode
+		sp.Flags = 0
+		sp.Dropped = 0
+
+		for _, ev := range s.Events {
+			e := sp.AddEvent()
+			e.Time = int64(ev.Timestamp)
+			e.Name = []byte(ev.Name)
+			e.Attributes = convertAttrs(ev.Attrs)
+			e.Dropped = 0
+		}
+
+		for _, ln := range s.Links {
+			l := sp.AddLink()
+			l.TraceID = traceIDBytes(ln.TraceID)
+			l.SpanID = spanIDBytes(ln.SpanID)
+			l.TraceState = []byte(ln.TraceState)
+			l.Attributes = convertAttrs(ln.Attrs)
+			l.Dropped = 0
+		}
+	}
+
+	return dst
+}
+
+// metricKey names one Metric within a stream. chstorage stores decomposed Prometheus-style series,
+// so points of the same name accumulate under a single gauge.
+type metricKey struct {
+	stream streamKey
+	name   string
+}
+
+// ConvertNumberPoints projects chstorage's decomposed numeric samples into the engine's metric
+// batch, one gauge per (resource, scope, name) — matching [metricstorage.NumberPointsToMetrics].
+// chstorage discards the original gauge-vs-sum distinction for these points, so every series is
+// emitted as a gauge; values, names, and labels round-trip exactly.
+//
+// Only the number-point path is direct. Exponential histograms keep the pdata route, because the
+// engine decomposes them into classic _count/_sum/_bucket{le} series inside its pdataconv bridge
+// and that bucket math is not reachable from here; re-deriving it would duplicate subtle logic for
+// a small minority of points.
+func ConvertNumberPoints(points []metricstorage.NumberPoint, c *attrConv) sigmetric.Metrics {
+	var (
+		dst     sigmetric.Metrics
+		streams = map[streamKey]streamPos{}
+		metrics = map[metricKey]int{}
+	)
+
+	for _, p := range points {
+		// chstorage does not store a scope name/version for metrics, only a scope attribute map,
+		// so the stream is identified by the two attribute hashes alone.
+		skey := streamKey{resource: p.Resource.Hash(), scope: p.Scope.Hash()}
+
+		spos, ok := streams[skey]
+		if !ok {
+			rm := dst.AddResource()
+			rm.Resource = signal.Resource{Attributes: c.convert(p.Resource)}
+
+			sm := rm.AddScope()
+			sm.Scope = signal.Scope{Attributes: c.convert(p.Scope)}
+
+			spos = streamPos{resource: len(dst.Resources) - 1, scope: len(rm.Scopes) - 1}
+			streams[skey] = spos
+		}
+		sm := &dst.Resources[spos.resource].Scopes[spos.scope]
+
+		mkey := metricKey{stream: skey, name: p.Name}
+		mi, ok := metrics[mkey]
+		if !ok {
+			mt := sm.AddMetric()
+			mt.Name = []byte(p.Name)
+			mt.Unit = []byte(p.Unit)
+			mt.Kind = sigmetric.KindGauge
+
+			mi = len(sm.Metrics) - 1
+			metrics[mkey] = mi
+		}
+
+		pt := sm.Metrics[mi].AddPoint()
+		pt.Attributes = c.convert(p.Attrs)
+		pt.Ts = int64(p.Timestamp)
+		pt.Value = p.Value
+	}
+
+	return dst
+}

--- a/internal/ch2storagebackend/convert_bench_test.go
+++ b/internal/ch2storagebackend/convert_bench_test.go
@@ -1,0 +1,204 @@
+package ch2storagebackend
+
+import (
+	"strconv"
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/oteldb/storage/otlp/pdataconv"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/metricstorage"
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// benchSeriesAttrs builds n distinct series attribute sets, mimicking how chstorage resolves a
+// row's identity: the same map instance is handed back for every row of a series, which is what the
+// direct path's memoization exploits.
+func benchSeriesAttrs(n int) []otelstorage.Attrs {
+	out := make([]otelstorage.Attrs, n)
+	for i := range out {
+		m := pcommon.NewMap()
+		m.PutStr("route", "/route/"+strconv.Itoa(i))
+		m.PutStr("method", "GET")
+		out[i] = otelstorage.Attrs(m)
+	}
+	return out
+}
+
+func benchResource() otelstorage.Attrs {
+	m := pcommon.NewMap()
+	m.PutStr("service.name", "bench")
+	m.PutStr("host.name", "node-1")
+	return otelstorage.Attrs(m)
+}
+
+// benchPoints lays out rows the way a metrics scan delivers them: pointsPerSeries samples for each
+// of seriesCount series, all sharing one resource and scope.
+func benchPoints(seriesCount, pointsPerSeries int) []metricstorage.NumberPoint {
+	var (
+		res    = benchResource()
+		scope  = otelstorage.Attrs(pcommon.NewMap())
+		series = benchSeriesAttrs(seriesCount)
+		out    = make([]metricstorage.NumberPoint, 0, seriesCount*pointsPerSeries)
+	)
+	for s := range seriesCount {
+		for p := range pointsPerSeries {
+			out = append(out, metricstorage.NumberPoint{
+				Name: "http.requests", Unit: "1",
+				Resource: res, Scope: scope, Attrs: series[s],
+				Timestamp: otelstorage.Timestamp(uint64(1_000_000_000 + p*15_000)),
+				Value:     float64(p),
+			})
+		}
+	}
+	return out
+}
+
+func benchRecords(n int) []logstorage.Record {
+	var (
+		res   = benchResource()
+		scope = otelstorage.Attrs(pcommon.NewMap())
+		attrs = benchSeriesAttrs(16)
+		out   = make([]logstorage.Record, 0, n)
+	)
+	for i := range n {
+		out = append(out, logstorage.Record{
+			Timestamp: otelstorage.Timestamp(uint64(i + 1)),
+			Body:      "GET /api/v1/resource 200 in 13ms",
+			Attrs:     attrs[i%len(attrs)],
+			TraceID:   otelstorage.TraceID{byte(i), 2, 3},
+			SpanID:    otelstorage.SpanID{byte(i), 5},
+
+			ResourceAttrs: res, ScopeName: "zap", ScopeVersion: "1.0", ScopeAttrs: scope,
+		})
+	}
+	return out
+}
+
+func benchSpans(n int) []tracestorage.Span {
+	var (
+		res   = benchResource()
+		scope = otelstorage.Attrs(pcommon.NewMap())
+		attrs = benchSeriesAttrs(16)
+		out   = make([]tracestorage.Span, 0, n)
+	)
+	for i := range n {
+		out = append(out, tracestorage.Span{
+			TraceID: otelstorage.TraceID{byte(i), 1}, SpanID: otelstorage.SpanID{byte(i), 2},
+			Name: "GET /api", Kind: 2,
+			Start: otelstorage.Timestamp(uint64(i * 1000)),
+			End:   otelstorage.Timestamp(uint64(i*1000 + 500)),
+			Attrs: attrs[i%len(attrs)], StatusCode: 1, StatusMessage: "ok",
+
+			ResourceAttrs: res, ScopeName: "otel", ScopeVersion: "1.0", ScopeAttrs: scope,
+		})
+	}
+	return out
+}
+
+func reportRows(b *testing.B, rows int) {
+	b.Helper()
+
+	if secs := b.Elapsed().Seconds(); secs > 0 {
+		b.ReportMetric(float64(rows)*float64(b.N)/secs/1e6, "Mrows/s")
+	}
+}
+
+// The Direct/PDATA pairs below measure exactly what item 2 bought: the same batch, built with and
+// without the intermediate OTLP tree.
+
+func BenchmarkConvertNumberPoints(b *testing.B) {
+	shapes := []struct {
+		name            string
+		series, perSeri int
+	}{
+		{"1000series_5points", 1000, 5},
+		{"100series_50points", 100, 50},
+		{"5000series_1point", 5000, 1},
+	}
+
+	for _, sh := range shapes {
+		points := benchPoints(sh.series, sh.perSeri)
+		rows := len(points)
+
+		b.Run(sh.name+"/Direct", func(b *testing.B) {
+			c := newAttrConv()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				sink(ConvertNumberPoints(points, c))
+			}
+			reportRows(b, rows)
+		})
+
+		b.Run(sh.name+"/PDATA", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				var dst sigmetric.Metrics
+				pdataconv.AppendMetrics(&dst, metricstorage.NumberPointsToMetrics(points))
+				sink(dst)
+			}
+			reportRows(b, rows)
+		})
+	}
+}
+
+func BenchmarkConvertLogs(b *testing.B) {
+	records := benchRecords(5000)
+
+	b.Run("Direct", func(b *testing.B) {
+		c := newAttrConv()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			sink(ConvertLogs(records, c))
+		}
+		reportRows(b, len(records))
+	})
+
+	b.Run("PDATA", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			var dst siglog.Logs
+			pdataconv.AppendLogs(&dst, logstorage.RecordsToLogs(records))
+			sink(dst)
+		}
+		reportRows(b, len(records))
+	})
+}
+
+func BenchmarkConvertTraces(b *testing.B) {
+	spans := benchSpans(5000)
+
+	b.Run("Direct", func(b *testing.B) {
+		c := newAttrConv()
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			sink(ConvertTraces(spans, c))
+		}
+		reportRows(b, len(spans))
+	})
+
+	b.Run("PDATA", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			var dst sigtrace.Traces
+			pdataconv.AppendTraces(&dst, tracestorage.SpansToTraces(spans))
+			sink(dst)
+		}
+		reportRows(b, len(spans))
+	})
+}
+
+//go:noinline
+func sink(any) {}

--- a/internal/ch2storagebackend/convert_test.go
+++ b/internal/ch2storagebackend/convert_test.go
@@ -1,0 +1,323 @@
+package ch2storagebackend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage/otlp/pdataconv"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/metricstorage"
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+func attrs(kvs map[string]any) otelstorage.Attrs {
+	m := pcommon.NewMap()
+	for k, v := range kvs {
+		switch v := v.(type) {
+		case string:
+			m.PutStr(k, v)
+		case int:
+			m.PutInt(k, int64(v))
+		case float64:
+			m.PutDouble(k, v)
+		case bool:
+			m.PutBool(k, v)
+		default:
+			panic("unsupported attribute type")
+		}
+	}
+	return otelstorage.Attrs(m)
+}
+
+// sampleRecords spans several streams, attribute types, and an empty-attribute record, so the
+// equivalence check exercises the grouping and the value projection, not just the happy path.
+func sampleRecords() []logstorage.Record {
+	res := attrs(map[string]any{"service.name": "api", "host": "a"})
+	other := attrs(map[string]any{"service.name": "worker"})
+	scope := attrs(map[string]any{"lib": "zap"})
+
+	return []logstorage.Record{
+		{
+			Timestamp: 100, ObservedTimestamp: 101,
+			SeverityText: "INFO", SeverityNumber: plog.SeverityNumberInfo,
+			Body:          "hello",
+			TraceID:       otelstorage.TraceID{1, 2, 3},
+			SpanID:        otelstorage.SpanID{4, 5},
+			Flags:         plog.LogRecordFlags(1),
+			Attrs:         attrs(map[string]any{"code": 200, "ok": true, "ratio": 0.5}),
+			ResourceAttrs: res, ScopeName: "zap", ScopeVersion: "1.0", ScopeAttrs: scope,
+		},
+		{
+			// Same stream as above: must land under the same resource/scope.
+			Timestamp: 200, Body: "second", Attrs: attrs(map[string]any{"code": 500}),
+			ResourceAttrs: res, ScopeName: "zap", ScopeVersion: "1.0", ScopeAttrs: scope,
+		},
+		{
+			// Different resource, no ids, empty attribute set.
+			Timestamp: 300, Body: "third", Attrs: attrs(nil),
+			ResourceAttrs: other, ScopeName: "zap", ScopeVersion: "1.0", ScopeAttrs: scope,
+		},
+		{
+			// Same resource as the first, different scope version: a distinct stream.
+			Timestamp: 400, Body: "fourth", Attrs: attrs(nil),
+			ResourceAttrs: res, ScopeName: "zap", ScopeVersion: "2.0", ScopeAttrs: scope,
+		},
+	}
+}
+
+func sampleSpans() []tracestorage.Span {
+	res := attrs(map[string]any{"service.name": "api"})
+	other := attrs(map[string]any{"service.name": "db"})
+	scope := attrs(map[string]any{"lib": "otel"})
+
+	return []tracestorage.Span{
+		{
+			TraceID: otelstorage.TraceID{1}, SpanID: otelstorage.SpanID{2},
+			ParentSpanID: otelstorage.SpanID{3},
+			TraceState:   "vendor=1",
+			Name:         "GET /", Kind: 2,
+			Start: 1000, End: 2000,
+			Attrs:      attrs(map[string]any{"http.status": 200}),
+			StatusCode: 1, StatusMessage: "ok",
+			ResourceAttrs: res, ScopeName: "otel", ScopeVersion: "1.0", ScopeAttrs: scope,
+			Events: []tracestorage.Event{
+				{Timestamp: 1500, Name: "cache.miss", Attrs: attrs(map[string]any{"key": "k"})},
+				{Timestamp: 1600, Name: "retry", Attrs: attrs(nil)},
+			},
+			Links: []tracestorage.Link{
+				{TraceID: otelstorage.TraceID{9}, SpanID: otelstorage.SpanID{8}, TraceState: "x=1", Attrs: attrs(nil)},
+			},
+		},
+		{
+			// No parent, no events/links, empty attrs — the minimal span.
+			TraceID: otelstorage.TraceID{4}, SpanID: otelstorage.SpanID{5},
+			Name: "query", Start: 1100, End: 1200, Attrs: attrs(nil),
+			ResourceAttrs: other, ScopeName: "otel", ScopeVersion: "1.0", ScopeAttrs: scope,
+		},
+	}
+}
+
+func samplePoints() []metricstorage.NumberPoint {
+	res := attrs(map[string]any{"service.name": "api"})
+	other := attrs(map[string]any{"service.name": "worker"})
+	scope := attrs(map[string]any{})
+	series := attrs(map[string]any{"route": "/a"})
+
+	return []metricstorage.NumberPoint{
+		{Name: "http_requests", Unit: "1", Resource: res, Scope: scope, Attrs: series, Timestamp: 100, Value: 1},
+		// Same series, later point: must accumulate under the same Metric.
+		{Name: "http_requests", Unit: "1", Resource: res, Scope: scope, Attrs: series, Timestamp: 200, Value: 2},
+		// Same stream, different name: a second Metric under the same scope.
+		{Name: "http_errors", Unit: "1", Resource: res, Scope: scope, Attrs: series, Timestamp: 100, Value: 3},
+		// Different resource: a second stream.
+		{Name: "http_requests", Unit: "1", Resource: other, Scope: scope, Attrs: series, Timestamp: 100, Value: 4},
+		// No datapoint attributes.
+		{Name: "uptime", Unit: "s", Resource: res, Scope: scope, Attrs: attrs(nil), Timestamp: 100, Value: 5},
+	}
+}
+
+// The direct converters exist only as a faster route to the same batch the OTLP path produces.
+// These tests pin that equivalence, so a drift in either path fails here rather than silently
+// changing what a migration writes.
+//
+// One field is normalized before comparing. chstorage stores no schema URL for any signal, so both
+// paths mean "absent" — but the pdata route spells it []byte("") (the artifact of converting an
+// empty Go string) while the direct route leaves it nil. Nothing downstream distinguishes the two,
+// and nil avoids the allocation, so the difference is normalized away rather than reproduced.
+func nilIfEmpty(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	return b
+}
+
+func normalizeLogs(l *siglog.Logs) {
+	for i := range l.Resources {
+		r := &l.Resources[i]
+		r.Resource.SchemaURL = nilIfEmpty(r.Resource.SchemaURL)
+		for j := range r.Scopes {
+			r.Scopes[j].Scope.SchemaURL = nilIfEmpty(r.Scopes[j].Scope.SchemaURL)
+		}
+	}
+}
+
+func normalizeTraces(t *sigtrace.Traces) {
+	for i := range t.Resources {
+		r := &t.Resources[i]
+		r.Resource.SchemaURL = nilIfEmpty(r.Resource.SchemaURL)
+		for j := range r.Scopes {
+			r.Scopes[j].Scope.SchemaURL = nilIfEmpty(r.Scopes[j].Scope.SchemaURL)
+		}
+	}
+}
+
+// normalizeMetrics also nils the scope name/version: chstorage stores neither for metrics (only a
+// scope attribute map), so the same empty-string-vs-nil artifact applies to them.
+func normalizeMetrics(m *sigmetric.Metrics) {
+	for i := range m.Resources {
+		r := &m.Resources[i]
+		r.Resource.SchemaURL = nilIfEmpty(r.Resource.SchemaURL)
+		for j := range r.Scopes {
+			sc := &r.Scopes[j].Scope
+			sc.SchemaURL = nilIfEmpty(sc.SchemaURL)
+			sc.Name = nilIfEmpty(sc.Name)
+			sc.Version = nilIfEmpty(sc.Version)
+		}
+	}
+}
+
+func TestConvertLogsMatchesPDATA(t *testing.T) {
+	records := sampleRecords()
+
+	var want siglog.Logs
+	pdataconv.AppendLogs(&want, logstorage.RecordsToLogs(records))
+
+	got := ConvertLogs(records, newAttrConv())
+
+	normalizeLogs(&want)
+	normalizeLogs(&got)
+	require.Equal(t, want, got)
+}
+
+func TestConvertTracesMatchesPDATA(t *testing.T) {
+	spans := sampleSpans()
+
+	var want sigtrace.Traces
+	pdataconv.AppendTraces(&want, tracestorage.SpansToTraces(spans))
+
+	got := ConvertTraces(spans, newAttrConv())
+
+	normalizeTraces(&want)
+	normalizeTraces(&got)
+	require.Equal(t, want, got)
+}
+
+func TestConvertNumberPointsMatchesPDATA(t *testing.T) {
+	points := samplePoints()
+
+	var want sigmetric.Metrics
+	pdataconv.AppendMetrics(&want, metricstorage.NumberPointsToMetrics(points))
+
+	got := ConvertNumberPoints(points, newAttrConv())
+
+	normalizeMetrics(&want)
+	normalizeMetrics(&got)
+	require.Equal(t, want, got)
+}
+
+func TestConvertEmptyBatches(t *testing.T) {
+	c := newAttrConv()
+	assert.Empty(t, ConvertLogs(nil, c).Resources)
+	assert.Empty(t, ConvertTraces(nil, c).Resources)
+	assert.Empty(t, ConvertNumberPoints(nil, c).Resources)
+}
+
+func TestConvertGrouping(t *testing.T) {
+	t.Run("logs group by resource and scope", func(t *testing.T) {
+		got := ConvertLogs(sampleRecords(), newAttrConv())
+
+		// Three distinct streams: (api, zap 1.0), (worker, zap 1.0), (api, zap 2.0).
+		require.Len(t, got.Resources, 3)
+		assert.Len(t, got.Resources[0].Scopes[0].Records, 2, "same stream accumulates")
+		assert.Len(t, got.Resources[1].Scopes[0].Records, 1)
+		assert.Len(t, got.Resources[2].Scopes[0].Records, 1)
+	})
+
+	t.Run("points accumulate under one metric per name", func(t *testing.T) {
+		got := ConvertNumberPoints(samplePoints(), newAttrConv())
+
+		require.Len(t, got.Resources, 2)
+		metrics := got.Resources[0].Scopes[0].Metrics
+		require.Len(t, metrics, 3, "http_requests, http_errors, uptime")
+
+		assert.Equal(t, []byte("http_requests"), metrics[0].Name)
+		assert.Len(t, metrics[0].Points, 2, "two points of the same series")
+		assert.Equal(t, sigmetric.KindGauge, metrics[0].Kind)
+	})
+}
+
+// A grouping map that cached pointers into the batch's backing arrays would be writing into
+// abandoned arrays once a later append reallocated them. This drives enough distinct streams to
+// force several reallocations and checks nothing was lost.
+func TestConvertSurvivesBackingArrayGrowth(t *testing.T) {
+	const streams = 64
+
+	var records []logstorage.Record
+	for i := range streams {
+		res := attrs(map[string]any{"service.name": "svc", "shard": i})
+		// Two records per stream, interleaved across streams so the map is hit after growth.
+		records = append(records, logstorage.Record{Timestamp: int64ToTS(i), Body: "a", Attrs: attrs(nil), ResourceAttrs: res})
+	}
+	for i := range streams {
+		res := attrs(map[string]any{"service.name": "svc", "shard": i})
+		records = append(records, logstorage.Record{Timestamp: int64ToTS(i), Body: "b", Attrs: attrs(nil), ResourceAttrs: res})
+	}
+
+	got := ConvertLogs(records, newAttrConv())
+	require.Len(t, got.Resources, streams)
+
+	total := 0
+	for _, r := range got.Resources {
+		require.Len(t, r.Scopes, 1)
+		total += len(r.Scopes[0].Records)
+		assert.Len(t, r.Scopes[0].Records, 2, "both records landed in the same stream")
+	}
+	assert.Equal(t, len(records), total, "no record lost to a reallocated slice")
+}
+
+func int64ToTS(i int) otelstorage.Timestamp {
+	return otelstorage.Timestamp(uint64(i + 1))
+}
+
+func TestAttrConvMemoizes(t *testing.T) {
+	c := newAttrConv()
+	a := attrs(map[string]any{"service.name": "api"})
+
+	first := c.convert(a)
+	second := c.convert(a)
+
+	require.Equal(t, first, second)
+	assert.Len(t, c.cache, 1, "an identical attribute set is converted once")
+
+	// A distinct set gets its own entry.
+	c.convert(attrs(map[string]any{"service.name": "worker"}))
+	assert.Len(t, c.cache, 2)
+
+	// An empty or unset map converts to nil without occupying the cache.
+	assert.Nil(t, c.convert(attrs(map[string]any{})))
+	assert.Nil(t, c.convert(otelstorage.Attrs{}))
+	assert.Len(t, c.cache, 2)
+}
+
+func TestConvertValueTypes(t *testing.T) {
+	m := pcommon.NewMap()
+	m.PutStr("str", "s")
+	m.PutInt("int", 7)
+	m.PutDouble("double", 1.5)
+	m.PutBool("bool", true)
+	m.PutEmptyBytes("bytes").Append(1, 2, 3)
+	m.PutEmpty("empty")
+	sl := m.PutEmptySlice("slice")
+	sl.AppendEmpty().SetStr("a")
+	sl.AppendEmpty().SetInt(2)
+	nested := m.PutEmptyMap("map")
+	nested.PutStr("k", "v")
+
+	// pdataconv is the reference projection; the local copy must agree on every value type.
+	var want siglog.Logs
+	ld := plog.NewLogs()
+	rec := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	m.CopyTo(rec.Attributes())
+	pdataconv.AppendLogs(&want, ld)
+
+	assert.Equal(t, want.Resources[0].Scopes[0].Records[0].Attributes, convertMap(m))
+}

--- a/internal/ch2storagebackend/estimate.go
+++ b/internal/ch2storagebackend/estimate.go
@@ -1,0 +1,247 @@
+package ch2storagebackend
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/oteldb/internal/chstorage"
+)
+
+// Throughput defaults, in rows per second, for the projected wall-clock in an [Estimate].
+//
+// These are the *serial* end-to-end rates of the current migration path — ClickHouse scan, decode,
+// pdata construction, and ingest all run in one goroutine, so the pipeline is bounded by their sum
+// rather than by the slowest stage. Metrics is measured: NumberPointsToMetrics sustains ~3.3M
+// points/s and the engine's ingest+flush ~3.3M points/s on a 5950X, which compose to ~1.6M
+// points/s before the ClickHouse scan is counted. Logs and traces are set an order of magnitude
+// lower because their rows are far larger. They are deliberately crude — the estimate exists to
+// separate "an hour" from "a week", not to predict a finish time — and are overridable.
+const (
+	DefaultMetricsRowsPerSecond = 1_500_000
+	DefaultLogsRowsPerSecond    = 150_000
+	DefaultTracesRowsPerSecond  = 200_000
+)
+
+// RowsPerSecond returns the default projected throughput for a signal.
+func RowsPerSecond(signal string) float64 {
+	switch signal {
+	case SignalMetrics:
+		return DefaultMetricsRowsPerSecond
+	case SignalTraces:
+		return DefaultTracesRowsPerSecond
+	default:
+		return DefaultLogsRowsPerSecond
+	}
+}
+
+// Estimate is the pre-flight sizing of one signal's migration window: what it will read, how big it
+// is, and roughly how long it will take. It is produced without ingesting anything.
+type Estimate struct {
+	Signal string
+	// From/To are the effective window, after intersecting the request with the source's range.
+	From time.Time
+	To   time.Time
+	// Days is the per-UTC-day row count. Days already recorded in the checkpoint have Skipped set.
+	Days []EstimateDay
+	// Rows is the total across Days; Remaining excludes the skipped ones.
+	Rows      uint64
+	Remaining uint64
+	// Size is the source table's whole-table footprint, the basis for the per-row byte averages.
+	Size chstorage.TableSize
+	// RowsPerSecond is the throughput the projection assumes.
+	RowsPerSecond float64
+}
+
+// EstimateDay is one day of an [Estimate].
+type EstimateDay struct {
+	Day     time.Time
+	Rows    uint64
+	Skipped bool
+}
+
+// Bytes returns the compressed and uncompressed size of the remaining rows, projected from the
+// source table's average bytes per row.
+//
+// Both are ClickHouse-side figures and they differ by roughly an order of magnitude on telemetry,
+// which is why they are reported as a pair rather than as a single "size". Neither predicts what
+// the target engine writes: it applies its own codecs, and its own MaxPartSize limit is itself
+// expressed in *uncompressed* bytes.
+func (e Estimate) Bytes() (compressed, uncompressed uint64) {
+	perCompressed, perUncompressed := e.Size.BytesPerRow()
+	return uint64(perCompressed * float64(e.Remaining)), uint64(perUncompressed * float64(e.Remaining))
+}
+
+// Duration returns the projected wall-clock for the remaining rows.
+func (e Estimate) Duration() time.Duration {
+	if e.RowsPerSecond <= 0 {
+		return 0
+	}
+	return time.Duration(float64(e.Remaining) / e.RowsPerSecond * float64(time.Second))
+}
+
+// EstimateLogs sizes a log migration over w without ingesting anything.
+func (m *Migrator) EstimateLogs(ctx context.Context, w chstorage.Window) (Estimate, error) {
+	mint, maxt, err := m.logs.Range(ctx)
+	if err != nil {
+		return Estimate{}, errors.Wrap(err, "resolve range")
+	}
+	return m.estimate(ctx, SignalLogs, w, mint, maxt, m.logs.Counts, m.logs.Size)
+}
+
+// EstimateTraces sizes a trace migration over w without ingesting anything.
+func (m *Migrator) EstimateTraces(ctx context.Context, w chstorage.Window) (Estimate, error) {
+	mint, maxt, err := m.traces.Range(ctx)
+	if err != nil {
+		return Estimate{}, errors.Wrap(err, "resolve range")
+	}
+	return m.estimate(ctx, SignalTraces, w, mint, maxt, m.traces.Counts, m.traces.Size)
+}
+
+// EstimateMetrics sizes a metrics migration over w without ingesting anything.
+func (m *Migrator) EstimateMetrics(ctx context.Context, w chstorage.Window) (Estimate, error) {
+	mint, maxt, err := m.metrics.Range(ctx)
+	if err != nil {
+		return Estimate{}, errors.Wrap(err, "resolve range")
+	}
+	return m.estimate(ctx, SignalMetrics, w, mint, maxt, m.metrics.Counts, m.metrics.Size)
+}
+
+type (
+	countsFunc func(ctx context.Context, from, to time.Time) ([]chstorage.DayCount, error)
+	sizeFunc   func(ctx context.Context) (chstorage.TableSize, error)
+)
+
+func (m *Migrator) estimate(
+	ctx context.Context,
+	signal string,
+	w chstorage.Window,
+	mint, maxt time.Time,
+	counts countsFunc,
+	size sizeFunc,
+) (Estimate, error) {
+	est := Estimate{Signal: signal, RowsPerSecond: RowsPerSecond(signal)}
+
+	days, from, to, ok := plan(w, mint, maxt)
+	if !ok {
+		return est, nil
+	}
+	est.From, est.To = from, to
+
+	byDay, err := counts(ctx, from, to)
+	if err != nil {
+		return est, errors.Wrap(err, "count rows")
+	}
+	rows := make(map[time.Time]uint64, len(byDay))
+	for _, c := range byDay {
+		rows[c.Day] = c.Rows
+	}
+
+	for _, d := range days {
+		day := EstimateDay{
+			Day:     d.Day,
+			Rows:    rows[d.Day.UTC()],
+			Skipped: m.checkpoint.Done(signal, d.Day),
+		}
+		est.Rows += day.Rows
+		if !day.Skipped {
+			est.Remaining += day.Rows
+		}
+		est.Days = append(est.Days, day)
+	}
+
+	if est.Size, err = size(ctx); err != nil {
+		return est, errors.Wrap(err, "size table")
+	}
+	return est, nil
+}
+
+// String renders e as an operator-readable report.
+func (e Estimate) String() string {
+	if len(e.Days) == 0 {
+		return fmt.Sprintf("%s: nothing to migrate\n\n", e.Signal)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s: %s .. %s (%d days)\n",
+		e.Signal, e.From.UTC().Format(time.DateTime), e.To.UTC().Format(time.DateTime), len(e.Days))
+
+	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', tabwriter.AlignRight)
+	_, _ = fmt.Fprintln(tw, "  day\trows\t")
+	for _, d := range e.Days {
+		note := ""
+		if d.Skipped {
+			note = "  (done)"
+		}
+		_, _ = fmt.Fprintf(tw, "  %s\t%s\t%s\n", d.Day.UTC().Format(time.DateOnly), formatCount(d.Rows), note)
+	}
+	_, _ = fmt.Fprintf(tw, "  total\t%s\t\n", formatCount(e.Rows))
+	if e.Remaining != e.Rows {
+		_, _ = fmt.Fprintf(tw, "  remaining\t%s\t\n", formatCount(e.Remaining))
+	}
+	// tabwriter only fails on the underlying writer, and a strings.Builder never errors.
+	_ = tw.Flush()
+
+	compressed, uncompressed := e.Bytes()
+	fmt.Fprintf(&b, "  source size: %s compressed / %s uncompressed (ClickHouse)\n",
+		formatBytes(compressed), formatBytes(uncompressed))
+	fmt.Fprintf(&b, "  projected:   %s at %s rows/s (serial path; target engine size will differ)\n\n",
+		formatDuration(e.Duration()), formatCount(uint64(e.RowsPerSecond)))
+
+	return b.String()
+}
+
+func formatProgress(i, total int) string {
+	return fmt.Sprintf("%d/%d", i, total)
+}
+
+// formatCount renders a row count with thousands separators, which is what makes the difference
+// between 2.7e9 and 2.7e6 legible at a glance in a sizing report.
+func formatCount(n uint64) string {
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+
+	var b strings.Builder
+	if lead := len(s) % 3; lead > 0 {
+		b.WriteString(s[:lead])
+		s = s[lead:]
+	}
+	for i := 0; i < len(s); i += 3 {
+		if b.Len() > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(s[i : i+3])
+	}
+	return b.String()
+}
+
+func formatBytes(n uint64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+
+	div, exp := uint64(unit), 0
+	for n/div >= unit && exp < 4 {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTP"[exp])
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d >= time.Hour:
+		return fmt.Sprintf("%.1fh", d.Hours())
+	case d >= time.Minute:
+		return fmt.Sprintf("%.1fm", d.Minutes())
+	default:
+		return d.Round(time.Second).String()
+	}
+}

--- a/internal/ch2storagebackend/estimate.go
+++ b/internal/ch2storagebackend/estimate.go
@@ -14,17 +14,22 @@ import (
 
 // Throughput defaults, in rows per second, for the projected wall-clock in an [Estimate].
 //
-// These are the *serial* end-to-end rates of the current migration path — ClickHouse scan, decode,
-// pdata construction, and ingest all run in one goroutine, so the pipeline is bounded by their sum
-// rather than by the slowest stage. Metrics is measured: NumberPointsToMetrics sustains ~3.3M
-// points/s and the engine's ingest+flush ~3.3M points/s on a 5950X, which compose to ~1.6M
-// points/s before the ClickHouse scan is counted. Logs and traces are set an order of magnitude
-// lower because their rows are far larger. They are deliberately crude — the estimate exists to
-// separate "an hour" from "a week", not to predict a finish time — and are overridable.
+// These are the *serial* rates of the migration path: conversion and ingest run in one goroutine,
+// so the pipeline is bounded by their sum rather than by the slowest stage. Each is the harmonic
+// sum of two measured legs on a 5950X — the direct converters in convert.go (see
+// BenchmarkConvert*) and the engine's own ingest+flush (its BenchmarkWrite* suites):
+//
+//	metrics   3.1M convert + 3.3M ingest ≈ 1.6M/s
+//	logs      1.8M convert + 1.0M ingest ≈ 0.64M/s
+//	traces    1.7M convert + 0.8M ingest ≈ 0.54M/s
+//
+// They are rounded down because neither leg accounts for the ClickHouse scan or the network in
+// front of it, so a real run lands below them. The estimate exists to separate "an hour" from "a
+// week", not to predict a finish time.
 const (
 	DefaultMetricsRowsPerSecond = 1_500_000
-	DefaultLogsRowsPerSecond    = 150_000
-	DefaultTracesRowsPerSecond  = 200_000
+	DefaultLogsRowsPerSecond    = 600_000
+	DefaultTracesRowsPerSecond  = 500_000
 )
 
 // RowsPerSecond returns the default projected throughput for a signal.

--- a/internal/ch2storagebackend/estimate_test.go
+++ b/internal/ch2storagebackend/estimate_test.go
@@ -1,0 +1,191 @@
+package ch2storagebackend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/chstorage"
+)
+
+// weekEstimate is the shape that motivated the pre-flight report: seven days of production
+// metrics, ~2.8B points each.
+func weekEstimate() Estimate {
+	est := Estimate{
+		Signal:        SignalMetrics,
+		From:          day("2026-08-05"),
+		To:            day("2026-08-12"),
+		RowsPerSecond: DefaultMetricsRowsPerSecond,
+		Size: chstorage.TableSize{
+			Rows:              20_000_000_000,
+			CompressedBytes:   80_000_000_000,
+			UncompressedBytes: 680_000_000_000,
+		},
+	}
+	for i, rows := range []uint64{
+		2_740_237_809, 2_750_850_075, 2_800_000_000,
+		2_810_000_000, 2_820_000_000, 2_830_000_000, 2_950_209_213,
+	} {
+		est.Days = append(est.Days, EstimateDay{Day: day("2026-08-05").AddDate(0, 0, i), Rows: rows})
+		est.Rows += rows
+		est.Remaining += rows
+	}
+	return est
+}
+
+func TestEstimateDuration(t *testing.T) {
+	t.Run("projects from the remaining rows", func(t *testing.T) {
+		est := weekEstimate()
+		// ~19.7B points at 1.5M/s is hours, not minutes — the distinction the report exists to make.
+		assert.Greater(t, est.Duration(), 3*time.Hour)
+		assert.Less(t, est.Duration(), 5*time.Hour)
+	})
+
+	t.Run("checkpointed days do not count", func(t *testing.T) {
+		full := weekEstimate()
+
+		partial := weekEstimate()
+		partial.Remaining = 0
+		for i := range partial.Days {
+			if i < 5 {
+				partial.Days[i].Skipped = true
+				continue
+			}
+			partial.Remaining += partial.Days[i].Rows
+		}
+
+		assert.Less(t, partial.Duration(), full.Duration()/2)
+	})
+
+	t.Run("zero throughput does not divide by zero", func(t *testing.T) {
+		est := weekEstimate()
+		est.RowsPerSecond = 0
+		assert.Zero(t, est.Duration())
+	})
+}
+
+func TestEstimateBytes(t *testing.T) {
+	t.Run("scales the source averages by remaining rows", func(t *testing.T) {
+		est := weekEstimate()
+		compressed, uncompressed := est.Bytes()
+
+		// The whole table averages 4 compressed / 34 uncompressed bytes per row.
+		assert.InDelta(t, float64(est.Remaining)*4, float64(compressed), float64(compressed)*0.01)
+		assert.InDelta(t, float64(est.Remaining)*34, float64(uncompressed), float64(uncompressed)*0.01)
+
+		// The pair must stay distinguishable: quoting one as "the size" is the confusion the
+		// report is meant to remove.
+		assert.Greater(t, uncompressed, compressed*5)
+	})
+
+	t.Run("empty source table", func(t *testing.T) {
+		compressed, uncompressed := Estimate{Remaining: 100}.Bytes()
+		assert.Zero(t, compressed)
+		assert.Zero(t, uncompressed)
+	})
+}
+
+func TestEstimateString(t *testing.T) {
+	t.Run("nothing to migrate", func(t *testing.T) {
+		out := Estimate{Signal: SignalLogs}.String()
+		assert.Contains(t, out, "nothing to migrate")
+	})
+
+	t.Run("reports both size units and the assumed rate", func(t *testing.T) {
+		out := weekEstimate().String()
+
+		assert.Contains(t, out, "metrics")
+		assert.Contains(t, out, "2026-08-05")
+		assert.Contains(t, out, "2,740,237,809", "day counts are separated for legibility")
+		assert.Contains(t, out, "compressed")
+		assert.Contains(t, out, "uncompressed")
+		assert.Contains(t, out, "rows/s", "the projection states the rate it assumes")
+	})
+
+	t.Run("marks and excludes checkpointed days", func(t *testing.T) {
+		est := weekEstimate()
+		est.Days[0].Skipped = true
+		est.Remaining -= est.Days[0].Rows
+
+		out := est.String()
+		assert.Contains(t, out, "(done)")
+		assert.Contains(t, out, "remaining")
+	})
+}
+
+func TestRowsPerSecond(t *testing.T) {
+	assert.Equal(t, float64(DefaultMetricsRowsPerSecond), RowsPerSecond(SignalMetrics))
+	assert.Equal(t, float64(DefaultTracesRowsPerSecond), RowsPerSecond(SignalTraces))
+	assert.Equal(t, float64(DefaultLogsRowsPerSecond), RowsPerSecond(SignalLogs))
+}
+
+func TestFormatCount(t *testing.T) {
+	tests := []struct {
+		in   uint64
+		want string
+	}{
+		{0, "0"},
+		{7, "7"},
+		{999, "999"},
+		{1000, "1,000"},
+		{12_345, "12,345"},
+		{123_456, "123,456"},
+		{1_234_567, "1,234,567"},
+		{2_740_237_809, "2,740,237,809"},
+		{19_700_000_000, "19,700,000,000"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, formatCount(tt.in))
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		in   uint64
+		want string
+	}{
+		{512, "512 B"},
+		{1024, "1.0 KiB"},
+		{1536, "1.5 KiB"},
+		{1 << 20, "1.0 MiB"},
+		{1 << 30, "1.0 GiB"},
+		{670 << 30, "670.0 GiB"},
+		{1 << 40, "1.0 TiB"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, formatBytes(tt.in))
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	assert.Equal(t, "45s", formatDuration(45*time.Second))
+	assert.Equal(t, "5.0m", formatDuration(5*time.Minute))
+	assert.Equal(t, "3.5h", formatDuration(3*time.Hour+30*time.Minute))
+}
+
+func TestPlan(t *testing.T) {
+	var (
+		mint = day("2026-08-05")
+		maxt = day("2026-08-11")
+	)
+
+	t.Run("empty source", func(t *testing.T) {
+		_, _, _, ok := plan(chstorage.Window{}, time.Time{}, time.Time{})
+		assert.False(t, ok)
+	})
+
+	t.Run("window selects nothing", func(t *testing.T) {
+		_, _, _, ok := plan(chstorage.Window{From: day("2026-09-01")}, mint, maxt)
+		assert.False(t, ok)
+	})
+
+	t.Run("returns one bucket per day", func(t *testing.T) {
+		days, from, to, ok := plan(chstorage.Window{From: day("2026-08-08")}, mint, maxt)
+		require.True(t, ok)
+		assert.Equal(t, day("2026-08-08"), from)
+		assert.Equal(t, maxt, to)
+		assert.Len(t, days, 4)
+	})
+}

--- a/internal/ch2storagebackend/migrator.go
+++ b/internal/ch2storagebackend/migrator.go
@@ -7,6 +7,11 @@
 // _count/_sum/_bucket{le}/{quantile} series), so each stored series is re-ingested 1:1 as a gauge
 // number point, and exponential histograms (stored natively) are reconstructed as OTLP
 // exponential-histogram datapoints. Exemplars are not migrated (the target engine drops them).
+//
+// A migration is driven one UTC day at a time. That is the unit of work, of progress reporting,
+// and of resumption: with a [Checkpoint] configured, a completed day is journalled once its data is
+// durable in the target, and a restarted run skips it. See [Estimate] for the pre-flight sizing
+// that says what a given window will cost before it is started.
 package ch2storagebackend
 
 import (
@@ -23,12 +28,22 @@ import (
 	"github.com/oteldb/oteldb/internal/tracestorage"
 )
 
+// Signal names, as recorded in the [Checkpoint] journal.
+const (
+	SignalLogs    = "logs"
+	SignalTraces  = "traces"
+	SignalMetrics = "metrics"
+)
+
 // LogsStats reports the outcome of a [Migrator.MigrateLogs] run.
 type LogsStats struct {
 	// Records is the total number of log records migrated.
 	Records int
 	// Batches is the number of batches ConsumeLogs was called with.
 	Batches int
+	// DaysDone is the number of UTC days migrated; DaysSkipped were already in the checkpoint.
+	DaysDone    int
+	DaysSkipped int
 }
 
 // TracesStats reports the outcome of a [Migrator.MigrateTraces] run.
@@ -37,6 +52,9 @@ type TracesStats struct {
 	Spans int
 	// Batches is the number of batches ConsumeTraces was called with.
 	Batches int
+	// DaysDone is the number of UTC days migrated; DaysSkipped were already in the checkpoint.
+	DaysDone    int
+	DaysSkipped int
 }
 
 // MetricsStats reports the outcome of a [Migrator.MigrateMetrics] run.
@@ -47,16 +65,21 @@ type MetricsStats struct {
 	ExpHistograms int
 	// Batches is the number of batches ConsumeMetrics was called with.
 	Batches int
+	// DaysDone is the number of UTC days migrated; DaysSkipped were already in the checkpoint.
+	DaysDone    int
+	DaysSkipped int
 }
 
 // Migrator copies data from chstorage's ClickHouse tables into a [storagebackend.Backend].
 type Migrator struct {
-	logs     *chstorage.LogsSource
-	traces   *chstorage.TracesSource
-	metrics  *chstorage.MetricsSource
-	back     *storagebackend.Backend
-	logger   *zap.Logger
-	throttle time.Duration
+	logs       *chstorage.LogsSource
+	traces     *chstorage.TracesSource
+	metrics    *chstorage.MetricsSource
+	back       *storagebackend.Backend
+	logger     *zap.Logger
+	throttle   time.Duration
+	checkpoint *Checkpoint
+	sync       func(context.Context) error
 }
 
 // Option configures a [Migrator].
@@ -69,6 +92,22 @@ type Option func(*Migrator)
 // backpressure on the write path). Zero (the default) applies no throttling.
 func WithThrottle(d time.Duration) Option {
 	return func(m *Migrator) { m.throttle = d }
+}
+
+// WithCheckpoint makes the migration resumable: completed UTC days are journalled to c and skipped
+// on a later run. Without a sync hook (see [WithSync]) a day is journalled once it has been handed
+// to the target engine, which is only as durable as the engine's own flush cadence — pair the two
+// for a resume point that cannot lose data.
+func WithCheckpoint(c *Checkpoint) Option {
+	return func(m *Migrator) { m.checkpoint = c }
+}
+
+// WithSync installs a barrier run at the end of each UTC day, before that day is marked complete.
+// It should make everything ingested so far durable in the target (for the embedded engine, flush
+// every tenant/signal head to a part). Besides making the checkpoint trustworthy, it bounds the
+// head at one day's data rather than letting it grow for the whole migration.
+func WithSync(fn func(context.Context) error) Option {
+	return func(m *Migrator) { m.sync = fn }
 }
 
 // NewMigrator creates a new [Migrator].
@@ -104,90 +143,227 @@ func (m *Migrator) sleep(ctx context.Context) error {
 	}
 }
 
-// MigrateLogs migrates log records stored in ClickHouse into the storagebackend engine,
-// converting and ingesting up to batchSize records at a time. When since is positive, only
-// the last since of data (relative to the most recent record) is migrated.
-func (m *Migrator) MigrateLogs(ctx context.Context, since time.Duration, batchSize int) (LogsStats, error) {
-	var stats LogsStats
-	err := m.logs.Do(ctx, since, batchSize, func(ctx context.Context, records []logstorage.Record) error {
-		ld := logstorage.RecordsToLogs(records)
-		if err := m.back.ConsumeLogs(ctx, ld); err != nil {
-			return errors.Wrap(err, "consume logs")
+// finishDay runs the durability barrier and journals the day as complete, in that order.
+func (m *Migrator) finishDay(ctx context.Context, signal string, day time.Time, rows int) error {
+	if m.sync != nil {
+		if err := m.sync(ctx); err != nil {
+			return errors.Wrap(err, "sync target")
 		}
-		stats.Records += len(records)
-		stats.Batches++
-		m.logger.Info("Migrated logs batch",
-			zap.Int("batch_records", len(records)),
+	}
+	if err := m.checkpoint.Mark(signal, day, rows); err != nil {
+		return errors.Wrap(err, "mark checkpoint")
+	}
+	return nil
+}
+
+// plan resolves w against a source's range and returns the day slices to scan. ok is false when
+// the source is empty or the window selects nothing.
+func plan(w chstorage.Window, mint, maxt time.Time) (days []chstorage.DayRange, from, to time.Time, ok bool) {
+	if mint.IsZero() && maxt.IsZero() {
+		return nil, from, to, false
+	}
+	from, to, ok = w.Resolve(mint, maxt)
+	if !ok {
+		return nil, from, to, false
+	}
+	return chstorage.Days(from, to), from, to, true
+}
+
+// dayLogger annotates the logger with the slice being migrated, so per-day progress lines carry
+// their position in the run.
+func dayLogger(lg *zap.Logger, day time.Time, i, total int) *zap.Logger {
+	return lg.With(
+		zap.Time("day", day),
+		zap.String("progress", formatProgress(i+1, total)),
+	)
+}
+
+// MigrateLogs migrates log records stored in ClickHouse into the storagebackend engine, one UTC day
+// at a time, converting and ingesting up to batchSize records at a time. The window w selects which
+// span of the table to migrate; the zero window migrates all of it.
+func (m *Migrator) MigrateLogs(ctx context.Context, w chstorage.Window, batchSize int) (LogsStats, error) {
+	var stats LogsStats
+
+	mint, maxt, err := m.logs.Range(ctx)
+	if err != nil {
+		return stats, errors.Wrap(err, "resolve range")
+	}
+	days, from, to, ok := plan(w, mint, maxt)
+	if !ok {
+		m.logger.Info("No logs to migrate")
+		return stats, nil
+	}
+	m.logger.Info("Migrating logs",
+		zap.Time("from", from), zap.Time("to", to), zap.Int("days", len(days)),
+	)
+
+	for i, d := range days {
+		lg := dayLogger(m.logger, d.Day, i, len(days))
+		if m.checkpoint.Done(SignalLogs, d.Day) {
+			stats.DaysSkipped++
+			lg.Info("Skipping day, already migrated")
+			continue
+		}
+
+		dayRecords := 0
+		err := m.logs.Scan(ctx, d.From, d.To, batchSize, func(ctx context.Context, records []logstorage.Record) error {
+			ld := logstorage.RecordsToLogs(records)
+			if err := m.back.ConsumeLogs(ctx, ld); err != nil {
+				return errors.Wrap(err, "consume logs")
+			}
+			dayRecords += len(records)
+			stats.Records += len(records)
+			stats.Batches++
+			return m.sleep(ctx)
+		})
+		if err != nil {
+			return stats, errors.Wrapf(err, "migrate logs %s", d.Day.Format(time.DateOnly))
+		}
+
+		if err := m.finishDay(ctx, SignalLogs, d.Day, dayRecords); err != nil {
+			return stats, errors.Wrapf(err, "finish logs %s", d.Day.Format(time.DateOnly))
+		}
+		stats.DaysDone++
+		lg.Info("Migrated day",
+			zap.Int("day_records", dayRecords),
 			zap.Int("total_records", stats.Records),
 		)
-		return m.sleep(ctx)
-	})
-	if err != nil {
-		return stats, errors.Wrap(err, "migrate logs")
 	}
 	return stats, nil
 }
 
-// MigrateTraces migrates spans stored in ClickHouse into the storagebackend engine,
-// converting and ingesting up to batchSize spans at a time. When since is positive, only
-// the last since of data (relative to the most recent span) is migrated.
-func (m *Migrator) MigrateTraces(ctx context.Context, since time.Duration, batchSize int) (TracesStats, error) {
+// MigrateTraces migrates spans stored in ClickHouse into the storagebackend engine, one UTC day at
+// a time, converting and ingesting up to batchSize spans at a time. The window w selects which span
+// of the table to migrate; the zero window migrates all of it.
+func (m *Migrator) MigrateTraces(ctx context.Context, w chstorage.Window, batchSize int) (TracesStats, error) {
 	var stats TracesStats
-	err := m.traces.Do(ctx, since, batchSize, func(ctx context.Context, spans []tracestorage.Span) error {
-		td := tracestorage.SpansToTraces(spans)
-		if err := m.back.ConsumeTraces(ctx, td); err != nil {
-			return errors.Wrap(err, "consume traces")
+
+	mint, maxt, err := m.traces.Range(ctx)
+	if err != nil {
+		return stats, errors.Wrap(err, "resolve range")
+	}
+	days, from, to, ok := plan(w, mint, maxt)
+	if !ok {
+		m.logger.Info("No traces to migrate")
+		return stats, nil
+	}
+	m.logger.Info("Migrating traces",
+		zap.Time("from", from), zap.Time("to", to), zap.Int("days", len(days)),
+	)
+
+	for i, d := range days {
+		lg := dayLogger(m.logger, d.Day, i, len(days))
+		if m.checkpoint.Done(SignalTraces, d.Day) {
+			stats.DaysSkipped++
+			lg.Info("Skipping day, already migrated")
+			continue
 		}
-		stats.Spans += len(spans)
-		stats.Batches++
-		m.logger.Info("Migrated traces batch",
-			zap.Int("batch_spans", len(spans)),
+
+		daySpans := 0
+		err := m.traces.Scan(ctx, d.From, d.To, batchSize, func(ctx context.Context, spans []tracestorage.Span) error {
+			td := tracestorage.SpansToTraces(spans)
+			if err := m.back.ConsumeTraces(ctx, td); err != nil {
+				return errors.Wrap(err, "consume traces")
+			}
+			daySpans += len(spans)
+			stats.Spans += len(spans)
+			stats.Batches++
+			return m.sleep(ctx)
+		})
+		if err != nil {
+			return stats, errors.Wrapf(err, "migrate traces %s", d.Day.Format(time.DateOnly))
+		}
+
+		if err := m.finishDay(ctx, SignalTraces, d.Day, daySpans); err != nil {
+			return stats, errors.Wrapf(err, "finish traces %s", d.Day.Format(time.DateOnly))
+		}
+		stats.DaysDone++
+		lg.Info("Migrated day",
+			zap.Int("day_spans", daySpans),
 			zap.Int("total_spans", stats.Spans),
 		)
-		return m.sleep(ctx)
-	})
-	if err != nil {
-		return stats, errors.Wrap(err, "migrate traces")
 	}
 	return stats, nil
 }
 
-// MigrateMetrics migrates metrics stored in ClickHouse into the storagebackend engine. Decomposed
-// number series (gauges/sums and histogram/summary components) are ingested verbatim as gauge
-// datapoints; exponential histograms are reconstructed natively. When since is positive, only the
-// last since of data (relative to the most recent point) is migrated.
-func (m *Migrator) MigrateMetrics(ctx context.Context, since time.Duration, batchSize int) (MetricsStats, error) {
+// MigrateMetrics migrates metrics stored in ClickHouse into the storagebackend engine, one UTC day
+// at a time. Decomposed number series (gauges/sums and histogram/summary components) are ingested
+// verbatim as gauge datapoints; exponential histograms are reconstructed natively. The window w
+// selects which span of the tables to migrate; the zero window migrates all of them.
+func (m *Migrator) MigrateMetrics(ctx context.Context, w chstorage.Window, batchSize int) (MetricsStats, error) {
 	var stats MetricsStats
-	err := m.metrics.Do(ctx, since, batchSize,
-		func(ctx context.Context, points []metricstorage.NumberPoint) error {
+
+	mint, maxt, err := m.metrics.Range(ctx)
+	if err != nil {
+		return stats, errors.Wrap(err, "resolve range")
+	}
+	days, from, to, ok := plan(w, mint, maxt)
+	if !ok {
+		m.logger.Info("No metrics to migrate")
+		return stats, nil
+	}
+
+	// The series set is loaded once for the whole window: it is small relative to the point volume,
+	// and reloading it per day would re-read metrics_timeseries for every day of the run.
+	scan, err := m.metrics.Prepare(ctx, from, to)
+	if err != nil {
+		return stats, errors.Wrap(err, "prepare metrics scan")
+	}
+	m.logger.Info("Migrating metrics",
+		zap.Time("from", from), zap.Time("to", to),
+		zap.Int("days", len(days)), zap.Int("series", scan.Series()),
+	)
+
+	for i, d := range days {
+		lg := dayLogger(m.logger, d.Day, i, len(days))
+		if m.checkpoint.Done(SignalMetrics, d.Day) {
+			stats.DaysSkipped++
+			lg.Info("Skipping day, already migrated")
+			continue
+		}
+
+		dayPoints := 0
+		err := scan.ScanNumbers(ctx, d.From, d.To, batchSize, func(ctx context.Context, points []metricstorage.NumberPoint) error {
 			md := metricstorage.NumberPointsToMetrics(points)
 			if err := m.back.ConsumeMetrics(ctx, md); err != nil {
 				return errors.Wrap(err, "consume metrics")
 			}
+			dayPoints += len(points)
 			stats.Points += len(points)
 			stats.Batches++
-			m.logger.Info("Migrated metric points batch",
-				zap.Int("batch_points", len(points)),
-				zap.Int("total_points", stats.Points),
-			)
 			return m.sleep(ctx)
-		},
-		func(ctx context.Context, points []metricstorage.ExpHistogramPoint) error {
+		})
+		if err != nil {
+			return stats, errors.Wrapf(err, "migrate number points %s", d.Day.Format(time.DateOnly))
+		}
+
+		err = scan.ScanExpHistograms(ctx, d.From, d.To, batchSize, func(ctx context.Context, points []metricstorage.ExpHistogramPoint) error {
 			md := metricstorage.ExpHistogramsToMetrics(points)
 			if err := m.back.ConsumeMetrics(ctx, md); err != nil {
 				return errors.Wrap(err, "consume exp histograms")
 			}
+			dayPoints += len(points)
 			stats.ExpHistograms += len(points)
 			stats.Batches++
-			m.logger.Info("Migrated exp histograms batch",
-				zap.Int("batch_points", len(points)),
-				zap.Int("total_exp_histograms", stats.ExpHistograms),
-			)
 			return m.sleep(ctx)
-		},
-	)
-	if err != nil {
-		return stats, errors.Wrap(err, "migrate metrics")
+		})
+		if err != nil {
+			return stats, errors.Wrapf(err, "migrate exp histograms %s", d.Day.Format(time.DateOnly))
+		}
+
+		if err := m.finishDay(ctx, SignalMetrics, d.Day, dayPoints); err != nil {
+			return stats, errors.Wrapf(err, "finish metrics %s", d.Day.Format(time.DateOnly))
+		}
+		stats.DaysDone++
+		lg.Info("Migrated day",
+			zap.Int("day_points", dayPoints),
+			zap.Int("total_points", stats.Points),
+			zap.Int("total_exp_histograms", stats.ExpHistograms),
+		)
+	}
+
+	if missing := scan.Missing(); missing > 0 {
+		m.logger.Warn("Skipped points with no matching series", zap.Int("count", missing))
 	}
 	return stats, nil
 }

--- a/internal/ch2storagebackend/migrator.go
+++ b/internal/ch2storagebackend/migrator.go
@@ -1,6 +1,10 @@
 // Package ch2storagebackend migrates data out of chstorage's ClickHouse tables into the
 // embedded storagebackend engine, by scanning ClickHouse directly (bypassing chstorage's
-// selector-oriented queriers) and re-ingesting the decoded records as OTLP pdata.
+// selector-oriented queriers) and re-ingesting the decoded rows.
+//
+// Rows are converted straight into the engine's native signal types (see convert.go). The one
+// exception is exponential histograms, which go through OTLP pdata because the engine decomposes
+// them into classic bucket series inside its own bridge.
 //
 // Logs, traces, and metrics are supported. Metrics are migrated verbatim: chstorage already
 // stores them as decomposed Prometheus-style series (histograms/summaries exploded into
@@ -39,7 +43,7 @@ const (
 type LogsStats struct {
 	// Records is the total number of log records migrated.
 	Records int
-	// Batches is the number of batches ConsumeLogs was called with.
+	// Batches is the number of batches written to the target.
 	Batches int
 	// DaysDone is the number of UTC days migrated; DaysSkipped were already in the checkpoint.
 	DaysDone    int
@@ -50,7 +54,7 @@ type LogsStats struct {
 type TracesStats struct {
 	// Spans is the total number of spans migrated.
 	Spans int
-	// Batches is the number of batches ConsumeTraces was called with.
+	// Batches is the number of batches written to the target.
 	Batches int
 	// DaysDone is the number of UTC days migrated; DaysSkipped were already in the checkpoint.
 	DaysDone    int
@@ -63,7 +67,7 @@ type MetricsStats struct {
 	Points int
 	// ExpHistograms is the total number of exponential-histogram datapoints migrated.
 	ExpHistograms int
-	// Batches is the number of batches ConsumeMetrics was called with.
+	// Batches is the number of batches written to the target.
 	Batches int
 	// DaysDone is the number of UTC days migrated; DaysSkipped were already in the checkpoint.
 	DaysDone    int
@@ -80,12 +84,15 @@ type Migrator struct {
 	throttle   time.Duration
 	checkpoint *Checkpoint
 	sync       func(context.Context) error
+	// attrs memoizes attribute-set projections across the whole migration (see convert.go). It is
+	// shared by every signal: a resource attribute set is typically common to all of them.
+	attrs *attrConv
 }
 
 // Option configures a [Migrator].
 type Option func(*Migrator)
 
-// WithThrottle sleeps d after every ConsumeLogs/ConsumeTraces batch. A bulk migration can
+// WithThrottle sleeps d after every ingested batch. A bulk migration can
 // ingest orders of magnitude faster than the storage engine's background flush/compaction
 // loop can drain, so without a cap the head grows unbounded in RAM until the process OOMs
 // (see [storagebackend], the FlushInterval/FlushThresholdBytes options alone do not apply
@@ -121,6 +128,7 @@ func NewMigrator(client chstorage.ClickHouseClient, tables chstorage.Tables, bac
 		metrics: chstorage.NewMetricsSource(client, tables, logger.Named("metrics_source")),
 		back:    back,
 		logger:  logger,
+		attrs:   newAttrConv(),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -207,9 +215,8 @@ func (m *Migrator) MigrateLogs(ctx context.Context, w chstorage.Window, batchSiz
 
 		dayRecords := 0
 		err := m.logs.Scan(ctx, d.From, d.To, batchSize, func(ctx context.Context, records []logstorage.Record) error {
-			ld := logstorage.RecordsToLogs(records)
-			if err := m.back.ConsumeLogs(ctx, ld); err != nil {
-				return errors.Wrap(err, "consume logs")
+			if err := m.back.WriteLogs(ctx, ConvertLogs(records, m.attrs)); err != nil {
+				return errors.Wrap(err, "write logs")
 			}
 			dayRecords += len(records)
 			stats.Records += len(records)
@@ -261,9 +268,8 @@ func (m *Migrator) MigrateTraces(ctx context.Context, w chstorage.Window, batchS
 
 		daySpans := 0
 		err := m.traces.Scan(ctx, d.From, d.To, batchSize, func(ctx context.Context, spans []tracestorage.Span) error {
-			td := tracestorage.SpansToTraces(spans)
-			if err := m.back.ConsumeTraces(ctx, td); err != nil {
-				return errors.Wrap(err, "consume traces")
+			if err := m.back.WriteTraces(ctx, ConvertTraces(spans, m.attrs)); err != nil {
+				return errors.Wrap(err, "write traces")
 			}
 			daySpans += len(spans)
 			stats.Spans += len(spans)
@@ -324,9 +330,8 @@ func (m *Migrator) MigrateMetrics(ctx context.Context, w chstorage.Window, batch
 
 		dayPoints := 0
 		err := scan.ScanNumbers(ctx, d.From, d.To, batchSize, func(ctx context.Context, points []metricstorage.NumberPoint) error {
-			md := metricstorage.NumberPointsToMetrics(points)
-			if err := m.back.ConsumeMetrics(ctx, md); err != nil {
-				return errors.Wrap(err, "consume metrics")
+			if err := m.back.WriteMetrics(ctx, ConvertNumberPoints(points, m.attrs)); err != nil {
+				return errors.Wrap(err, "write metrics")
 			}
 			dayPoints += len(points)
 			stats.Points += len(points)

--- a/internal/chstorage/bridge.go
+++ b/internal/chstorage/bridge.go
@@ -1,28 +1,212 @@
 package chstorage
 
-import "time"
+import (
+	"context"
+	"slices"
+	"time"
 
-// forEachDayBucket calls fn for each UTC-day-aligned window covering [mint, maxt]. Day-aligning
-// keeps each scan inside a single daily table partition; the first bucket's lower bound is clamped
-// to mint so a `since`-limited window skips the early part of its first day instead of scanning the
-// whole calendar day.
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/oteldb/internal/chstorage/chsql"
+)
+
+// Window bounds a migration scan in time. The zero Window covers the source table's whole range.
+//
+// From/To are absolute bounds. Since is an alternative lower bound, used only when From is zero:
+// it starts the scan Since before the effective upper bound, which expresses "the last 24h"
+// without having to know the table's max timestamp up front.
+type Window struct {
+	From  time.Time
+	To    time.Time
+	Since time.Duration
+}
+
+// Resolve intersects w with a source's [mint, maxt] range and returns the effective scan bounds.
+// ok is false when the intersection is empty, meaning there is nothing to scan.
+func (w Window) Resolve(mint, maxt time.Time) (from, to time.Time, ok bool) {
+	from, to = mint, maxt
+	if !w.To.IsZero() && w.To.Before(to) {
+		to = w.To
+	}
+	switch {
+	case !w.From.IsZero():
+		if w.From.After(from) {
+			from = w.From
+		}
+	case w.Since > 0:
+		if cut := to.Add(-w.Since); cut.After(from) {
+			from = cut
+		}
+	}
+	if from.After(to) {
+		return from, to, false
+	}
+	return from, to, true
+}
+
+// DayRange is one UTC-day-aligned scan bucket. Day is the day's start (the stable identity a
+// migration checkpoints against); From/To are the bounds actually scanned, which may be narrower
+// than the whole day at the edges of the requested window.
+type DayRange struct {
+	Day  time.Time
+	From time.Time
+	To   time.Time
+}
+
+// Days returns the UTC-day-aligned buckets covering [mint, maxt]. Day-aligning keeps each scan
+// inside a single daily table partition; the first bucket's lower bound is clamped to mint so a
+// windowed scan skips the early part of its first day instead of scanning the whole calendar day.
 //
 // Only the lower bound is clamped. The upper bound stays at the day's end because mint/maxt come
 // from queryMinMaxTimestamp, which floors to whole seconds (toDateTime): clamping the top to a
 // floored maxt would drop any sub-second data in maxt's final second. Since no data exists past the
 // true max, a full-day upper bound reads the same rows without that risk.
-func forEachDayBucket(mint, maxt time.Time, fn func(from, to time.Time) error) error {
+func Days(mint, maxt time.Time) []DayRange {
 	const step = 24 * time.Hour
-	start := mint.Truncate(step)
-	end := maxt.Truncate(step).Add(step)
+
+	var (
+		out   []DayRange
+		start = mint.Truncate(step)
+		end   = maxt.Truncate(step).Add(step)
+	)
 	for ts := start; ts.Before(end); ts = ts.Add(step) {
 		from, to := ts, ts.Add(step)
 		if from.Before(mint) {
 			from = mint
 		}
-		if err := fn(from, to); err != nil {
-			return err
+		out = append(out, DayRange{Day: ts, From: from, To: to})
+	}
+	return out
+}
+
+// DayCount is the row count of one UTC day of a source table.
+type DayCount struct {
+	Day  time.Time
+	Rows uint64
+}
+
+// mergeDayCounts sums per-day counts from several tables into one ascending series.
+func mergeDayCounts(sets ...[]DayCount) []DayCount {
+	total := map[time.Time]uint64{}
+	for _, set := range sets {
+		for _, c := range set {
+			total[c.Day] += c.Rows
 		}
 	}
-	return nil
+
+	out := make([]DayCount, 0, len(total))
+	for day, rows := range total {
+		out = append(out, DayCount{Day: day, Rows: rows})
+	}
+	slices.SortFunc(out, func(a, b DayCount) int { return a.Day.Compare(b.Day) })
+	return out
+}
+
+// dayCounts groups a table's rows in [from, to] by UTC day. It is the pre-flight sizing query: a
+// grouped count reads only the timestamp column, so it is orders of magnitude cheaper than the
+// scan it estimates.
+func dayCounts(
+	ctx context.Context,
+	client ClickHouseClient,
+	table, column string,
+	prec proto.Precision,
+	from, to time.Time,
+) ([]DayCount, error) {
+	var (
+		dayCol   proto.ColDateTime
+		countCol proto.ColUInt64
+		day      = chsql.Function("toStartOfDay", chsql.Ident(column))
+	)
+
+	query := chsql.Select(table,
+		chsql.ResultColumn{Name: "day", Expr: day, Data: &dayCol},
+		chsql.ResultColumn{Name: "rows", Expr: chsql.Count(), Data: &countCol},
+	).
+		Where(chsql.InTimeRange(column, from, to, prec)).
+		GroupBy(day).
+		Order(chsql.Ident("day"), chsql.Asc)
+
+	var out []DayCount
+	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
+		for i := range dayCol.Rows() {
+			out = append(out, DayCount{
+				Day:  dayCol.Row(i).UTC(),
+				Rows: countCol.Row(i),
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "prepare query")
+	}
+	if err := client.Do(ctx, chq); err != nil {
+		return nil, errors.Wrap(err, "execute query")
+	}
+	return out, nil
+}
+
+// TableSize is a source table's on-disk footprint, as ClickHouse accounts it over active parts.
+//
+// Compressed is what the data occupies today; Uncompressed is the logical size of the same rows.
+// The two differ by an order of magnitude on telemetry, so a migration estimate must say which one
+// it is quoting — and neither predicts what the *target* engine will write, since it applies its
+// own codecs.
+type TableSize struct {
+	Rows              uint64
+	CompressedBytes   uint64
+	UncompressedBytes uint64
+}
+
+// BytesPerRow returns the table's average compressed and uncompressed bytes per row, or zeroes
+// when the table is empty.
+func (s TableSize) BytesPerRow() (compressed, uncompressed float64) {
+	if s.Rows == 0 {
+		return 0, 0
+	}
+	return float64(s.CompressedBytes) / float64(s.Rows), float64(s.UncompressedBytes) / float64(s.Rows)
+}
+
+// tableSize reads a table's active-part totals from system.parts. The table name is matched within
+// the connection's current database, so it works regardless of which database the DSN selects.
+func tableSize(ctx context.Context, client ClickHouseClient, table string) (TableSize, error) {
+	var (
+		rows         proto.ColUInt64
+		compressed   proto.ColUInt64
+		uncompressed proto.ColUInt64
+	)
+
+	sum := func(column string) chsql.Expr {
+		return chsql.Function("sum", chsql.Ident(column))
+	}
+	query := chsql.Select("system.parts",
+		chsql.ResultColumn{Name: "rows", Expr: sum("rows"), Data: &rows},
+		chsql.ResultColumn{Name: "compressed", Expr: sum("data_compressed_bytes"), Data: &compressed},
+		chsql.ResultColumn{Name: "uncompressed", Expr: sum("data_uncompressed_bytes"), Data: &uncompressed},
+	).
+		Where(
+			chsql.Eq(chsql.Ident("database"), chsql.Function("currentDatabase")),
+			chsql.Eq(chsql.Ident("table"), chsql.String(table)),
+			chsql.Ident("active"),
+		)
+
+	var out TableSize
+	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
+		if rows.Rows() == 0 {
+			return nil
+		}
+		out = TableSize{
+			Rows:              rows.Row(0),
+			CompressedBytes:   compressed.Row(0),
+			UncompressedBytes: uncompressed.Row(0),
+		}
+		return nil
+	})
+	if err != nil {
+		return out, errors.Wrap(err, "prepare query")
+	}
+	if err := client.Do(ctx, chq); err != nil {
+		return out, errors.Wrap(err, "execute query")
+	}
+	return out, nil
 }

--- a/internal/chstorage/bridge_logs.go
+++ b/internal/chstorage/bridge_logs.go
@@ -12,13 +12,14 @@ import (
 	"github.com/oteldb/oteldb/internal/logstorage"
 )
 
-// LogsBatchFunc is called with each decoded batch of records read by [LogsSource.Do].
+// LogsBatchFunc is called with each decoded batch of records read by [LogsSource.Scan].
 type LogsBatchFunc func(ctx context.Context, records []logstorage.Record) error
 
 // LogsSource reads every log record stored in ClickHouse, decoded as [logstorage.Record],
 // for migrating them into another storage engine. Unlike [Querier], it performs a full
-// table scan with no selector pushdown, day-bucketed like [Backup] so a single scan never
-// buffers more than one day's worth of rows in ClickHouse at a time.
+// table scan with no selector pushdown. Callers drive it one UTC day at a time (see [Days]),
+// so a single scan never buffers more than one day's worth of rows in ClickHouse — and so a
+// migration can checkpoint its progress at a day boundary.
 type LogsSource struct {
 	client ClickHouseClient
 	table  string
@@ -37,34 +38,28 @@ func NewLogsSource(client ClickHouseClient, tables Tables, logger *zap.Logger) *
 	}
 }
 
-// Do scans every log record in the table, in day-bucket then timestamp order, invoking
-// batchFn with batches of up to batchSize records. When since is positive, the scan is
-// restricted to the last since of data, relative to the table's most recent timestamp,
-// instead of the full table.
-func (s *LogsSource) Do(ctx context.Context, since time.Duration, batchSize int, batchFn LogsBatchFunc) error {
+// Range returns the timestamp bounds of the stored records. Both are zero when the table is empty.
+func (s *LogsSource) Range(ctx context.Context) (mint, maxt time.Time, _ error) {
 	mint, maxt, err := queryMinMaxTimestamp(ctx, s.client, [2]string{s.table, "timestamp"})
 	if err != nil {
-		return errors.Wrap(err, "query min/max timestamp")
+		return mint, maxt, errors.Wrap(err, "query min/max timestamp")
 	}
-	if mint.IsZero() && maxt.IsZero() {
-		s.logger.Info("No logs to migrate")
-		return nil
-	}
-	if since > 0 {
-		if cut := maxt.Add(-since); cut.After(mint) {
-			mint = cut
-		}
-	}
-
-	return forEachDayBucket(mint, maxt, func(from, to time.Time) error {
-		if err := s.scanDay(ctx, from, to, batchSize, batchFn); err != nil {
-			return errors.Wrapf(err, "scan %s", from)
-		}
-		return nil
-	})
+	return mint, maxt, nil
 }
 
-func (s *LogsSource) scanDay(ctx context.Context, start, end time.Time, batchSize int, batchFn LogsBatchFunc) error {
+// Counts returns the per-UTC-day record counts within [from, to].
+func (s *LogsSource) Counts(ctx context.Context, from, to time.Time) ([]DayCount, error) {
+	return dayCounts(ctx, s.client, s.table, "timestamp", proto.PrecisionNano, from, to)
+}
+
+// Size returns the table's active-part footprint, for pre-flight sizing.
+func (s *LogsSource) Size(ctx context.Context) (TableSize, error) {
+	return tableSize(ctx, s.client, s.table)
+}
+
+// Scan reads the records in [from, to] in timestamp order, invoking batchFn with batches of up to
+// batchSize records.
+func (s *LogsSource) Scan(ctx context.Context, from, to time.Time, batchSize int, batchFn LogsBatchFunc) error {
 	var (
 		lc  = newLogColumns()
 		buf []logstorage.Record
@@ -82,7 +77,7 @@ func (s *LogsSource) scanDay(ctx context.Context, start, end time.Time, batchSiz
 	}
 
 	query := chsql.Select(s.table, lc.ChsqlResult()...).
-		Where(chsql.InTimeRange("timestamp", start, end, proto.PrecisionNano))
+		Where(chsql.InTimeRange("timestamp", from, to, proto.PrecisionNano))
 
 	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
 		// The decoded columns accumulate across blocks (ch-go appends, it never resets),

--- a/internal/chstorage/bridge_metrics.go
+++ b/internal/chstorage/bridge_metrics.go
@@ -13,7 +13,7 @@ import (
 	"github.com/oteldb/oteldb/internal/otelstorage"
 )
 
-// NumberPointsBatchFunc is called with each decoded batch of number points read by [MetricsSource].
+// NumberPointsBatchFunc is called with each decoded batch of number points read by [MetricsScan].
 type NumberPointsBatchFunc func(ctx context.Context, points []metricstorage.NumberPoint) error
 
 // ExpHistogramsBatchFunc is called with each decoded batch of exponential histograms.
@@ -31,12 +31,13 @@ type seriesMeta struct {
 	resource    otelstorage.Attrs
 }
 
-// MetricsSource reads metrics stored in ClickHouse for migration into another storage engine. It
-// first loads the series set from metrics_timeseries (small relative to the point volume) into an
-// in-memory hash→[seriesMeta] map, then day-bucket scans metrics_points and metrics_exp_histograms
-// (mirroring [Backup]) and resolves each row's series by hash. Exemplars are not read (the target
-// engine drops them). metrics_labels is not read (it is an autocomplete index, deriving nothing
-// the timeseries rows do not already carry).
+// MetricsSource reads metrics stored in ClickHouse for migration into another storage engine.
+// Scanning is two-staged: [MetricsSource.Prepare] loads the series set from metrics_timeseries
+// (small relative to the point volume) into an in-memory hash→[seriesMeta] map, and the returned
+// [MetricsScan] then reads metrics_points and metrics_exp_histograms a day at a time, resolving
+// each row's series by hash. Exemplars are not read (the target engine drops them).
+// metrics_labels is not read (it is an autocomplete index, deriving nothing the timeseries rows do
+// not already carry).
 type MetricsSource struct {
 	client     ClickHouseClient
 	timeseries string
@@ -59,52 +60,74 @@ func NewMetricsSource(client ClickHouseClient, tables Tables, logger *zap.Logger
 	}
 }
 
-// Do migrates metrics: it loads the series set (restricted to the scan window when since is
-// positive), then scans number points and exponential histograms, invoking numberFn and expFn
-// with batches of up to batchSize decoded points. Rows whose hash is absent from the series set
-// are skipped and counted (logged at the end).
-func (s *MetricsSource) Do(
-	ctx context.Context,
-	since time.Duration,
-	batchSize int,
-	numberFn NumberPointsBatchFunc,
-	expFn ExpHistogramsBatchFunc,
-) error {
+// Range returns the timestamp bounds across both point tables. Both are zero when they are empty.
+func (s *MetricsSource) Range(ctx context.Context) (mint, maxt time.Time, _ error) {
 	mint, maxt, err := queryMinMaxTimestamp(ctx, s.client,
 		[2]string{s.points, "timestamp"},
 		[2]string{s.expHistos, "timestamp"},
 	)
 	if err != nil {
-		return errors.Wrap(err, "query min/max timestamp")
+		return mint, maxt, errors.Wrap(err, "query min/max timestamp")
 	}
-	if mint.IsZero() && maxt.IsZero() {
-		s.logger.Info("No metrics to migrate")
-		return nil
-	}
-	if since > 0 {
-		if cut := maxt.Add(-since); cut.After(mint) {
-			mint = cut
-		}
-	}
+	return mint, maxt, nil
+}
 
+// Counts returns the per-UTC-day point counts within [from, to], summing both point tables.
+func (s *MetricsSource) Counts(ctx context.Context, from, to time.Time) ([]DayCount, error) {
+	numbers, err := dayCounts(ctx, s.client, s.points, "timestamp", proto.PrecisionMilli, from, to)
+	if err != nil {
+		return nil, errors.Wrap(err, "count number points")
+	}
+	exp, err := dayCounts(ctx, s.client, s.expHistos, "timestamp", proto.PrecisionMilli, from, to)
+	if err != nil {
+		return nil, errors.Wrap(err, "count exp histograms")
+	}
+	return mergeDayCounts(numbers, exp), nil
+}
+
+// Size returns the combined active-part footprint of both point tables, for pre-flight sizing.
+func (s *MetricsSource) Size(ctx context.Context) (TableSize, error) {
+	numbers, err := tableSize(ctx, s.client, s.points)
+	if err != nil {
+		return TableSize{}, errors.Wrap(err, "size number points")
+	}
+	exp, err := tableSize(ctx, s.client, s.expHistos)
+	if err != nil {
+		return TableSize{}, errors.Wrap(err, "size exp histograms")
+	}
+	return TableSize{
+		Rows:              numbers.Rows + exp.Rows,
+		CompressedBytes:   numbers.CompressedBytes + exp.CompressedBytes,
+		UncompressedBytes: numbers.UncompressedBytes + exp.UncompressedBytes,
+	}, nil
+}
+
+// MetricsScan is a prepared metrics scan: the series set for a time range, plus the day-at-a-time
+// readers over the point tables. Obtain it from [MetricsSource.Prepare]. It is not safe for
+// concurrent use.
+type MetricsScan struct {
+	src     *MetricsSource
+	series  map[[16]byte]seriesMeta
+	missing int
+}
+
+// Prepare loads the series set covering [mint, maxt] — series whose [first_seen, last_seen]
+// overlaps the range — and returns a scan bound to it.
+func (s *MetricsSource) Prepare(ctx context.Context, mint, maxt time.Time) (*MetricsScan, error) {
 	series, err := s.loadSeries(ctx, mint, maxt)
 	if err != nil {
-		return errors.Wrap(err, "load series")
+		return nil, errors.Wrap(err, "load series")
 	}
 	s.logger.Info("Loaded metric series", zap.Int("series", len(series)))
-
-	var missing int
-	if err := s.scanNumberPoints(ctx, series, mint, maxt, batchSize, &missing, numberFn); err != nil {
-		return errors.Wrap(err, "scan number points")
-	}
-	if err := s.scanExpHistograms(ctx, series, mint, maxt, batchSize, &missing, expFn); err != nil {
-		return errors.Wrap(err, "scan exp histograms")
-	}
-	if missing > 0 {
-		s.logger.Warn("Skipped points with no matching series", zap.Int("count", missing))
-	}
-	return nil
+	return &MetricsScan{src: s, series: series}, nil
 }
+
+// Series returns the number of series loaded for the scan.
+func (m *MetricsScan) Series() int { return len(m.series) }
+
+// Missing returns the running count of points skipped because their hash was absent from the
+// series set.
+func (m *MetricsScan) Missing() int { return m.missing }
 
 // loadSeries reads metrics_timeseries into a hash→meta map, restricted to series whose
 // [first_seen, last_seen] overlaps [mint, maxt].
@@ -141,30 +164,10 @@ func (s *MetricsSource) loadSeries(ctx context.Context, mint, maxt time.Time) (m
 	return out, nil
 }
 
-func (s *MetricsSource) scanNumberPoints(
-	ctx context.Context,
-	series map[[16]byte]seriesMeta,
-	mint, maxt time.Time,
-	batchSize int,
-	missing *int,
-	fn NumberPointsBatchFunc,
-) error {
-	return forEachDayBucket(mint, maxt, func(from, to time.Time) error {
-		if err := s.scanNumberDay(ctx, series, from, to, batchSize, missing, fn); err != nil {
-			return errors.Wrapf(err, "scan %s", from)
-		}
-		return nil
-	})
-}
-
-func (s *MetricsSource) scanNumberDay(
-	ctx context.Context,
-	series map[[16]byte]seriesMeta,
-	start, end time.Time,
-	batchSize int,
-	missing *int,
-	fn NumberPointsBatchFunc,
-) error {
+// ScanNumbers reads the number points in [from, to], invoking fn with batches of up to batchSize
+// decoded points. Rows whose hash is absent from the series set are skipped and counted
+// (see [MetricsScan.Missing]).
+func (m *MetricsScan) ScanNumbers(ctx context.Context, from, to time.Time, batchSize int, fn NumberPointsBatchFunc) error {
 	var (
 		c   = newPointColumns()
 		buf []metricstorage.NumberPoint
@@ -181,15 +184,15 @@ func (s *MetricsSource) scanNumberDay(
 		return nil
 	}
 
-	query := chsql.Select(s.points, c.ChsqlResult()...).
-		Where(chsql.InTimeRange("timestamp", start, end, proto.PrecisionMilli))
+	query := chsql.Select(m.src.points, c.ChsqlResult()...).
+		Where(chsql.InTimeRange("timestamp", from, to, proto.PrecisionMilli))
 
 	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
 		defer c.Columns().Reset()
 		for i := 0; i < c.timestamp.Rows(); i++ {
-			meta, ok := series[c.hash.Row(i)]
+			meta, ok := m.series[c.hash.Row(i)]
 			if !ok {
-				*missing++
+				m.missing++
 				continue
 			}
 			buf = append(buf, metricstorage.NumberPoint{
@@ -213,36 +216,15 @@ func (s *MetricsSource) scanNumberDay(
 	if err != nil {
 		return errors.Wrap(err, "prepare query")
 	}
-	if err := s.client.Do(ctx, chq); err != nil {
+	if err := m.src.client.Do(ctx, chq); err != nil {
 		return errors.Wrap(err, "execute query")
 	}
 	return flush(ctx)
 }
 
-func (s *MetricsSource) scanExpHistograms(
-	ctx context.Context,
-	series map[[16]byte]seriesMeta,
-	mint, maxt time.Time,
-	batchSize int,
-	missing *int,
-	fn ExpHistogramsBatchFunc,
-) error {
-	return forEachDayBucket(mint, maxt, func(from, to time.Time) error {
-		if err := s.scanExpDay(ctx, series, from, to, batchSize, missing, fn); err != nil {
-			return errors.Wrapf(err, "scan %s", from)
-		}
-		return nil
-	})
-}
-
-func (s *MetricsSource) scanExpDay(
-	ctx context.Context,
-	series map[[16]byte]seriesMeta,
-	start, end time.Time,
-	batchSize int,
-	missing *int,
-	fn ExpHistogramsBatchFunc,
-) error {
+// ScanExpHistograms reads the exponential-histogram points in [from, to], invoking fn with batches
+// of up to batchSize decoded points.
+func (m *MetricsScan) ScanExpHistograms(ctx context.Context, from, to time.Time, batchSize int, fn ExpHistogramsBatchFunc) error {
 	var (
 		c   = newExpHistogramColumns()
 		buf []metricstorage.ExpHistogramPoint
@@ -266,15 +248,15 @@ func (s *MetricsSource) scanExpDay(
 		return &v.Value
 	}
 
-	query := chsql.Select(s.expHistos, c.ChsqlResult()...).
-		Where(chsql.InTimeRange("timestamp", start, end, proto.PrecisionMilli))
+	query := chsql.Select(m.src.expHistos, c.ChsqlResult()...).
+		Where(chsql.InTimeRange("timestamp", from, to, proto.PrecisionMilli))
 
 	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
 		defer c.Columns().Reset()
 		for i := 0; i < c.timestamp.Rows(); i++ {
-			meta, ok := series[c.hash.Row(i)]
+			meta, ok := m.series[c.hash.Row(i)]
 			if !ok {
-				*missing++
+				m.missing++
 				continue
 			}
 			buf = append(buf, metricstorage.ExpHistogramPoint{
@@ -308,7 +290,7 @@ func (s *MetricsSource) scanExpDay(
 	if err != nil {
 		return errors.Wrap(err, "prepare query")
 	}
-	if err := s.client.Do(ctx, chq); err != nil {
+	if err := m.src.client.Do(ctx, chq); err != nil {
 		return errors.Wrap(err, "execute query")
 	}
 	return flush(ctx)

--- a/internal/chstorage/bridge_test.go
+++ b/internal/chstorage/bridge_test.go
@@ -1,0 +1,195 @@
+package chstorage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func day(s string) time.Time {
+	t, err := time.ParseInLocation(time.DateOnly, s, time.UTC)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func ts(s string) time.Time {
+	t, err := time.ParseInLocation(time.DateTime, s, time.UTC)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestWindowResolve(t *testing.T) {
+	var (
+		mint = ts("2026-08-05 04:00:00")
+		maxt = ts("2026-08-11 20:00:00")
+	)
+
+	tests := []struct {
+		name       string
+		window     Window
+		wantFrom   time.Time
+		wantTo     time.Time
+		wantNoData bool
+	}{
+		{
+			name:     "zero window covers the source range",
+			window:   Window{},
+			wantFrom: mint,
+			wantTo:   maxt,
+		},
+		{
+			name:     "from clamps up",
+			window:   Window{From: day("2026-08-08")},
+			wantFrom: day("2026-08-08"),
+			wantTo:   maxt,
+		},
+		{
+			name:     "from before the source range is ignored",
+			window:   Window{From: day("2026-01-01")},
+			wantFrom: mint,
+			wantTo:   maxt,
+		},
+		{
+			name:     "to clamps down",
+			window:   Window{To: day("2026-08-09")},
+			wantFrom: mint,
+			wantTo:   day("2026-08-09"),
+		},
+		{
+			name:     "to after the source range is ignored",
+			window:   Window{To: day("2027-01-01")},
+			wantFrom: mint,
+			wantTo:   maxt,
+		},
+		{
+			name:     "from and to bound both ends",
+			window:   Window{From: day("2026-08-07"), To: day("2026-08-09")},
+			wantFrom: day("2026-08-07"),
+			wantTo:   day("2026-08-09"),
+		},
+		{
+			name:     "since counts back from the upper bound",
+			window:   Window{Since: 24 * time.Hour},
+			wantFrom: ts("2026-08-10 20:00:00"),
+			wantTo:   maxt,
+		},
+		{
+			// Since is relative to the *effective* upper bound, so it composes with -to.
+			name:     "since composes with to",
+			window:   Window{To: day("2026-08-09"), Since: 24 * time.Hour},
+			wantFrom: day("2026-08-08"),
+			wantTo:   day("2026-08-09"),
+		},
+		{
+			name:     "from wins over since",
+			window:   Window{From: day("2026-08-06"), Since: time.Hour},
+			wantFrom: day("2026-08-06"),
+			wantTo:   maxt,
+		},
+		{
+			name:     "since longer than the range keeps the range",
+			window:   Window{Since: 365 * 24 * time.Hour},
+			wantFrom: mint,
+			wantTo:   maxt,
+		},
+		{
+			name:       "window entirely after the source range selects nothing",
+			window:     Window{From: day("2026-09-01")},
+			wantNoData: true,
+		},
+		{
+			name:       "window entirely before the source range selects nothing",
+			window:     Window{To: day("2026-01-01")},
+			wantNoData: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, to, ok := tt.window.Resolve(mint, maxt)
+			if tt.wantNoData {
+				assert.False(t, ok)
+				return
+			}
+			require.True(t, ok)
+			assert.Equal(t, tt.wantFrom, from, "from")
+			assert.Equal(t, tt.wantTo, to, "to")
+		})
+	}
+}
+
+func TestDays(t *testing.T) {
+	t.Run("clamps the lower bound but not the upper", func(t *testing.T) {
+		days := Days(ts("2026-08-05 04:00:00"), ts("2026-08-07 20:00:00"))
+		require.Len(t, days, 3)
+
+		// First bucket starts at mint, not at midnight: a windowed scan must not re-read the
+		// earlier part of its first day.
+		assert.Equal(t, day("2026-08-05"), days[0].Day)
+		assert.Equal(t, ts("2026-08-05 04:00:00"), days[0].From)
+		assert.Equal(t, day("2026-08-06"), days[0].To)
+
+		assert.Equal(t, day("2026-08-06"), days[1].From)
+		assert.Equal(t, day("2026-08-07"), days[1].To)
+
+		// Last bucket runs to the day's end, past maxt, because maxt is floored to whole seconds
+		// upstream and clamping would drop sub-second data.
+		assert.Equal(t, day("2026-08-08"), days[2].To)
+	})
+
+	t.Run("day identity is midnight even when the scan is partial", func(t *testing.T) {
+		days := Days(ts("2026-08-05 04:00:00"), ts("2026-08-05 06:00:00"))
+		require.Len(t, days, 1)
+		assert.Equal(t, day("2026-08-05"), days[0].Day)
+		assert.Equal(t, ts("2026-08-05 04:00:00"), days[0].From)
+	})
+
+	t.Run("covers every day of a week", func(t *testing.T) {
+		days := Days(day("2026-08-05"), ts("2026-08-11 23:59:59"))
+		require.Len(t, days, 7)
+		for i, d := range days {
+			assert.Equal(t, day("2026-08-05").AddDate(0, 0, i), d.Day)
+		}
+	})
+
+	t.Run("buckets are contiguous", func(t *testing.T) {
+		days := Days(ts("2026-08-05 04:00:00"), ts("2026-08-09 12:00:00"))
+		for i := 1; i < len(days); i++ {
+			assert.Equal(t, days[i-1].To, days[i].From, "gap before %s", days[i].Day)
+		}
+	})
+}
+
+func TestMergeDayCounts(t *testing.T) {
+	merged := mergeDayCounts(
+		[]DayCount{{Day: day("2026-08-06"), Rows: 2}, {Day: day("2026-08-05"), Rows: 1}},
+		[]DayCount{{Day: day("2026-08-06"), Rows: 40}, {Day: day("2026-08-07"), Rows: 300}},
+	)
+
+	assert.Equal(t, []DayCount{
+		{Day: day("2026-08-05"), Rows: 1},
+		{Day: day("2026-08-06"), Rows: 42},
+		{Day: day("2026-08-07"), Rows: 300},
+	}, merged)
+}
+
+func TestTableSizeBytesPerRow(t *testing.T) {
+	t.Run("empty table", func(t *testing.T) {
+		compressed, uncompressed := TableSize{}.BytesPerRow()
+		assert.Zero(t, compressed)
+		assert.Zero(t, uncompressed)
+	})
+
+	t.Run("averages over rows", func(t *testing.T) {
+		size := TableSize{Rows: 100, CompressedBytes: 400, UncompressedBytes: 3200}
+		compressed, uncompressed := size.BytesPerRow()
+		assert.InDelta(t, 4.0, compressed, 1e-9)
+		assert.InDelta(t, 32.0, uncompressed, 1e-9)
+	})
+}

--- a/internal/chstorage/bridge_traces.go
+++ b/internal/chstorage/bridge_traces.go
@@ -12,13 +12,14 @@ import (
 	"github.com/oteldb/oteldb/internal/tracestorage"
 )
 
-// TracesBatchFunc is called with each decoded batch of spans read by [TracesSource.Do].
+// TracesBatchFunc is called with each decoded batch of spans read by [TracesSource.Scan].
 type TracesBatchFunc func(ctx context.Context, spans []tracestorage.Span) error
 
 // TracesSource reads every span stored in ClickHouse, decoded as [tracestorage.Span], for
 // migrating them into another storage engine. Unlike [Querier], it performs a full table
-// scan with no selector pushdown, day-bucketed like [Backup] so a single scan never buffers
-// more than one day's worth of rows in ClickHouse at a time.
+// scan with no selector pushdown. Callers drive it one UTC day at a time (see [Days]), so a
+// single scan never buffers more than one day's worth of rows in ClickHouse — and so a
+// migration can checkpoint its progress at a day boundary.
 type TracesSource struct {
 	client ClickHouseClient
 	table  string
@@ -37,34 +38,29 @@ func NewTracesSource(client ClickHouseClient, tables Tables, logger *zap.Logger)
 	}
 }
 
-// Do scans every span in the table, in day-bucket then start-timestamp order, invoking
-// batchFn with batches of up to batchSize spans. When since is positive, the scan is
-// restricted to the last since of data, relative to the table's most recent start
-// timestamp, instead of the full table.
-func (s *TracesSource) Do(ctx context.Context, since time.Duration, batchSize int, batchFn TracesBatchFunc) error {
+// Range returns the start-timestamp bounds of the stored spans. Both are zero when the table is
+// empty.
+func (s *TracesSource) Range(ctx context.Context) (mint, maxt time.Time, _ error) {
 	mint, maxt, err := queryMinMaxTimestamp(ctx, s.client, [2]string{s.table, "start"})
 	if err != nil {
-		return errors.Wrap(err, "query min/max timestamp")
+		return mint, maxt, errors.Wrap(err, "query min/max timestamp")
 	}
-	if mint.IsZero() && maxt.IsZero() {
-		s.logger.Info("No traces to migrate")
-		return nil
-	}
-	if since > 0 {
-		if cut := maxt.Add(-since); cut.After(mint) {
-			mint = cut
-		}
-	}
-
-	return forEachDayBucket(mint, maxt, func(from, to time.Time) error {
-		if err := s.scanDay(ctx, from, to, batchSize, batchFn); err != nil {
-			return errors.Wrapf(err, "scan %s", from)
-		}
-		return nil
-	})
+	return mint, maxt, nil
 }
 
-func (s *TracesSource) scanDay(ctx context.Context, start, end time.Time, batchSize int, batchFn TracesBatchFunc) error {
+// Counts returns the per-UTC-day span counts within [from, to].
+func (s *TracesSource) Counts(ctx context.Context, from, to time.Time) ([]DayCount, error) {
+	return dayCounts(ctx, s.client, s.table, "start", proto.PrecisionNano, from, to)
+}
+
+// Size returns the table's active-part footprint, for pre-flight sizing.
+func (s *TracesSource) Size(ctx context.Context) (TableSize, error) {
+	return tableSize(ctx, s.client, s.table)
+}
+
+// Scan reads the spans in [from, to] in start-timestamp order, invoking batchFn with batches of up
+// to batchSize spans.
+func (s *TracesSource) Scan(ctx context.Context, from, to time.Time, batchSize int, batchFn TracesBatchFunc) error {
 	var (
 		sc  = newSpanColumns()
 		buf []tracestorage.Span
@@ -82,7 +78,7 @@ func (s *TracesSource) scanDay(ctx context.Context, start, end time.Time, batchS
 	}
 
 	query := chsql.Select(s.table, sc.ChsqlResult()...).
-		Where(chsql.InTimeRange("start", start, end, proto.PrecisionNano))
+		Where(chsql.InTimeRange("start", from, to, proto.PrecisionNano))
 
 	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
 		// The decoded columns accumulate across blocks (ch-go appends, it never resets),

--- a/internal/storagebackend/ingest.go
+++ b/internal/storagebackend/ingest.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/oteldb/storage/otlp/pdataconv"
 	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
 	sigprofile "github.com/oteldb/storage/signal/profile"
 	sigtrace "github.com/oteldb/storage/signal/trace"
 )
@@ -46,6 +47,34 @@ func (b *Backend) ConsumeProfiles(ctx context.Context, pd pprofile.Profiles) err
 
 	if _, err := b.store.WriteProfiles(ctx, batch); err != nil {
 		return errors.Wrap(err, "write profiles")
+	}
+	return nil
+}
+
+// The Write* methods below take the engine's native batch types directly, for producers that
+// already build them (a bulk migration out of another store, for instance). The Consume* sinks
+// above are the OTLP entry points and go through pdataconv; these skip that translation.
+
+// WriteMetrics ingests a native metrics batch into the storage engine.
+func (b *Backend) WriteMetrics(ctx context.Context, batch sigmetric.Metrics) error {
+	if _, err := b.store.WriteMetrics(ctx, batch); err != nil {
+		return errors.Wrap(err, "write metrics")
+	}
+	return nil
+}
+
+// WriteLogs ingests a native logs batch into the storage engine.
+func (b *Backend) WriteLogs(ctx context.Context, batch siglog.Logs) error {
+	if _, err := b.store.WriteLogs(ctx, batch); err != nil {
+		return errors.Wrap(err, "write logs")
+	}
+	return nil
+}
+
+// WriteTraces ingests a native traces batch into the storage engine.
+func (b *Backend) WriteTraces(ctx context.Context, batch sigtrace.Traces) error {
+	if _, err := b.store.WriteTraces(ctx, batch); err != nil {
+		return errors.Wrap(err, "write traces")
 	}
 	return nil
 }


### PR DESCRIPTION
Backfilling 7 days of production metrics (~19.7B points) surfaced three problems with
`ch2storagebackend`: you could not find out what the job would cost before starting it, you could
not slice or resume it, and the ingest path materialized every row three times.

## Window selection and resumption

`-since` was relative-to-max only, so a large migration was one indivisible job. Scans are now driven
one UTC day at a time over an explicit `-from`/`-to` window (`-since` remains as shorthand, and now
composes with `-to`). Each completed day is journalled to `-checkpoint` and skipped on a re-run.

Ordering matters here: `WithSync` runs a durability barrier — flushing every tenant/signal head via
`Admin().Flush` — *before* the day is marked done. Marking first would turn a crash into silent data
loss on resume. The barrier also caps the head at one day's ingest instead of letting it grow for the
whole run. A torn trailing line in the journal is treated as an interrupted append; a malformed line
anywhere else is reported as corruption rather than skipped.

## Pre-flight estimate

`-estimate` prints per-day row counts and projected wall-clock without opening the target:

```
metrics: 2026-08-05 00:00:00 .. 2026-08-12 00:00:00 (7 days)
           day            rows
    2026-08-05   2,740,237,809  (done)
    ...
         total  19,701,297,097
     remaining  16,961,059,288
  source size: 63.2 GiB compressed / 537.1 GiB uncompressed (ClickHouse)
  projected:   3.1h at 1,500,000 rows/s (serial path; target engine size will differ)
```

Compressed and uncompressed are always reported as a pair. They differ by an order of magnitude, and
`MaxPartSize` — the knob that bounds merge memory — is itself expressed in uncompressed bytes, so
quoting a single "size" is what makes the job hard to plan. Neither predicts what the target engine
writes; it applies its own codecs.

## Direct conversion

Rows crossed three materializations: ClickHouse columns to row structs, to a pdata tree, and back out
through `pdataconv` to the engine's signal types. The middle tree is now gone, and attribute sets are
memoized by content hash — chstorage hands back the same map for every row of a series, so the
projection scales with distinct series rather than rows.

Same 5000-row batch, 5950X:

| signal | pdata | direct | |
|---|---|---|---|
| metrics | 1.78 M/s, 50,059 allocs | 3.10 M/s, ~24 allocs | 1.7x |
| logs | 1.40 M/s, 65,051 allocs | 1.81 M/s, 40,021 allocs | 1.3x |
| traces | 1.26 M/s, 65,051 allocs | 1.74 M/s, 45,021 allocs | 1.4x |

The metrics allocation collapse is the cache at steady state; the first batch still pays full price.

Each converter is asserted equal to `pdataconv.Append*(RowsToPdata(rows))`, so drift in either path
fails loudly. One field is normalized: `SchemaURL` (and scope name/version for metrics), where the
pdata route yields `[]byte("")` and the direct route `nil` — chstorage stores neither, so both mean
absent. Exponential histograms deliberately stay on the pdata path, because the engine decomposes
them into classic bucket series inside its own bridge and reproducing that math here would duplicate
subtle logic for a small minority of points.

The estimate constants for logs and traces were guesses in the first commit and are corrected in the
second (150k -> 600k, 200k -> 500k) now that both legs are measured.

## Notes

- Both commits build and test standalone.
- Not yet run against a live ClickHouse: the instance needs a credential this machine does not have.
  `-estimate` is the cheap way to smoke-test it.
- Follow-up, not included: parallel day workers plus real backpressure driven by `StoreStats` head
  bytes, replacing the fixed `-throttle` sleep. That is the larger remaining lever for logs and
  traces, where ingest — not conversion — is the bottleneck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)