### PR TITLE
fix(logparser): detect all registered formats by default

### DIFF
--- a/internal/logparser/default.go
+++ b/internal/logparser/default.go
@@ -1,0 +1,25 @@
+package logparser
+
+// DefaultFormats returns default detection order, from strictest to loosest.
+//
+// [GenericJSONParser.Detect] is a strict "first token is a JSON object" check and is mutually
+// exclusive with the rest. [LogFmtParser.Detect] is the most permissive one and falsely matches
+// zap-development lines, so it goes last.
+func DefaultFormats() []Parser {
+	return []Parser{
+		new(GenericJSONParser),
+		new(KLogParser),
+		new(ZapDevelopmentParser),
+		new(LogFmtParser),
+	}
+}
+
+// DefaultFormatNames returns names of [DefaultFormats], in the same order.
+func DefaultFormatNames() []string {
+	formats := DefaultFormats()
+	names := make([]string, 0, len(formats))
+	for _, p := range formats {
+		names = append(names, p.String())
+	}
+	return names
+}

--- a/internal/logparser/default_test.go
+++ b/internal/logparser/default_test.go
@@ -1,0 +1,24 @@
+package logparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultFormats(t *testing.T) {
+	want := []string{"generic-json", "klog", "zap-development", "logfmt"}
+	require.Equal(t, want, DefaultFormatNames())
+
+	formats := DefaultFormats()
+	require.Len(t, formats, len(want))
+	for i, p := range formats {
+		require.Equal(t, want[i], p.String())
+	}
+
+	for _, name := range DefaultFormatNames() {
+		p, ok := LookupFormat(name)
+		require.Truef(t, ok, "format %q is not registered", name)
+		require.Equal(t, name, p.String())
+	}
+}

--- a/internal/logparser/logfmt.go
+++ b/internal/logparser/logfmt.go
@@ -118,7 +118,7 @@ func (LogFmtParser) Detect(line string) bool {
 	noop := logfmt.HandlerFunc(func(k, _ []byte) error {
 		ftyp, ok := deduceFieldType(k)
 		if ok {
-			detectedFields |= uint64(ftyp)
+			detectedFields |= 1 << uint64(ftyp)
 		}
 		return nil
 	})
@@ -127,6 +127,6 @@ func (LogFmtParser) Detect(line string) bool {
 	}
 
 	// A bit of bit magic: ensure we met at least two of useful fields.
-	detectedFields &= uint64(levelField | timestampField | messageField)
+	detectedFields &= 1<<levelField | 1<<timestampField | 1<<messageField
 	return bits.OnesCount64(detectedFields) >= 2
 }

--- a/internal/logparser/logfmt_test.go
+++ b/internal/logparser/logfmt_test.go
@@ -2,10 +2,40 @@ package logparser
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogFmtParser(t *testing.T) {
 	testParser("logfmt")(t)
+}
+
+func TestLogFmtParserDetect(t *testing.T) {
+	tests := []struct {
+		line string
+		want bool
+	}{
+		{"", false},
+		{`{"level":"info"}`, false},
+		{`ts=2023-01-01T00:00:00Z`, false},
+		{`trace_id=4bf92f3577b34da6a3ce929d0e0e4736`, false},
+		{`span_id=00f067aa0ba902b7`, false},
+		{`level=info`, false},
+		{`msg=hi`, false},
+		{`level=info msg=hi`, true},
+		{`ts=2023-01-01T00:00:00Z msg=hi`, true},
+		{`ts=2023-01-01T00:00:00Z level=info`, true},
+		{
+			"2023-12-12T15:49:36.355+0300\tDEBUG\tlogparser/zap_development_test.go:123\tIntruder alert\t" +
+				`{"red_spy": "in the base", "pin": 1111, "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736", "span_id": "00f067aa0ba902b7"}`,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			require.Equal(t, tt.want, LogFmtParser{}.Detect(tt.line))
+		})
+	}
 }
 
 func FuzzLogFmtParser(f *testing.F) {

--- a/internal/logstorage/consumer_config.go
+++ b/internal/logstorage/consumer_config.go
@@ -41,7 +41,7 @@ func (o *ConsumerOptions) setDefaults() {
 		}
 	}
 	if o.DetectFormats == nil {
-		o.DetectFormats = []logparser.Parser{new(logparser.GenericJSONParser)}
+		o.DetectFormats = logparser.DefaultFormats()
 	}
 	if o.MeterProvider == nil {
 		o.MeterProvider = otel.GetMeterProvider()

--- a/internal/logstorage/consumer_test.go
+++ b/internal/logstorage/consumer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,6 +182,48 @@ func TestConsumeLogs(t *testing.T) {
 		},
 	}
 	require.Equal(t, expected, i.records)
+}
+
+func TestConsumeLogsDefaultFormats(t *testing.T) {
+	ctx := t.Context()
+
+	i := &mockInserter{}
+	c, err := NewConsumer(i, ConsumerOptions{})
+	require.NoError(t, err)
+
+	recordTime := time.Date(2024, time.June, 21, 0, 0, 0, 0, time.UTC)
+
+	logs := plog.NewLogs()
+	resLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resLogs.ScopeLogs().AppendEmpty()
+	records := scopeLogs.LogRecords()
+	{
+		record := records.AppendEmpty()
+		record.SetTimestamp(pcommon.NewTimestampFromTime(recordTime))
+		record.Body().SetStr(`I0621 16:26:15.372343       1 leaderelection.go:250] Starting Provisioner`)
+		record.Attributes().PutStr("log", "klog-line")
+	}
+
+	err = c.ConsumeLogs(ctx, logs)
+	require.NoError(t, err)
+	require.Len(t, i.records, 1)
+
+	got := i.records[0]
+	require.Equal(t, "Starting Provisioner", got.Body)
+	require.Equal(t, plog.SeverityNumberInfo, got.SeverityNumber)
+	require.Equal(t,
+		otelstorage.NewTimestampFromTime(time.Date(2024, time.June, 21, 16, 26, 15, 372343000, time.UTC)),
+		got.Timestamp,
+	)
+
+	attrs := got.Attrs.AsMap()
+	typ, ok := attrs.Get("logparser.type")
+	require.True(t, ok)
+	require.Equal(t, "klog", typ.AsString())
+
+	file, ok := attrs.Get("code.file.path")
+	require.True(t, ok)
+	require.Equal(t, "leaderelection.go", file.AsString())
 }
 
 func attrMap(kv ...string) otelstorage.Attrs {

--- a/internal/otelreceiver/oteldbexporter/logparser_test.go
+++ b/internal/otelreceiver/oteldbexporter/logparser_test.go
@@ -1,0 +1,20 @@
+package oteldbexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestParseDetectFormats(t *testing.T) {
+	lg := zaptest.NewLogger(t)
+
+	// Must be nil, otherwise logstorage.ConsumerOptions would not install defaults.
+	require.Nil(t, parseDetectFormats(nil, lg))
+	require.Nil(t, parseDetectFormats([]string{}, lg))
+
+	got := parseDetectFormats([]string{"logfmt", "unknown-format"}, lg)
+	require.Len(t, got, 1)
+	require.Equal(t, "logfmt", got[0].String())
+}

--- a/internal/otelreceiver/oteldbexporter/oteldbexporter.go
+++ b/internal/otelreceiver/oteldbexporter/oteldbexporter.go
@@ -225,15 +225,7 @@ func (f *factory) createLogsExporter(
 	procCfg := ecfg.Logs.Processing
 	triggerAttrs := parseAttributeRefs(procCfg.TriggerAttributes, "trigger_attributes", lg)
 	formatAttrs := parseAttributeRefs(procCfg.FormatAttributes, "format_attributes", lg)
-	formats := make([]logparser.Parser, 0, len(procCfg.DetectFormats))
-	for _, raw := range procCfg.DetectFormats {
-		p, ok := logparser.LookupFormat(raw)
-		if !ok {
-			lg.Warn("Unknown format", zap.String("format", raw))
-			continue
-		}
-		formats = append(formats, p)
-	}
+	formats := parseDetectFormats(procCfg.DetectFormats, lg)
 	lg.Info("Creating logs consumer",
 		zap.Int("trigger_attributes", len(triggerAttrs)),
 		zap.Int("format_attributes", len(triggerAttrs)),
@@ -268,6 +260,24 @@ func (f *factory) createLogsExporter(
 		}
 	}
 	return exporterhelper.NewLogs(ctx, settings, cfg, consume)
+}
+
+// parseDetectFormats returns nil if formats are unset, so [logstorage.ConsumerOptions] installs
+// its own defaults.
+func parseDetectFormats(formats []string, lg *zap.Logger) []logparser.Parser {
+	if len(formats) == 0 {
+		return nil
+	}
+	result := make([]logparser.Parser, 0, len(formats))
+	for _, raw := range formats {
+		p, ok := logparser.LookupFormat(raw)
+		if !ok {
+			lg.Warn("Unknown format", zap.String("format", raw))
+			continue
+		}
+		result = append(result, p)
+	}
+	return result
 }
 
 func parseAttributeRefs(refs []string, field string, lg *zap.Logger) []logstorage.AttributeRef {

--- a/otelcolmod/odblogparser/README.md
+++ b/otelcolmod/odblogparser/README.md
@@ -37,7 +37,7 @@ receivers:
         parse_from: body
         parse_to: attributes
         detect: true
-        detect_formats: [generic-json, logfmt, zap-development, klog]
+        detect_formats: [generic-json, klog, zap-development, logfmt]
 ```
 
 ### Config fields
@@ -48,7 +48,7 @@ receivers:
 | `parse_to`       | string   | inherited from helper  | Target attribute field                               |
 | `format`         | string   | `""`                   | Force a single parser (`generic-json`, `logfmt`, …)  |
 | `detect`         | bool     | `true`                 | Auto-detect format when `format` is unset            |
-| `detect_formats` | []string | `["generic-json"]`     | Ordered list of formats to try during detection      |
+| `detect_formats` | []string | `["generic-json", "klog", "zap-development", "logfmt"]` | Ordered list of formats to try during detection |
 
 ### Supported formats
 

--- a/otelcolmod/odblogparser/config.go
+++ b/otelcolmod/odblogparser/config.go
@@ -28,7 +28,7 @@ func NewConfigWithID(operatorID string) *Config {
 	return &Config{
 		ParserConfig:  helper.NewParserConfig(operatorID, Type),
 		Detect:        true,
-		DetectFormats: []string{"generic-json"},
+		DetectFormats: logparser.DefaultFormatNames(),
 	}
 }
 
@@ -64,7 +64,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 	} else if c.Detect {
 		detectFormats := c.DetectFormats
 		if detectFormats == nil {
-			detectFormats = []string{"generic-json"}
+			detectFormats = logparser.DefaultFormatNames()
 		}
 		detect = make([]logparser.Parser, 0, len(detectFormats))
 		for _, format := range detectFormats {


### PR DESCRIPTION
Fixes #1248

The issue's read was right that this is a wiring gap, not a parser bug — all four parsers self-register via `init()`, so `LookupFormat("klog")` has always worked. There turned out to be two defects, and the second explains the "0 rows carrying a `logparser.type` attribute" measurement better than a missing list entry alone does.

## 1. Every default detect list held only `generic-json`

`logstorage.ConsumerOptions.setDefaults`, and both hardcoded spots in `odblogparser.Config`. klog, logfmt and zap-development were registered but never selected.

## 2. The exporter path disabled detection outright

```go
formats := make([]logparser.Parser, 0, len(procCfg.DetectFormats))
```

This is non-nil even when `logs.processing.formats` is unset, so `setDefaults`' `if o.DetectFormats == nil` guard never fired, and `consumer.go`'s `if len(c.opts.DetectFormats) > 0` then skipped detection entirely. No config in this repo sets `formats`, so on the exporter path *no* parser ran at all — not even generic-json. `parseDetectFormats` now returns nil when unset so the defaults actually apply.

## 3. `LogFmtParser.Detect` bitset (found while choosing the order)

`fieldKind` constants are `iota + 1` but were OR-ed as if they were bit flags and popcounted against a mask of `levelField|timestampField|messageField` (== 7). Measured consequences: a lone `trace_id=`, `span_id=` or `ts=` returned true, while a lone `level=info` or `msg=hi` returned false — both over- and under-permissive. Now shifts (`1 << ftyp`), preserving the documented "at least two of level/timestamp/message" intent.

## Ordering

`logparser.DefaultFormats()` is the single source of the order, used by all three config surfaces:

```
generic-json, klog, zap-development, logfmt
```

The order is load-bearing. I built a cross-detection matrix over `internal/logparser/_testdata/*` plus the production klog lines from the issue: logfmt is the only parser with cross-format false positives (it detects *and* successfully parses zap-development lines whose JSON field blob contains `trace_id`/`span_id`, producing garbage attributes), so it sorts last. generic-json's `Detect` is a strict "first token is a JSON object" check and logfmt explicitly bails on lines starting with `{`, so it is mutually exclusive with the rest. klog's fixed `[DIWEF]MMDD HH:MM:SS.uuuuuu` header had zero false positives in either direction. Defect 3 removes the logfmt/zap collision at the source, but the ordering is kept as defence in depth.

## Tests

- `LogFmtParser.Detect` table covering the lone-field cases above and a real zap console line.
- `DefaultFormats()` order, and that every `DefaultFormatNames()` entry resolves via `LookupFormat`.
- End-to-end: a real klog line through `ConsumerOptions{}` asserting stripped body, `logparser.type == "klog"`, severity, `code.file.path`, and the timestamp taken from the klog header rather than the collector's.
- `parseDetectFormats(nil) == nil`, the invariant defect 2's fix depends on.

`go build ./...` and `go test -race` over the affected packages pass; `golangci-lint run` is clean. No golden or fuzz test was affected — the logparser goldens exercise `Parse`, not `Detect`.

## Rollout note

This changes ingest behaviour for every deployment. Records that previously passed through as raw bodies will now be parsed, and — the point of the issue — their `Timestamp` becomes the in-body event time instead of the collector's receipt time. On the corpus in the issue those differ by 30–80 µs, so the shift is small, but any dashboard or alert that has been filtering on what was effectively receipt time is now filtering on event time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)