### PR TITLE
build(frontend): format and lint with Biome

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Formatting and lint, from biome.jsonc. Fails on anything `bun run fmt` would rewrite.
+      - name: Lint
+        run: bun run lint
+
       - name: Typecheck
         run: bun run typecheck
 

--- a/internal/adminhandler/frontend/biome.jsonc
+++ b/internal/adminhandler/frontend/biome.jsonc
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+  "files": {
+    "includes": ["src/**", "*.ts", "*.json", "!src/api", "!dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "all"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "correctness": {
+        // Fires on every [label, <Mono/>] pair passed to KV. Those are values in a static tuple,
+        // not iterated children: KV keys the list itself when it maps them.
+        "useJsxKeyInIterable": "off"
+      }
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "off"
+      }
+    }
+  }
+}

--- a/internal/adminhandler/frontend/bun.lock
+++ b/internal/adminhandler/frontend/bun.lock
@@ -15,6 +15,7 @@
         "react-router-dom": "^7.1.1",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.5.8",
         "@types/react": "^19.0.2",
         "@types/react-dom": "^19.0.2",
         "@vitejs/plugin-react": "^4.3.4",
@@ -114,6 +115,24 @@
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@bem-react/classname": ["@bem-react/classname@1.8.0", "", {}, "sha512-uazGRFKTMNbGR8KLvEh5qT+aP0yuym+sB+YFFaAyCkFodtjI0SskV6BfkiZ9+E3FloIFYPkwqJ1owxp48WCS9g=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.8", "@biomejs/cli-darwin-x64": "2.5.8", "@biomejs/cli-linux-arm64": "2.5.8", "@biomejs/cli-linux-arm64-musl": "2.5.8", "@biomejs/cli-linux-x64": "2.5.8", "@biomejs/cli-linux-x64-musl": "2.5.8", "@biomejs/cli-win32-arm64": "2.5.8", "@biomejs/cli-win32-x64": "2.5.8" }, "bin": { "biome": "bin/biome" } }, "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.8", "", { "os": "linux", "cpu": "x64" }, "sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.8", "", { "os": "linux", "cpu": "x64" }, "sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.8", "", { "os": "win32", "cpu": "x64" }, "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA=="],
 
     "@commander-js/extra-typings": ["@commander-js/extra-typings@14.0.0", "", { "peerDependencies": { "commander": "~14.0.0" } }, "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg=="],
 

--- a/internal/adminhandler/frontend/package.json
+++ b/internal/adminhandler/frontend/package.json
@@ -10,7 +10,9 @@
     "build": "orval --config ./orval.config.ts && tsc -b && vite build",
     "build:only": "tsc -b && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "fmt": "biome format --write .",
+    "lint": "biome check ."
   },
   "dependencies": {
     "@gravity-ui/charts": "^1.57.1",
@@ -23,6 +25,7 @@
     "react-router-dom": "^7.1.1"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.5.8",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-react": "^4.3.4",

--- a/internal/adminhandler/frontend/src/app.css
+++ b/internal/adminhandler/frontend/src/app.css
@@ -18,8 +18,8 @@
   --g-font-family-sans:
     system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --g-font-family-monospace:
-    ui-monospace, "JetBrains Mono", "SF Mono", "SFMono-Regular", Menlo, Consolas,
-    "Liberation Mono", monospace;
+    ui-monospace, "JetBrains Mono", "SF Mono", "SFMono-Regular", Menlo, Consolas, "Liberation Mono",
+    monospace;
   --g-text-caption-font-family: var(--g-font-family-monospace);
 
   /* Live values must not jitter as digits change width. */

--- a/internal/adminhandler/frontend/src/components/GoFasterMark.tsx
+++ b/internal/adminhandler/frontend/src/components/GoFasterMark.tsx
@@ -15,7 +15,13 @@ const BARS = [
  */
 export function GoFasterMark(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 539.38 219.79" xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      viewBox="0 0 539.38 219.79"
+      xmlns="http://www.w3.org/2000/svg"
+      role="presentation"
+      aria-hidden="true"
+      {...props}
+    >
       <defs>
         <linearGradient id="gofaster-mark" x1="0" y1="1" x2="1" y2="0">
           <stop offset="0" stopColor="#00808f" />

--- a/internal/adminhandler/frontend/src/components/Vitals.tsx
+++ b/internal/adminhandler/frontend/src/components/Vitals.tsx
@@ -28,9 +28,7 @@ function Spark({ points }: { points: number[] }) {
   const d = points
     .map((v, i) => {
       const x = i * step;
-      const y = flat
-        ? SPARK_H / 2
-        : SPARK_H - 1 - ((v - min) / span) * (SPARK_H - 2);
+      const y = flat ? SPARK_H / 2 : SPARK_H - 1 - ((v - min) / span) * (SPARK_H - 2);
       return `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
@@ -109,32 +107,22 @@ export function Vitals() {
   const series = read("series");
 
   return (
+    // biome-ignore lint/a11y/useSemanticElements: the semantic equivalent is <fieldset>, which is for form controls, not a labelled tape of readouts.
     <div className="vitals" role="group" aria-label="Instance vitals">
-      <Cell
-        label="uptime"
-        value={info.data ? fmtDur(info.data.uptime_seconds) : DASH}
-      />
+      <Cell label="uptime" value={info.data ? fmtDur(info.data.uptime_seconds) : DASH} />
       <Cell
         label="ingest"
         value={ingest == null ? DASH : fmtNum(Math.round(ingest))}
         unit={ingest == null ? undefined : "/s"}
         points={history.ingest}
       />
-      <Cell
-        label="heap"
-        value={heap == null ? DASH : fmtBytes(heap)}
-        points={history.heap}
-      />
+      <Cell label="heap" value={heap == null ? DASH : fmtBytes(heap)} points={history.heap} />
       <Cell
         label="goroutines"
         value={goroutines == null ? DASH : fmtNum(goroutines)}
         points={history.goroutines}
       />
-      <Cell
-        label="series"
-        value={series == null ? DASH : fmtNum(series)}
-        points={history.series}
-      />
+      <Cell label="series" value={series == null ? DASH : fmtNum(series)} points={history.series} />
     </div>
   );
 }

--- a/internal/adminhandler/frontend/src/components/ui.tsx
+++ b/internal/adminhandler/frontend/src/components/ui.tsx
@@ -135,6 +135,7 @@ export function KV({ rows }: { rows: [ReactNode, ReactNode][] }) {
   return (
     <DefinitionList responsive>
       {rows.map(([name, value], i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: rows are a static, order-stable tuple list, never reordered or spliced.
         <DefinitionList.Item key={i} name={name}>
           {value}
         </DefinitionList.Item>

--- a/internal/adminhandler/frontend/src/lib/format.ts
+++ b/internal/adminhandler/frontend/src/lib/format.ts
@@ -11,7 +11,7 @@ export function fmtBytes(n: number | null | undefined): string {
     v /= 1024;
     i++;
   }
-  return (neg ? "-" : "") + v.toFixed(i ? 1 : 0) + " " + u[i];
+  return `${(neg ? "-" : "") + v.toFixed(i ? 1 : 0)} ${u[i]}`;
 }
 
 export function fmtNum(n: number | null | undefined): string {
@@ -28,7 +28,7 @@ export function fmtDur(secondsInput: number): string {
   const h = Math.floor((sec % 86400) / 3600);
   const m = Math.floor((sec % 3600) / 60);
   const s = sec % 60;
-  const parts = [d && d + "d", h && h + "h", m && m + "m", s + "s"].filter(Boolean) as string[];
+  const parts = [d && `${d}d`, h && `${h}h`, m && `${m}m`, `${s}s`].filter(Boolean) as string[];
   return parts.slice(0, 2).join(" ") || "0s";
 }
 

--- a/internal/adminhandler/frontend/src/main.tsx
+++ b/internal/adminhandler/frontend/src/main.tsx
@@ -25,6 +25,7 @@ const queryClient = new QueryClient({
 
 const toaster = new Toaster();
 
+// biome-ignore lint/style/noNonNullAssertion: index.html always ships the #root container.
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <AppThemeProvider>

--- a/internal/adminhandler/frontend/src/pages/Runtime.tsx
+++ b/internal/adminhandler/frontend/src/pages/Runtime.tsx
@@ -34,10 +34,9 @@ export function Runtime() {
   useEffect(() => {
     if (!data) return;
     setSeries((prev) =>
-      [
-        ...prev,
-        { t: Date.now(), heap: data.heap_alloc_bytes, next: data.next_gc_bytes },
-      ].slice(-KEEP_POINTS),
+      [...prev, { t: Date.now(), heap: data.heap_alloc_bytes, next: data.next_gc_bytes }].slice(
+        -KEEP_POINTS,
+      ),
     );
   }, [data]);
 

--- a/internal/adminhandler/frontend/src/pages/Storage.tsx
+++ b/internal/adminhandler/frontend/src/pages/Storage.tsx
@@ -37,11 +37,7 @@ function Caches({ caches }: { caches: CacheStats }) {
   return (
     <Panel title="Caches" sub="decode">
       <Flex direction="column" gap={4}>
-        <UsageBar
-          label="decode hit rate"
-          value={`${(rate * 100).toFixed(1)}%`}
-          ratio={rate}
-        />
+        <UsageBar label="decode hit rate" value={`${(rate * 100).toFixed(1)}%`} ratio={rate} />
         <KV
           rows={[
             ["cached bytes", <Mono>{fmtBytes(dc.bytes)}</Mono>],
@@ -135,8 +131,18 @@ function Cluster({ cluster }: { cluster: ClusterStats }) {
 
 const SIGNAL_COLUMNS: TableColumnConfig<EngineSignalStats>[] = [
   { id: "signal", name: head("signal"), primary: true },
-  { id: "head_items", name: head("head items"), align: "end", template: (s) => fmtNum(s.head_items) },
-  { id: "head_bytes", name: head("head bytes"), align: "end", template: (s) => fmtBytes(s.head_bytes) },
+  {
+    id: "head_items",
+    name: head("head items"),
+    align: "end",
+    template: (s) => fmtNum(s.head_items),
+  },
+  {
+    id: "head_bytes",
+    name: head("head bytes"),
+    align: "end",
+    template: (s) => fmtBytes(s.head_bytes),
+  },
   { id: "series", name: head("series"), align: "end", template: (s) => fmtNum(s.series) },
   {
     id: "parts",
@@ -149,7 +155,12 @@ const SIGNAL_COLUMNS: TableColumnConfig<EngineSignalStats>[] = [
       </Flex>
     ),
   },
-  { id: "sealed_parts", name: head("sealed"), align: "end", template: (s) => fmtNum(s.sealed_parts) },
+  {
+    id: "sealed_parts",
+    name: head("sealed"),
+    align: "end",
+    template: (s) => fmtNum(s.sealed_parts),
+  },
   {
     id: "merge",
     name: head("merge backlog"),
@@ -192,8 +203,7 @@ const SIGNAL_COLUMNS: TableColumnConfig<EngineSignalStats>[] = [
 
 function Tenant({ t }: { t: TenantStats }) {
   const a = t.admission;
-  const rejected =
-    a.rejected_ooo + a.rejected_rate + a.rejected_cardinality + a.rejected_in_flight;
+  const rejected = a.rejected_ooo + a.rejected_rate + a.rejected_cardinality + a.rejected_in_flight;
   return (
     <Panel
       title={t.tenant}
@@ -203,9 +213,7 @@ function Tenant({ t }: { t: TenantStats }) {
           <Text variant="body-1" color="secondary">
             accepted <Mono>{fmtNum(a.accepted)}</Mono>
           </Text>
-          {rejected ? (
-            <ErrCount bad>{`rejected ${fmtNum(rejected)}`}</ErrCount>
-          ) : null}
+          {rejected ? <ErrCount bad>{`rejected ${fmtNum(rejected)}`}</ErrCount> : null}
         </Flex>
       }
       scroll
@@ -223,7 +231,12 @@ const EFFICIENCY_COLUMNS: TableColumnConfig<EfficiencyRow>[] = [
   { id: "series", name: head("series"), align: "end", template: (s) => fmtNum(s.series) },
   { id: "parts", name: head("parts"), align: "end", template: (s) => fmtNum(s.parts) },
   { id: "points", name: head("points"), align: "end", template: (s) => fmtNum(s.points) },
-  { id: "stored_bytes", name: head("stored"), align: "end", template: (s) => fmtBytes(s.stored_bytes) },
+  {
+    id: "stored_bytes",
+    name: head("stored"),
+    align: "end",
+    template: (s) => fmtBytes(s.stored_bytes),
+  },
   {
     id: "bytes_per_point",
     name: head("bytes / point"),
@@ -254,7 +267,7 @@ function Efficiency() {
 
   if (isLoading) return <Loading />;
   if (error) return <ErrorAlert error={error} what="efficiency stats" />;
-  if (!data || !data.tenants.length) return null;
+  if (!data?.tenants.length) return null;
 
   const rows = flattenEfficiency(data.tenants);
 
@@ -272,7 +285,12 @@ function Efficiency() {
 const CH_COLUMNS: TableColumnConfig<TableStats>[] = [
   { id: "table", name: head("table"), primary: true },
   { id: "rows", name: head("rows"), align: "end", template: (t) => fmtNum(t.rows) },
-  { id: "bytes_on_disk", name: head("on disk"), align: "end", template: (t) => fmtBytes(t.bytes_on_disk) },
+  {
+    id: "bytes_on_disk",
+    name: head("on disk"),
+    align: "end",
+    template: (t) => fmtBytes(t.bytes_on_disk),
+  },
   {
     id: "data_uncompressed_bytes",
     name: head("uncompressed"),


### PR DESCRIPTION
The admin frontend had no formatter and no linter — CI ran only `typecheck` and `build`. Style was
whatever each file happened to be written in (Vitals and Storage hand-wrapped near 80 columns, the
rest running past 100), and nothing caught a11y or React mistakes.

Adds [Biome](https://biomejs.dev): one Rust binary for both, one config, one devDependency. That
mirrors how `golangci-lint fmt` / `golangci-lint run` already serve the Go side, and there was no
existing ESLint config to migrate away from.

## Notes

- **`biome.jsonc`, not `biome.json`.** Biome rejects comments in `.json`, and the failure is quiet:
  the config is skipped, defaults apply, and it happily lints `node_modules` (9952 errors across 216
  files). Worth knowing before someone adds a comment.
- **`src/api` is excluded** — it is orval output, and formatting it would fight codegen and the
  `lint / gen` job.
- **`useJsxKeyInIterable` is off globally.** It fires on all 29 `[label, <Mono/>]` pairs passed to
  `KV`; those are values in a static tuple, not iterated children, and `KV` keys the list itself
  when it maps them.
- **Three site-local suppressions**, each with its reason inline: `noArrayIndexKey` on `KV`'s
  stable-order rows, `noNonNullAssertion` on the React root, `useSemanticElements` on the vitals
  tape (its semantic equivalent is `<fieldset>`, which is for form controls).
- **One real fix:** the go-faster logo mark was an untitled `<svg>`; it is now marked decorative,
  which is correct since `AsideHeader` renders the "oteldb" text beside it.

Everything else in the diff is mechanical reflow. `bun run lint`, `bun run typecheck` and
`bun run build` are all clean; CI gains a `Lint` step that fails on anything `bun run fmt` would
rewrite.

Stacked note: #1252 (stream costs) adds a page that predates this and will need `bun run fmt` after
whichever of the two lands second.
