### PR TITLE
perf(chstorage): intern series attributes in loadSeries

### DIFF
--- a/internal/chstorage/bridge_attrs.go
+++ b/internal/chstorage/bridge_attrs.go
@@ -1,0 +1,34 @@
+package chstorage
+
+import "github.com/oteldb/oteldb/internal/otelstorage"
+
+// attrInterner keeps one [otelstorage.Attrs] per distinct attribute set, so a set decoded once per
+// row can be replaced by a shared instance and the duplicates collected.
+//
+// Every row of metrics_timeseries decodes its own resource and scope map, but those sets are shared
+// by construction: all series of one pod carry the same resource attributes. Retaining a map per
+// series therefore holds hundreds of thousands of copies of a few hundred distinct sets.
+type attrInterner struct {
+	cache map[otelstorage.Hash]otelstorage.Attrs
+}
+
+func newAttrInterner() *attrInterner {
+	return &attrInterner{cache: map[otelstorage.Hash]otelstorage.Attrs{}}
+}
+
+// intern returns a shared instance of an attribute set equal to a.
+//
+// Use it only for sets shared across many rows (resource, scope). Interning a set that is ~1:1 with
+// rows costs a hash per row and saves nothing.
+func (i *attrInterner) intern(a otelstorage.Attrs) otelstorage.Attrs {
+	if a.Len() == 0 {
+		return a
+	}
+
+	key := a.Hash()
+	if got, ok := i.cache[key]; ok {
+		return got
+	}
+	i.cache[key] = a
+	return a
+}

--- a/internal/chstorage/bridge_metrics.go
+++ b/internal/chstorage/bridge_metrics.go
@@ -141,16 +141,30 @@ func (s *MetricsSource) loadSeries(ctx context.Context, mint, maxt time.Time) (m
 			chsql.Gte(chsql.Ident("last_seen"), chsql.DateTime64(mint, prec)),
 		)
 
-	out := map[[16]byte]seriesMeta{}
+	var (
+		out = map[[16]byte]seriesMeta{}
+		// The map is retained for the whole scan, so decoded resource/scope maps and metric name
+		// strings would otherwise be held once per series instead of once per distinct value.
+		attrs = newAttrInterner()
+		strs  = map[string]string{}
+	)
+	intern := func(s string) string {
+		if got, ok := strs[s]; ok {
+			return got
+		}
+		strs[s] = s
+		return s
+	}
 	chq, err := query.Prepare(func(ctx context.Context, block proto.Block) error {
+		defer c.Columns().Reset()
 		for i := 0; i < c.hash.Rows(); i++ {
 			out[c.hash.Row(i)] = seriesMeta{
-				name:        c.name.Row(i),
-				unit:        c.unit.Row(i),
-				description: c.description.Row(i),
+				name:        intern(c.name.Row(i)),
+				unit:        intern(c.unit.Row(i)),
+				description: intern(c.description.Row(i)),
 				attrs:       c.attributes.Row(i),
-				scope:       c.scope.Row(i),
-				resource:    c.resource.Row(i),
+				scope:       attrs.intern(c.scope.Row(i)),
+				resource:    attrs.intern(c.resource.Row(i)),
 			}
 		}
 		return nil


### PR DESCRIPTION
Fixes #1242

`MetricsSource.loadSeries` retained one decoded `resource` and `scope` map per series. Those sets are shared by construction — every series of one pod carries the same resource attributes — so a 209k-series window materialized ~209k maps where the distinct count is in the hundreds. The map is held for the whole migration, so this was a floor on RSS rather than a transient.

## Changes

- **`bridge_attrs.go`** (new) — `attrInterner`, a small content-hash keyed cache that hands back one `otelstorage.Attrs` per distinct set.
- **`bridge_metrics.go`** — `loadSeries` interns `resource` and `scope`. Series `attrs` are left alone: they are ~1:1 with series, so interning them would cost a hash per row and save nothing, as the issue notes.

Two things beyond the issue, both in the same function and the same spirit:

- The `name` / `unit` / `description` strings are interned too. `ColStr.Row(i)` allocates a fresh string per call, so these were also retained once per series instead of once per distinct value.
- Added the `defer c.Columns().Reset()` that `ScanNumbers` and `ScanExpHistograms` already have. Without it the decoded-value slices accumulated across every block for the duration of the load, which raised the peak even though the retained set was dropped when `loadSeries` returned.

This is deliberately the interner-in-`chstorage` option from the issue rather than lifting `attrConv` out of `ch2storagebackend`; the two caches answer different questions (one dedupes the projection, this one dedupes the source map) and keeping them separate avoids a dependency edge between the packages.

## Verification

`go build ./...` and `go test -race ./internal/chstorage/...` pass.

Not measured against a real backfill — the RSS claim in the issue is reasoned from the code, and as it notes the migrator has no pprof endpoint to confirm the split between this floor and the engine head. Worth a heap profile on the next 209k-series run to confirm the size of the win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)