### PR TITLE
fix(ch2storagebackend): honor -to at sub-day granularity

### DIFF
--- a/internal/ch2storagebackend/checkpoint_test.go
+++ b/internal/ch2storagebackend/checkpoint_test.go
@@ -18,6 +18,14 @@ func day(s string) time.Time {
 	return t
 }
 
+func ts(s string) time.Time {
+	t, err := time.ParseInLocation(time.DateTime, s, time.UTC)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
 func tempCheckpoint(t *testing.T) (c *Checkpoint, path string) {
 	t.Helper()
 

--- a/internal/ch2storagebackend/estimate_test.go
+++ b/internal/ch2storagebackend/estimate_test.go
@@ -185,7 +185,23 @@ func TestPlan(t *testing.T) {
 		days, from, to, ok := plan(chstorage.Window{From: day("2026-08-08")}, mint, maxt)
 		require.True(t, ok)
 		assert.Equal(t, day("2026-08-08"), from)
-		assert.Equal(t, maxt, to)
+		// The source's maxt is floored to whole seconds, so plan widens it to that second's end
+		// rather than clamping the last bucket short of the rows it was floored from.
+		assert.Equal(t, chstorage.EndOfSecond(maxt), to)
 		assert.Len(t, days, 4)
+	})
+
+	// An explicit upper bound is exact and must survive to the last bucket. It used to be dropped
+	// at day granularity, so `-to 14:00` scanned and ingested the whole calendar day.
+	t.Run("honors an explicit upper bound", func(t *testing.T) {
+		to := ts("2026-08-08 14:00:00")
+		days, _, gotTo, ok := plan(chstorage.Window{From: day("2026-08-07"), To: to}, mint, maxt)
+		require.True(t, ok)
+		assert.Equal(t, to, gotTo)
+		require.Len(t, days, 2)
+		assert.Equal(t, day("2026-08-07"), days[0].From)
+		assert.Equal(t, day("2026-08-08"), days[0].To)
+		assert.Equal(t, day("2026-08-08"), days[1].From)
+		assert.Equal(t, to, days[1].To)
 	})
 }

--- a/internal/ch2storagebackend/migrator.go
+++ b/internal/ch2storagebackend/migrator.go
@@ -170,7 +170,10 @@ func plan(w chstorage.Window, mint, maxt time.Time) (days []chstorage.DayRange, 
 	if mint.IsZero() && maxt.IsZero() {
 		return nil, from, to, false
 	}
-	from, to, ok = w.Resolve(mint, maxt)
+	// maxt is floored to whole seconds by the source's Range, so the newest row can sit up to a
+	// second past it. Days clamps its last bucket to the upper bound now, so widen maxt to keep
+	// that row in range; an explicit Window.To is exact and passes through untouched.
+	from, to, ok = w.Resolve(mint, chstorage.EndOfSecond(maxt))
 	if !ok {
 		return nil, from, to, false
 	}

--- a/internal/chstorage/bridge.go
+++ b/internal/chstorage/bridge.go
@@ -55,13 +55,12 @@ type DayRange struct {
 }
 
 // Days returns the UTC-day-aligned buckets covering [mint, maxt]. Day-aligning keeps each scan
-// inside a single daily table partition; the first bucket's lower bound is clamped to mint so a
-// windowed scan skips the early part of its first day instead of scanning the whole calendar day.
+// inside a single daily table partition; the edge buckets are clamped to mint/maxt so a windowed
+// scan reads only the requested range instead of the whole calendar day at either end.
 //
-// Only the lower bound is clamped. The upper bound stays at the day's end because mint/maxt come
-// from queryMinMaxTimestamp, which floors to whole seconds (toDateTime): clamping the top to a
-// floored maxt would drop any sub-second data in maxt's final second. Since no data exists past the
-// true max, a full-day upper bound reads the same rows without that risk.
+// Callers deriving maxt from queryMinMaxTimestamp must widen it to the end of its second first:
+// that helper floors to whole seconds (toDateTime), and clamping to a floored maxt would drop
+// sub-second data in the final second. See [EndOfSecond].
 func Days(mint, maxt time.Time) []DayRange {
 	const step = 24 * time.Hour
 
@@ -75,9 +74,21 @@ func Days(mint, maxt time.Time) []DayRange {
 		if from.Before(mint) {
 			from = mint
 		}
+		if to.After(maxt) {
+			to = maxt
+		}
 		out = append(out, DayRange{Day: ts, From: from, To: to})
 	}
 	return out
+}
+
+// EndOfSecond rounds t up to the last instant of its second, turning a timestamp floored by
+// toDateTime back into an upper bound that still covers the sub-second data it was floored from.
+func EndOfSecond(t time.Time) time.Time {
+	if t.IsZero() {
+		return t
+	}
+	return t.Truncate(time.Second).Add(time.Second - time.Nanosecond)
 }
 
 // DayCount is the row count of one UTC day of a source table.

--- a/internal/chstorage/bridge_test.go
+++ b/internal/chstorage/bridge_test.go
@@ -125,7 +125,7 @@ func TestWindowResolve(t *testing.T) {
 }
 
 func TestDays(t *testing.T) {
-	t.Run("clamps the lower bound but not the upper", func(t *testing.T) {
+	t.Run("clamps both edges", func(t *testing.T) {
 		days := Days(ts("2026-08-05 04:00:00"), ts("2026-08-07 20:00:00"))
 		require.Len(t, days, 3)
 
@@ -138,9 +138,18 @@ func TestDays(t *testing.T) {
 		assert.Equal(t, day("2026-08-06"), days[1].From)
 		assert.Equal(t, day("2026-08-07"), days[1].To)
 
-		// Last bucket runs to the day's end, past maxt, because maxt is floored to whole seconds
-		// upstream and clamping would drop sub-second data.
-		assert.Equal(t, day("2026-08-08"), days[2].To)
+		// Last bucket stops at maxt, not at the day's end. Leaving it at the day's end made an
+		// explicit upper bound a no-op above day granularity, so a migration asked for half a day
+		// silently scanned — and ingested — the whole one.
+		assert.Equal(t, day("2026-08-07"), days[2].From)
+		assert.Equal(t, ts("2026-08-07 20:00:00"), days[2].To)
+	})
+
+	t.Run("a sub-day window scans only itself", func(t *testing.T) {
+		days := Days(ts("2026-08-05 04:00:00"), ts("2026-08-05 06:00:00"))
+		require.Len(t, days, 1)
+		assert.Equal(t, ts("2026-08-05 04:00:00"), days[0].From)
+		assert.Equal(t, ts("2026-08-05 06:00:00"), days[0].To)
 	})
 
 	t.Run("day identity is midnight even when the scan is partial", func(t *testing.T) {
@@ -163,6 +172,39 @@ func TestDays(t *testing.T) {
 		for i := 1; i < len(days); i++ {
 			assert.Equal(t, days[i-1].To, days[i].From, "gap before %s", days[i].Day)
 		}
+	})
+}
+
+func TestEndOfSecond(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   time.Time
+		want time.Time
+	}{
+		{"zero stays zero", time.Time{}, time.Time{}},
+		{
+			"whole second covers its own sub-second data",
+			ts("2026-08-05 04:00:00"),
+			ts("2026-08-05 04:00:00").Add(time.Second - time.Nanosecond),
+		},
+		{
+			"already sub-second rounds up to the same instant",
+			ts("2026-08-05 04:00:00").Add(250 * time.Millisecond),
+			ts("2026-08-05 04:00:00").Add(time.Second - time.Nanosecond),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, EndOfSecond(tt.in))
+		})
+	}
+
+	// The point of the helper: a maxt floored by toDateTime still bounds a bucket that contains
+	// the rows it was floored from.
+	t.Run("keeps a floored maxt's own second in range", func(t *testing.T) {
+		newest := ts("2026-08-05 04:00:00").Add(900 * time.Millisecond)
+		days := Days(ts("2026-08-05 00:00:00"), EndOfSecond(newest.Truncate(time.Second)))
+		require.Len(t, days, 1)
+		assert.False(t, days[0].To.Before(newest), "%s must cover %s", days[0].To, newest)
 	})
 }
 


### PR DESCRIPTION
Closes #1240.

`chstorage.Days` clamped each UTC-day bucket's lower bound to `mint` but left the upper bound at the day's end, so `-to` only ever chose *which* days a migration scanned. Found while backfilling two days of metrics into a store that already held part of that range — the run ingested a full extra day and duplicated ~8h of `(series, timestamp)` samples that were already there.

The unclamped top was deliberate: `queryMinMaxTimestamp` floors to whole seconds via `toDateTime`, and clamping to a floored `maxt` would drop sub-second rows in the final second. That holds for the table's own max, where no data exists past it — not for an operator-supplied bound. So this clamps both edges and fixes the flooring at its source instead, with `EndOfSecond` applied in `plan`, the seam where the source range meets the requested window. An explicit `Window.To` is exact and passes through untouched.

Tests: `TestDays` gains sub-day coverage and its "not the upper" case is inverted; `TestPlan` pins that an explicit bound survives to the last bucket; `TestEndOfSecond` covers the helper and the floored-maxt case it exists for.