### PR TITLE
feat(otelreceiver): register otlp, otlphttp, debug and nop exporters

### DIFF
--- a/internal/otelreceiver/receiver.go
+++ b/internal/otelreceiver/receiver.go
@@ -21,6 +21,10 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
+	"go.opentelemetry.io/collector/exporter/nopexporter"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/processor"
@@ -63,9 +67,19 @@ func processorFactoryMap() (map[component.Type]processor.Factory, error) {
 	)
 }
 
+// exporterFactoryMap returns exporters available to the embedded collector.
+//
+// Pipeline exporters fan out independently and sending_queue.blocking defaults to false, so a dead
+// mirror target drops its own queue without back-pressuring oteldbexporter. Setting it to true
+// couples the primary write path to the mirror's availability. Use filterprocessor to drop a mirror
+// target's own self-telemetry and break echo loops.
 func exporterFactoryMap(opts ...oteldbexporter.Option) (map[component.Type]exporter.Factory, error) {
 	return otelcol.MakeFactoryMap(
 		oteldbexporter.NewFactory(opts...),
+		otlpexporter.NewFactory(),
+		otlphttpexporter.NewFactory(),
+		debugexporter.NewFactory(),
+		nopexporter.NewFactory(),
 	)
 }
 

--- a/internal/otelreceiver/receiver_test.go
+++ b/internal/otelreceiver/receiver_test.go
@@ -1,0 +1,78 @@
+package otelreceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/otelcol"
+)
+
+func TestExporterFactoryMap(t *testing.T) {
+	factories, err := exporterFactoryMap()
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(factories))
+	for typ := range factories {
+		got = append(got, typ.String())
+	}
+	for _, want := range []string{
+		"oteldbexporter",
+		"otlp",
+		"otlphttp",
+		"debug",
+		"nop",
+	} {
+		require.Contains(t, got, want)
+	}
+}
+
+func TestCollectorConfigWithOTLPExporter(t *testing.T) {
+	cfg := map[string]any{
+		"receivers": map[string]any{
+			"otlp": map[string]any{
+				"protocols": map[string]any{
+					"grpc": map[string]any{
+						"endpoint": "localhost:0",
+					},
+				},
+			},
+		},
+		"exporters": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+			},
+			"otlphttp": map[string]any{
+				"endpoint": "http://localhost:4318",
+			},
+			"debug": map[string]any{},
+			"nop":   map[string]any{},
+		},
+		"service": map[string]any{
+			"pipelines": map[string]any{
+				"logs": map[string]any{
+					"receivers": []string{"otlp"},
+					"exporters": []string{"otlp", "otlphttp", "debug", "nop"},
+				},
+			},
+		},
+	}
+
+	col, err := otelcol.NewCollector(otelcol.CollectorSettings{
+		Factories: Factories(TelemetrySettings{}),
+		BuildInfo: component.NewDefaultBuildInfo(),
+		ConfigProviderSettings: otelcol.ConfigProviderSettings{
+			ResolverSettings: confmap.ResolverSettings{
+				URIs: []string{"oteldb:/"},
+				ProviderFactories: []confmap.ProviderFactory{
+					confmap.NewProviderFactory(func(confmap.ProviderSettings) confmap.Provider {
+						return NewMapProvider("oteldb", cfg)
+					}),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, col.DryRun(t.Context()))
+}


### PR DESCRIPTION
Fixes #1226

`exporterFactoryMap` registered only `oteldbexporter`, so any `otelcol:` config naming `otlp` as an exporter failed at startup with an unknown-type error, and everything reaching oteldb's OTLP receiver was terminal. This registers the OTLP pair so ingest can be teed to a second backend — which is the only place that fixes it for producers that deliberately bypass a gateway collector and push to oteldb directly.

Registered unconditionally, matching what `cmd/odbagent` already does. Gating behind a build tag or an option was considered and rejected: the `otelcol:` block is operator-supplied config, so anyone who could enable a flag could already edit the config, and a stock image that can't forward makes the feature unusable where it's needed.

Beyond the issue's proposal, `debugexporter` and `nopexporter` are registered too. Both are already direct deps via the same distribution and are the standard tools for troubleshooting an embedded-collector pipeline; registering only `otlp` would leave you unable to diagnose the fan-out you just enabled.

**No new modules.** All four were already direct requires (`go.mod:120-124`) because `cmd/odbagent/components.go` registers them — `git diff go.mod go.sum` is empty.

## Notes captured in the godoc

Two behaviours from the issue that are easy to get wrong, documented on `exporterFactoryMap` rather than in a new doc file (the embedded collector's config surface isn't documented anywhere today — `docs/` has no otelcol content and the README only links upstream):

- Pipeline exporters fan out independently and `sending_queue.blocking` defaults to false, so a dead mirror target drops its own queue without back-pressuring `oteldbexporter`. Setting it to true couples the primary write path to the mirror's availability.
- `filterprocessor` is already registered and can drop a mirror target's own self-telemetry to break echo loops.

## Tests

`internal/otelreceiver` had no test file before; this adds one.

- `TestExporterFactoryMap` asserts the returned map contains `oteldbexporter`, `otlp`, `otlphttp`, `debug` and `nop`. Containment rather than exact equality, because `otlpexporter`/`otlphttpexporter` also register the `otlp_grpc`/`otlp_http` aliases, giving 7 keys.
- `TestCollectorConfigWithOTLPExporter` builds a real collector through the existing `NewMapProvider` seam with a pipeline exporting to all four, and asserts `DryRun` succeeds — i.e. the exact startup failure from the issue is gone. `DryRun` validates the full config without starting components, so this needs no ClickHouse and no listening socket, and no production code was changed to make it testable.

## Verification

`go build ./...`, `go test -race ./internal/otelreceiver/...` and `golangci-lint run` all pass.

One caveat on how these were run: this machine's Go build-cache module index was in a corrupted state during the work (unrelated to this change — a concurrent cache prune), so the commands were run with `GODEBUG=goindex=0` to bypass the stale index. `go mod verify` reports all modules verified, and `goindex=0` changes only how Go reads its own file-list cache, not what gets compiled — but worth a clean CI run to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)