### PR TITLE
feat(otlpdirect): decode the whole OTLP pack without pdata, over HTTP and gRPC

### DIFF
--- a/cmd/odbingest/app.go
+++ b/cmd/odbingest/app.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/oteldb/storage/cluster/router"
 
+	"github.com/oteldb/oteldb/internal/otlpdirect"
 	"github.com/oteldb/oteldb/internal/promrw"
 )
 
@@ -51,6 +52,13 @@ func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (
 		return nil, errors.Wrap(err, "create metrics")
 	}
 
+	otlp := otlpdirect.NewHandler(sink, otlpdirect.HandlerConfig{
+		MaxBodyBytes:    int64(cfg.OTLP.MaxBodyBytes),
+		MaxDecodedBytes: int64(cfg.OTLP.MaxDecodedBytes),
+		Logger:          lg.Named("otlp"),
+		Observer:        obs.observeOTLP,
+	})
+
 	rw := cfg.RemoteWrite
 	handler := promrw.NewHandler(sink, promrw.HandlerConfig{
 		Options: promrw.Options{
@@ -63,6 +71,7 @@ func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (
 	})
 
 	mux := http.NewServeMux()
+	otlp.Register(mux)
 	mux.Handle(rw.Path, handler)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 	mux.Handle("GET /readyz", readyHandler(rt))
@@ -96,9 +105,12 @@ func readyHandler(rt *router.Router) http.Handler {
 
 // Run serves until ctx is canceled, then drains in-flight writes.
 func (a *App) Run(ctx context.Context) error {
-	a.lg.Info("Serving Prometheus remote write",
+	a.lg.Info("Serving ingest",
 		zap.String("bind", a.cfg.RemoteWrite.Bind),
-		zap.String("path", a.cfg.RemoteWrite.Path),
+		zap.String("remote_write_path", a.cfg.RemoteWrite.Path),
+		zap.Strings("otlp_paths", []string{
+			otlpdirect.LogsPath, otlpdirect.TracesPath, otlpdirect.MetricsPath, otlpdirect.ProfilesPath,
+		}),
 		zap.Strings("etcd", a.cfg.Cluster.Etcd),
 	)
 

--- a/cmd/odbingest/app.go
+++ b/cmd/odbingest/app.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"net"
 	"net/http"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/sdk/app"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+
+	"google.golang.org/grpc"
 
 	"github.com/oteldb/storage/cluster/router"
 
@@ -23,6 +26,7 @@ type App struct {
 	lg     *zap.Logger
 	router *router.Router
 	srv    *http.Server
+	grpc   *grpc.Server
 }
 
 func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*App, error) {
@@ -76,10 +80,17 @@ func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 	mux.Handle("GET /readyz", readyHandler(rt))
 
+	var grpcSrv *grpc.Server
+	if cfg.OTLP.GRPCBind != "-" {
+		grpcSrv = grpc.NewServer(otlp.GRPCServerOptions()...)
+		otlp.RegisterGRPC(grpcSrv)
+	}
+
 	return &App{
 		cfg:    cfg,
 		lg:     lg,
 		router: rt,
+		grpc:   grpcSrv,
 		srv: &http.Server{
 			Addr:              rw.Bind,
 			Handler:           mux,
@@ -111,17 +122,44 @@ func (a *App) Run(ctx context.Context) error {
 		zap.Strings("otlp_paths", []string{
 			otlpdirect.LogsPath, otlpdirect.TracesPath, otlpdirect.MetricsPath, otlpdirect.ProfilesPath,
 		}),
+		zap.String("otlp_grpc_bind", a.cfg.OTLP.GRPCBind),
 		zap.Strings("etcd", a.cfg.Cluster.Etcd),
 	)
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
 		if err := a.srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			return errors.Wrap(err, "serve remote write")
+			return errors.Wrap(err, "serve http")
 		}
 
 		return nil
 	})
+
+	if a.grpc != nil {
+		var lc net.ListenConfig
+
+		ln, err := lc.Listen(ctx, "tcp", a.cfg.OTLP.GRPCBind)
+		if err != nil {
+			return errors.Wrap(err, "listen for otlp grpc")
+		}
+
+		g.Go(func() error {
+			if err := a.grpc.Serve(ln); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+				return errors.Wrap(err, "serve otlp grpc")
+			}
+
+			return nil
+		})
+		g.Go(func() error {
+			<-gctx.Done()
+
+			// GracefulStop lets in-flight exports finish; a write cut off mid-flight is one the
+			// exporter must retry, and the cluster may already have taken it.
+			a.grpc.GracefulStop()
+
+			return nil
+		})
+	}
 	g.Go(func() error {
 		<-gctx.Done()
 

--- a/cmd/odbingest/app_test.go
+++ b/cmd/odbingest/app_test.go
@@ -26,8 +26,14 @@ import (
 	"github.com/oteldb/storage/signal"
 	"github.com/oteldb/storage/wal"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
 	"github.com/prometheus/prometheus/prompb"
 
+	"github.com/oteldb/oteldb/internal/otlpdirect"
 	"github.com/oteldb/oteldb/internal/promrw"
 )
 
@@ -80,6 +86,7 @@ type fakeNode struct {
 	mu      sync.Mutex
 	shards  map[string]int // shard key → samples applied
 	series  map[signal.SeriesID]signal.Series
+	records int
 	batches int
 }
 
@@ -136,7 +143,25 @@ func (n *fakeNode) apply(_ context.Context, _ signal.Signal, shardKey string, wa
 
 			return nil
 		},
+		OnRecords: func(signal.SeriesID, []byte) error {
+			n.records++
+
+			return nil
+		},
 	})
+}
+
+// applied is how many records and samples the node was asked to apply, across every signal.
+func (n *fakeNode) applied() int {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	total := n.records
+	for _, c := range n.shards {
+		total += c
+	}
+
+	return total
 }
 
 func (n *fakeNode) samples() int {
@@ -334,4 +359,84 @@ func TestValidateRequiresCluster(t *testing.T) {
 	cfg.setDefaults()
 
 	require.Error(t, cfg.validate())
+}
+
+// otlpPost sends a serialized OTLP export request at path.
+func otlpPost(t *testing.T, h http.Handler, path string, raw []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	return rec
+}
+
+// TestOTLPRoutesEverySignalToPrimary is the end-to-end check for the OTLP pack: each signal's
+// export must arrive at the ring primary as a WAL frame the node can replay, with odbingest
+// holding nothing.
+func TestOTLPRoutesEverySignalToPrimary(t *testing.T) {
+	t.Parallel()
+
+	const root = "/test"
+
+	endpoint := startEtcd(t)
+	node := startNode(t, endpoint, root, "node-a")
+
+	mux := http.NewServeMux()
+	otlpdirect.NewHandler(newTestSink(t, endpoint, root, 1), otlpdirect.HandlerConfig{}).Register(mux)
+
+	at := time.Now().Truncate(time.Second)
+
+	ld := plog.NewLogs()
+	lr := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetTimestamp(pcommon.NewTimestampFromTime(at))
+	lr.SetSeverityNumber(plog.SeverityNumberInfo)
+	lr.Body().SetStr("request completed")
+
+	logsRaw, err := (&plog.ProtoMarshaler{}).MarshalLogs(ld)
+	require.NoError(t, err)
+
+	td := ptrace.NewTraces()
+	sp := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	sp.SetName("GET /things")
+	sp.SetTraceID([16]byte{1})
+	sp.SetSpanID([8]byte{2})
+	sp.SetStartTimestamp(pcommon.NewTimestampFromTime(at))
+	sp.SetEndTimestamp(pcommon.NewTimestampFromTime(at.Add(time.Millisecond)))
+
+	tracesRaw, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
+	require.NoError(t, err)
+
+	md := pmetric.NewMetrics()
+	mt := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	mt.SetName("http_requests_total")
+
+	gp := mt.SetEmptyGauge().DataPoints().AppendEmpty()
+	gp.SetTimestamp(pcommon.NewTimestampFromTime(at))
+	gp.SetDoubleValue(42)
+
+	metricsRaw, err := (&pmetric.ProtoMarshaler{}).MarshalMetrics(md)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		path string
+		raw  []byte
+	}{
+		{otlpdirect.LogsPath, logsRaw},
+		{otlpdirect.TracesPath, tracesRaw},
+		{otlpdirect.MetricsPath, metricsRaw},
+	} {
+		// Twice, so the pooled buffers the batch aliased are overwritten before the assertion.
+		for range 2 {
+			rec := otlpPost(t, mux, tt.path, tt.raw)
+			require.Equal(t, http.StatusOK, rec.Code, "%s: %s", tt.path, rec.Body)
+		}
+	}
+
+	// Two of each signal: the logs and traces frames carry records, the metric frame carries a
+	// sample, and all three had to reach a primary to be counted.
+	assert.Equal(t, 6, node.applied(), "every signal's export reached the primary")
 }

--- a/cmd/odbingest/app_test.go
+++ b/cmd/odbingest/app_test.go
@@ -347,6 +347,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, []string{"127.0.0.1:2379"}, cfg.Cluster.Etcd)
 	assert.Equal(t, ":19291", cfg.RemoteWrite.Bind)
 	assert.Equal(t, "/", cfg.RemoteWrite.Path)
+	assert.Equal(t, ":4317", cfg.OTLP.GRPCBind)
 	assert.Equal(t, 15*time.Second, cfg.RemoteWrite.ShutdownTimeout)
 }
 

--- a/cmd/odbingest/config.go
+++ b/cmd/odbingest/config.go
@@ -17,6 +17,17 @@ type Config struct {
 	Cluster ClusterConfig `json:"cluster" yaml:"cluster"`
 	// RemoteWrite configures the Prometheus remote write endpoint.
 	RemoteWrite RemoteWriteConfig `json:"prometheus_remote_write" yaml:"prometheus_remote_write"`
+	// OTLP configures the OTLP/HTTP endpoints, which share the remote write listener.
+	OTLP OTLPConfig `json:"otlp" yaml:"otlp"`
+}
+
+// OTLPConfig configures the OTLP/HTTP ingest endpoints. They are always served, at the paths the
+// OTLP spec fixes (/v1/logs, /v1/traces, /v1/metrics, /v1/profiles).
+type OTLPConfig struct {
+	// MaxBodyBytes limits the request body. Zero ⇒ 64 MiB.
+	MaxBodyBytes xbytes.Bytes `json:"max_body_bytes" yaml:"max_body_bytes"`
+	// MaxDecodedBytes limits what a gzip body may expand to. Zero ⇒ 256 MiB.
+	MaxDecodedBytes xbytes.Bytes `json:"max_decoded_bytes" yaml:"max_decoded_bytes"`
 }
 
 // ClusterConfig points odbingest at the ring. odbingest joins nothing and stores nothing: it

--- a/cmd/odbingest/config.go
+++ b/cmd/odbingest/config.go
@@ -24,6 +24,9 @@ type Config struct {
 // OTLPConfig configures the OTLP/HTTP ingest endpoints. They are always served, at the paths the
 // OTLP spec fixes (/v1/logs, /v1/traces, /v1/metrics, /v1/profiles).
 type OTLPConfig struct {
+	// GRPCBind is the OTLP/gRPC listen address. Empty ⇒ ":4317", the port every OTLP exporter
+	// targets by default. "-" disables gRPC.
+	GRPCBind string `json:"grpc_bind" yaml:"grpc_bind"`
 	// MaxBodyBytes limits the request body. Zero ⇒ 64 MiB.
 	MaxBodyBytes xbytes.Bytes `json:"max_body_bytes" yaml:"max_body_bytes"`
 	// MaxDecodedBytes limits what a gzip body may expand to. Zero ⇒ 256 MiB.
@@ -83,6 +86,10 @@ func (cfg *Config) setDefaults() {
 	}
 	if rw.ShutdownTimeout == 0 {
 		rw.ShutdownTimeout = 15 * time.Second
+	}
+
+	if cfg.OTLP.GRPCBind == "" {
+		cfg.OTLP.GRPCBind = ":4317"
 	}
 }
 

--- a/cmd/odbingest/metrics.go
+++ b/cmd/odbingest/metrics.go
@@ -7,11 +7,16 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/oteldb/oteldb/internal/otlpdirect"
 	"github.com/oteldb/oteldb/internal/promrw"
 )
 
-// reasonKey labels a rejected point with why the shard primary refused it.
-const reasonKey = attribute.Key("reason")
+// reasonKey labels a rejected record with why the shard primary refused it, and signalKey with
+// which signal it belonged to.
+const (
+	reasonKey = attribute.Key("reason")
+	signalKey = attribute.Key("signal")
+)
 
 // observer records what the remote write endpoint ingested. Its counters are the ones an operator
 // alerts on: a sender that stopped, and points refused as too old.
@@ -21,6 +26,11 @@ type observer struct {
 	points    metric.Int64Counter
 	dropped   metric.Int64Counter
 	byteCount metric.Int64Counter
+
+	otlpRequests metric.Int64Counter
+	otlpItems    metric.Int64Counter
+	otlpRejected metric.Int64Counter
+	otlpBytes    metric.Int64Counter
 }
 
 func newObserver(mp metric.MeterProvider) (*observer, error) {
@@ -56,7 +66,42 @@ func newObserver(mp metric.MeterProvider) (*observer, error) {
 	); err != nil {
 		return nil, errors.Wrap(err, "create bytes counter")
 	}
+	if o.otlpRequests, err = meter.Int64Counter("odbingest.otlp.requests",
+		metric.WithDescription("Accepted OTLP export requests, by signal."),
+	); err != nil {
+		return nil, errors.Wrap(err, "create otlp requests counter")
+	}
+	if o.otlpItems, err = meter.Int64Counter("odbingest.otlp.items",
+		metric.WithDescription("Records, spans, points or samples received over OTLP, by signal."),
+	); err != nil {
+		return nil, errors.Wrap(err, "create otlp items counter")
+	}
+	if o.otlpRejected, err = meter.Int64Counter("odbingest.otlp.rejected_items",
+		metric.WithDescription("Items an OTLP request carried that could not be represented, by signal."),
+	); err != nil {
+		return nil, errors.Wrap(err, "create otlp rejected counter")
+	}
+	if o.otlpBytes, err = meter.Int64Counter("odbingest.otlp.decoded_bytes",
+		metric.WithDescription("Decompressed OTLP request bytes, by signal."),
+		metric.WithUnit("By"),
+	); err != nil {
+		return nil, errors.Wrap(err, "create otlp bytes counter")
+	}
+
 	return &o, nil
+}
+
+func (o *observer) observeOTLP(s otlpdirect.Stats) {
+	ctx := context.Background()
+	attr := metric.WithAttributes(signalKey.String(s.Signal.String()))
+
+	o.otlpRequests.Add(ctx, 1, attr)
+	o.otlpItems.Add(ctx, int64(s.Items), attr)
+	o.otlpBytes.Add(ctx, int64(s.Bytes), attr)
+
+	if s.Rejected > 0 {
+		o.otlpRejected.Add(ctx, int64(s.Rejected), attr)
+	}
 }
 
 func (o *observer) observe(s promrw.Stats) {

--- a/cmd/odbingest/sink.go
+++ b/cmd/odbingest/sink.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/oteldb/storage/cluster"
 	"github.com/oteldb/storage/cluster/router"
+	"github.com/oteldb/storage/signal/log"
 	sigmetric "github.com/oteldb/storage/signal/metric"
+	"github.com/oteldb/storage/signal/profile"
+	"github.com/oteldb/storage/signal/trace"
 )
 
 // clusterSink writes a batch into the cluster by routing each shard to its ring primary. odbingest
@@ -41,16 +44,41 @@ func newClusterSink(r *router.Router, tenantOf cluster.TenantFunc, mp metric.Met
 	return &clusterSink{router: r, tenantOf: tenantOf, accepted: accepted, rejected: rejected}, nil
 }
 
-// WriteMetrics implements promrw.Sink.
+// WriteMetrics implements promrw.Sink and otlpdirect.Sink.
 //
 // A rejection is not an error: the primaries admitted what they could and said why they refused
-// the rest, which is a 202 with the counters moving. Only a routing or transport failure fails the
-// request, so the sender retries a write that may not have landed and leaves one that did.
+// the rest, which is a success with the counters moving. Only a routing or transport failure fails
+// the request, so the sender retries a write that may not have landed and leaves one that did.
 func (s *clusterSink) WriteMetrics(ctx context.Context, batch sigmetric.Metrics) error {
 	res, err := s.router.WriteMetrics(ctx, batch, s.tenantOf)
 
-	s.accepted.Add(ctx, int64(res.Accepted))
-	s.observeRejects(ctx, res.Rejected)
+	return s.record(ctx, "metrics", res, err)
+}
+
+func (s *clusterSink) WriteLogs(ctx context.Context, batch log.Logs) error {
+	res, err := s.router.WriteLogs(ctx, batch, s.tenantOf)
+
+	return s.record(ctx, "logs", res, err)
+}
+
+func (s *clusterSink) WriteTraces(ctx context.Context, batch trace.Traces) error {
+	res, err := s.router.WriteTraces(ctx, batch, s.tenantOf)
+
+	return s.record(ctx, "traces", res, err)
+}
+
+func (s *clusterSink) WriteProfiles(ctx context.Context, batch *profile.Profiles) error {
+	res, err := s.router.WriteProfiles(ctx, batch, s.tenantOf)
+
+	return s.record(ctx, "profiles", res, err)
+}
+
+// record meters what the primaries said and turns a routing failure into the caller's error.
+func (s *clusterSink) record(ctx context.Context, sig string, res router.Written, err error) error {
+	attr := metric.WithAttributes(signalKey.String(sig))
+
+	s.accepted.Add(ctx, int64(res.Accepted), attr)
+	s.observeRejects(ctx, sig, res.Rejected)
 
 	if err != nil {
 		return errors.Wrap(err, "write to cluster")
@@ -59,14 +87,15 @@ func (s *clusterSink) WriteMetrics(ctx context.Context, batch sigmetric.Metrics)
 	return nil
 }
 
-func (s *clusterSink) observeRejects(ctx context.Context, rej cluster.Reject) {
+func (s *clusterSink) observeRejects(ctx context.Context, sig string, rej cluster.Reject) {
 	for reason, n := range map[string]int{
 		"out_of_order":  rej.OOO,
 		"max_series":    rej.Cardinality,
 		"max_in_flight": rej.InFlight,
 	} {
 		if n > 0 {
-			s.rejected.Add(ctx, int64(n), metric.WithAttributes(reasonKey.String(reason)))
+			s.rejected.Add(ctx, int64(n),
+				metric.WithAttributes(signalKey.String(sig), reasonKey.String(reason)))
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.158.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.37.3-0.20260816193804-dd8eb9b0b234
+	github.com/oteldb/storage v0.37.3-0.20260816211206-b7b99536087b
 	github.com/pierrec/lz4/v4 v4.1.28
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1

--- a/go.sum
+++ b/go.sum
@@ -1032,6 +1032,10 @@ github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
 github.com/oteldb/storage v0.37.3-0.20260816193804-dd8eb9b0b234 h1:rp20gedaGdJuPjR1S9CWYXlYRx7Azxichz6+s+kxXFE=
 github.com/oteldb/storage v0.37.3-0.20260816193804-dd8eb9b0b234/go.mod h1:5jH3Xz5R+arp//qqdtD6v01d86UhjKhWRli1Shb0Frc=
+github.com/oteldb/storage v0.37.3-0.20260816201201-da669d7a9e66 h1:bTraVBlqJXA9WWHdpl1rQd+ImtRn+7/3Qmwdj+olLpI=
+github.com/oteldb/storage v0.37.3-0.20260816201201-da669d7a9e66/go.mod h1:5jH3Xz5R+arp//qqdtD6v01d86UhjKhWRli1Shb0Frc=
+github.com/oteldb/storage v0.37.3-0.20260816211206-b7b99536087b h1:VSmAPF+QNd/4++S3RVwb/aVA6RshC81VCYXqW1Y25w8=
+github.com/oteldb/storage v0.37.3-0.20260816211206-b7b99536087b/go.mod h1:5jH3Xz5R+arp//qqdtD6v01d86UhjKhWRli1Shb0Frc=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/go.sum
+++ b/go.sum
@@ -1030,10 +1030,6 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.37.3-0.20260816193804-dd8eb9b0b234 h1:rp20gedaGdJuPjR1S9CWYXlYRx7Azxichz6+s+kxXFE=
-github.com/oteldb/storage v0.37.3-0.20260816193804-dd8eb9b0b234/go.mod h1:5jH3Xz5R+arp//qqdtD6v01d86UhjKhWRli1Shb0Frc=
-github.com/oteldb/storage v0.37.3-0.20260816201201-da669d7a9e66 h1:bTraVBlqJXA9WWHdpl1rQd+ImtRn+7/3Qmwdj+olLpI=
-github.com/oteldb/storage v0.37.3-0.20260816201201-da669d7a9e66/go.mod h1:5jH3Xz5R+arp//qqdtD6v01d86UhjKhWRli1Shb0Frc=
 github.com/oteldb/storage v0.37.3-0.20260816211206-b7b99536087b h1:VSmAPF+QNd/4++S3RVwb/aVA6RshC81VCYXqW1Y25w8=
 github.com/oteldb/storage v0.37.3-0.20260816211206-b7b99536087b/go.mod h1:5jH3Xz5R+arp//qqdtD6v01d86UhjKhWRli1Shb0Frc=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=

--- a/internal/otlpdirect/canonical_test.go
+++ b/internal/otlpdirect/canonical_test.go
@@ -1,0 +1,85 @@
+package otlpdirect_test
+
+import (
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/signal/log"
+)
+
+// The pdata path and the direct decoder disagree about how an absent byte field is spelled: pdata
+// renders a missing string as a zero-length non-nil slice ([]byte("") is never nil) and a missing
+// id as nil, while a decoder that simply never assigns the field leaves nil throughout.
+//
+// The distinction is not observable downstream. Identity hashing and column encoding both work off
+// length, so nil and []byte{} produce the same bytes on disk and the same series id — which is why
+// the parity tests canonicalize rather than chase pdata's spelling into the decoder. Everything
+// else is compared exactly.
+
+// canonical rewrites every zero-length byte slice in a batch to nil, so two batches that differ
+// only in that spelling compare equal.
+func canonical(l *log.Logs) *log.Logs {
+	for i := range l.Resources {
+		rl := &l.Resources[i]
+		rl.Resource.SchemaURL = canonBytes(rl.Resource.SchemaURL)
+		rl.Resource.Attributes = canonAttrs(rl.Resource.Attributes)
+
+		for j := range rl.Scopes {
+			sl := &rl.Scopes[j]
+			sl.Scope.Name = canonBytes(sl.Scope.Name)
+			sl.Scope.Version = canonBytes(sl.Scope.Version)
+			sl.Scope.SchemaURL = canonBytes(sl.Scope.SchemaURL)
+			sl.Scope.Attributes = canonAttrs(sl.Scope.Attributes)
+
+			for k := range sl.Records {
+				r := &sl.Records[k]
+				r.SeverityText = canonBytes(r.SeverityText)
+				r.Body = canonBytes(r.Body)
+				r.TraceID = canonBytes(r.TraceID)
+				r.SpanID = canonBytes(r.SpanID)
+				r.Attributes = canonAttrs(r.Attributes)
+			}
+		}
+	}
+
+	return l
+}
+
+func canonBytes(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+
+	return b
+}
+
+func canonAttrs(a signal.Attributes) signal.Attributes {
+	if len(a) == 0 {
+		return nil
+	}
+
+	for i := range a {
+		a[i].Key = canonBytes(a[i].Key)
+		a[i].Value = canonValue(a[i].Value)
+	}
+
+	return a
+}
+
+func canonValue(v signal.Value) signal.Value {
+	switch v.Kind() {
+	case signal.KindStr:
+		return signal.StringValue(canonBytes(v.Str()))
+	case signal.KindBytes:
+		return signal.BytesValue(canonBytes(v.Bytes()))
+	case signal.KindSlice:
+		vs := v.Slice()
+		for i := range vs {
+			vs[i] = canonValue(vs[i])
+		}
+
+		return signal.SliceValue(vs...)
+	case signal.KindMap:
+		return signal.MapValue(canonAttrs(v.Map())...)
+	default:
+		return v
+	}
+}

--- a/internal/otlpdirect/fuzz_metrics_test.go
+++ b/internal/otlpdirect/fuzz_metrics_test.go
@@ -1,0 +1,177 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// FuzzConvertMetrics drives the metric decoder with arbitrary bytes. Metrics is the only signal
+// that computes rather than copies: bucket bounds are derived from a scale, counts are cumulated,
+// and names are synthesized — so a malformed point can reach arithmetic the other decoders never
+// run, including a scale that makes math.Pow overflow.
+func FuzzConvertMetrics(f *testing.F) {
+	seed := func(build func(pmetric.Metrics)) {
+		md := pmetric.NewMetrics()
+		build(md)
+
+		raw, err := (&pmetric.ProtoMarshaler{}).MarshalMetrics(md)
+		if err != nil {
+			f.Fatal(err)
+		}
+
+		f.Add(raw)
+	}
+
+	seed(func(pmetric.Metrics) {})
+
+	seed(func(md pmetric.Metrics) {
+		m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		m.SetName("g")
+
+		p := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		p.SetTimestamp(1)
+		p.SetDoubleValue(1.5)
+	})
+
+	seed(func(md pmetric.Metrics) {
+		rm := md.ResourceMetrics().AppendEmpty()
+		rm.SetSchemaUrl("res")
+		rm.Resource().Attributes().PutStr("service.name", "api")
+
+		sm := rm.ScopeMetrics().AppendEmpty()
+		sm.SetSchemaUrl("scope")
+		sm.Scope().SetName("n")
+
+		s := sm.Metrics().AppendEmpty()
+		s.SetName("c")
+		s.SetUnit("1")
+
+		sum := s.SetEmptySum()
+		sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+		sum.SetIsMonotonic(true)
+
+		sp := sum.DataPoints().AppendEmpty()
+		sp.SetStartTimestamp(1)
+		sp.SetTimestamp(2)
+		sp.SetIntValue(3)
+		sp.Attributes().PutStr("k", "v")
+	})
+
+	seed(func(md pmetric.Metrics) {
+		m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		m.SetName("h")
+		m.SetUnit("ms")
+
+		h := m.SetEmptyHistogram()
+		h.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+		dp := h.DataPoints().AppendEmpty()
+		dp.SetTimestamp(1)
+		dp.SetCount(6)
+		dp.SetSum(1.5)
+		dp.ExplicitBounds().FromRaw([]float64{1, 2, 3})
+		dp.BucketCounts().FromRaw([]uint64{1, 2, 3, 0})
+		dp.Attributes().PutStr("k", "v")
+	})
+
+	seed(func(md pmetric.Metrics) {
+		m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		m.SetName("e")
+
+		eh := m.SetEmptyExponentialHistogram()
+		eh.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+		dp := eh.DataPoints().AppendEmpty()
+		dp.SetTimestamp(1)
+		dp.SetCount(9)
+		dp.SetSum(2)
+		dp.SetScale(3)
+		dp.SetZeroCount(1)
+		dp.Positive().SetOffset(2)
+		dp.Positive().BucketCounts().FromRaw([]uint64{1, 2, 3})
+		dp.Negative().SetOffset(-3)
+		dp.Negative().BucketCounts().FromRaw([]uint64{2})
+	})
+
+	seed(func(md pmetric.Metrics) {
+		m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		m.SetName("s")
+
+		dp := m.SetEmptySummary().DataPoints().AppendEmpty()
+		dp.SetTimestamp(1)
+		dp.SetCount(4)
+		dp.SetSum(2)
+
+		for _, q := range []float64{0, 0.5, 1} {
+			qv := dp.QuantileValues().AppendEmpty()
+			qv.SetQuantile(q)
+			qv.SetValue(q * 2)
+		}
+	})
+
+	f.Add([]byte{})
+	f.Add([]byte{0xff, 0xff, 0xff, 0xff})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var c otlpdirect.MetricsConverter
+
+		got, dropped, err := c.Convert(data)
+		if err != nil {
+			return
+		}
+
+		if dropped < 0 {
+			t.Fatalf("negative dropped count: %d", dropped)
+		}
+
+		points := 0
+
+		for i := range got.Resources {
+			rm := &got.Resources[i]
+			_ = len(rm.Resource.SchemaURL) + len(rm.Resource.Attributes)
+
+			for j := range rm.Scopes {
+				sm := &rm.Scopes[j]
+				_ = len(sm.Scope.Name)
+
+				for k := range sm.Metrics {
+					mt := &sm.Metrics[k]
+					_ = len(mt.Name) + len(mt.Unit)
+
+					for p := range mt.Points {
+						_ = len(mt.Points[p].Attributes)
+						points++
+					}
+				}
+			}
+		}
+
+		// The scratch is reused across points and across calls, and the decomposition writes
+		// synthesized names into the same arena the attributes come from — so a second pass over
+		// the same bytes must produce the same batch, not one built on recycled memory.
+		again, againDropped, err := c.Convert(data)
+		if err != nil {
+			t.Fatalf("second convert of the same input failed: %v", err)
+		}
+
+		if againDropped != dropped {
+			t.Fatalf("reuse changed the dropped count: %d then %d", dropped, againDropped)
+		}
+
+		againPoints := 0
+		for i := range again.Resources {
+			for j := range again.Resources[i].Scopes {
+				for k := range again.Resources[i].Scopes[j].Metrics {
+					againPoints += len(again.Resources[i].Scopes[j].Metrics[k].Points)
+				}
+			}
+		}
+
+		if againPoints != points {
+			t.Fatalf("reuse changed the point count: %d then %d", points, againPoints)
+		}
+	})
+}

--- a/internal/otlpdirect/fuzz_profiles_test.go
+++ b/internal/otlpdirect/fuzz_profiles_test.go
@@ -1,0 +1,127 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pprofile"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// FuzzConvertProfiles drives the profiles decoder with arbitrary bytes. Everything here is
+// index-based — samples name stacks, stacks name locations, locations name functions and mappings,
+// and all of them bottom out in a string table the same request supplies — so a malformed request
+// has plenty of room to point an index somewhere the table does not reach.
+func FuzzConvertProfiles(f *testing.F) {
+	seed := func(build func(pprofile.Profiles)) {
+		pd := pprofile.NewProfiles()
+		build(pd)
+
+		raw, err := (&pprofile.ProtoMarshaler{}).MarshalProfiles(pd)
+		if err != nil {
+			f.Fatal(err)
+		}
+
+		f.Add(raw)
+	}
+
+	seed(func(pprofile.Profiles) {})
+
+	seed(func(pd pprofile.Profiles) {
+		pd.Dictionary().StringTable().Append("")
+
+		pr := pd.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+		pr.SetTime(1)
+		pr.Samples().AppendEmpty().Values().Append(1)
+	})
+
+	seed(func(pd pprofile.Profiles) {
+		full := fullProfiles(f)
+		full.CopyTo(pd)
+	})
+
+	// Many samples in one profile, so the reused scratch is exercised under mutation.
+	seed(func(pd pprofile.Profiles) {
+		pd.Dictionary().StringTable().Append("")
+
+		pr := pd.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+		for i := range 8 {
+			s := pr.Samples().AppendEmpty()
+			s.SetStackIndex(int32(i))
+			s.Values().Append(int64(i))
+
+			if i%2 == 0 {
+				s.TimestampsUnixNano().Append(uint64(i))
+			}
+
+			if i%3 == 0 {
+				s.AttributeIndices().Append(int32(i))
+			}
+		}
+	})
+
+	f.Add([]byte{})
+	f.Add([]byte{0xff, 0xff, 0xff, 0xff})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var c otlpdirect.ProfilesConverter
+
+		got, err := c.Convert(data)
+		if err != nil {
+			return
+		}
+
+		dict := got.Dictionary
+		for i := range dict.Strings {
+			_ = len(dict.Strings[i])
+		}
+
+		for i := range dict.Locations {
+			_ = len(dict.Locations[i].Lines) + len(dict.Locations[i].AttributeIndices)
+		}
+
+		for i := range dict.Stacks {
+			_ = len(dict.Stacks[i].LocationIndices)
+		}
+
+		for i := range dict.Links {
+			_ = len(dict.Links[i].TraceID) + len(dict.Links[i].SpanID)
+		}
+
+		for i := range got.Resources {
+			rp := &got.Resources[i]
+			_ = len(rp.Resource.SchemaURL) + len(rp.Resource.Attributes)
+
+			for j := range rp.Scopes {
+				sp := &rp.Scopes[j]
+				_ = len(sp.Scope.Name) + len(sp.Scope.Attributes)
+
+				for k := range sp.Profiles {
+					pr := &sp.Profiles[k]
+					_ = len(pr.ProfileID) + len(pr.AttributeIndices)
+
+					for s := range pr.Samples {
+						_ = len(pr.Samples[s].Values) + len(pr.Samples[s].TimestampsUnixNano) +
+							len(pr.Samples[s].AttributeIndices)
+					}
+				}
+			}
+		}
+
+		// The scratch is reused across elements and across calls; a second pass over the same
+		// bytes must produce the same batch, not one contaminated by the first.
+		again, err := c.Convert(data)
+		if err != nil {
+			t.Fatalf("second convert of the same input failed: %v", err)
+		}
+
+		if len(again.Resources) != len(got.Resources) {
+			t.Fatalf("reuse changed the batch: %d resources then %d", len(got.Resources), len(again.Resources))
+		}
+
+		if len(again.Dictionary.Strings) != len(got.Dictionary.Strings) {
+			t.Fatalf("reuse changed the dictionary: %d strings then %d",
+				len(got.Dictionary.Strings), len(again.Dictionary.Strings))
+		}
+	})
+}

--- a/internal/otlpdirect/fuzz_test.go
+++ b/internal/otlpdirect/fuzz_test.go
@@ -1,0 +1,95 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// FuzzConvertLogs drives the decoder with arbitrary bytes: the request is attacker-controlled, so
+// no input may panic, hang, or allocate without bound — an error is the only acceptable failure.
+//
+// The seed corpus is real OTLP, so the fuzzer starts from structurally valid messages and mutates
+// outward rather than spending its budget rediscovering the framing.
+func FuzzConvertLogs(f *testing.F) {
+	seed := func(build func(plog.Logs)) {
+		ld := plog.NewLogs()
+		build(ld)
+
+		raw, err := (&plog.ProtoMarshaler{}).MarshalLogs(ld)
+		if err != nil {
+			f.Fatal(err)
+		}
+
+		f.Add(raw)
+	}
+
+	seed(func(plog.Logs) {})
+	seed(func(ld plog.Logs) {
+		r := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		r.SetTimestamp(1)
+		r.Body().SetStr("hello")
+	})
+	seed(func(ld plog.Logs) {
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.SetSchemaUrl("s")
+		rl.Resource().Attributes().PutStr("service.name", "api")
+
+		sl := rl.ScopeLogs().AppendEmpty()
+		sl.SetSchemaUrl("scope")
+		sl.Scope().SetName("n")
+
+		r := sl.LogRecords().AppendEmpty()
+		r.SetTimestamp(2)
+		r.SetObservedTimestamp(3)
+		r.SetSeverityNumber(plog.SeverityNumberWarn)
+		r.SetSeverityText("WARN")
+		r.SetTraceID([16]byte{1})
+		r.SetSpanID([8]byte{2})
+		r.SetFlags(plog.LogRecordFlags(1))
+		r.SetDroppedAttributesCount(1)
+
+		m := r.Body().SetEmptyMap()
+		m.PutStr("k", "v")
+		m.PutEmptySlice("l").AppendEmpty().SetInt(1)
+
+		r.Attributes().PutEmptyBytes("b").Append(1, 2, 3)
+		r.Attributes().PutDouble("d", 1.5)
+	})
+
+	f.Add([]byte{})
+	f.Add([]byte{0xff, 0xff, 0xff, 0xff})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var c otlpdirect.LogsConverter
+
+		got, err := c.Convert(data)
+		if err != nil {
+			return
+		}
+
+		// A successful decode must be internally consistent: every slot the walk created is
+		// reachable and every record is readable without panicking.
+		for i := range got.Resources {
+			rl := &got.Resources[i]
+			_ = len(rl.Resource.SchemaURL)
+
+			for j := range rl.Scopes {
+				sl := &rl.Scopes[j]
+				_ = len(sl.Scope.Name)
+
+				for k := range sl.Records {
+					rec := &sl.Records[k]
+					_ = len(rec.Body) + len(rec.TraceID) + len(rec.SpanID) + len(rec.Attributes)
+				}
+			}
+		}
+
+		// Reuse must not corrupt the previous batch's scratch into the next one.
+		if _, err := c.Convert(data); err != nil {
+			t.Fatalf("second convert of the same input failed: %v", err)
+		}
+	})
+}

--- a/internal/otlpdirect/fuzz_traces_test.go
+++ b/internal/otlpdirect/fuzz_traces_test.go
@@ -1,0 +1,145 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// FuzzConvertTraces drives the span decoder with arbitrary bytes. Traces is the deepest of the
+// signals — a span nests status, events and links, each with their own attributes, each of which
+// can nest maps and slices to any depth — so this is where a malformed request has the most room
+// to find an unchecked length or an unbounded recursion.
+func FuzzConvertTraces(f *testing.F) {
+	seed := func(build func(ptrace.Traces)) {
+		td := ptrace.NewTraces()
+		build(td)
+
+		raw, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
+		if err != nil {
+			f.Fatal(err)
+		}
+
+		f.Add(raw)
+	}
+
+	seed(func(ptrace.Traces) {})
+
+	seed(func(td ptrace.Traces) {
+		sp := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+		sp.SetName("op")
+		sp.SetStartTimestamp(1)
+		sp.SetEndTimestamp(2)
+	})
+
+	seed(func(td ptrace.Traces) {
+		rs := td.ResourceSpans().AppendEmpty()
+		rs.SetSchemaUrl("res")
+		rs.Resource().Attributes().PutStr("service.name", "api")
+
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.SetSchemaUrl("scope")
+		ss.Scope().SetName("n")
+		ss.Scope().SetVersion("1")
+
+		sp := ss.Spans().AppendEmpty()
+		sp.SetTraceID([16]byte{1, 2, 3})
+		sp.SetSpanID([8]byte{4})
+		sp.SetParentSpanID([8]byte{5})
+		sp.TraceState().FromRaw("k=v")
+		sp.SetName("GET /x")
+		sp.SetKind(ptrace.SpanKindClient)
+		sp.SetStartTimestamp(1)
+		sp.SetEndTimestamp(2)
+		sp.SetFlags(1)
+		sp.SetDroppedAttributesCount(1)
+		sp.Status().SetCode(ptrace.StatusCodeError)
+		sp.Status().SetMessage("boom")
+
+		nested := sp.Attributes().PutEmptyMap("nested")
+		nested.PutStr("a", "b")
+		nested.PutEmptySlice("l").AppendEmpty().SetDouble(1.5)
+		sp.Attributes().PutEmptyBytes("raw").Append(1, 2, 3)
+
+		ev := sp.Events().AppendEmpty()
+		ev.SetTimestamp(3)
+		ev.SetName("ev")
+		ev.SetDroppedAttributesCount(2)
+		ev.Attributes().PutInt("i", 1)
+
+		ln := sp.Links().AppendEmpty()
+		ln.SetTraceID([16]byte{9})
+		ln.SetSpanID([8]byte{9})
+		ln.TraceState().FromRaw("l=s")
+		ln.SetDroppedAttributesCount(3)
+		ln.Attributes().PutBool("b", true)
+	})
+
+	// Many spans in one scope, so the reused collectors are exercised under mutation.
+	seed(func(td ptrace.Traces) {
+		ss := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty()
+		for i := range 8 {
+			sp := ss.Spans().AppendEmpty()
+			sp.SetName("op")
+			sp.SetStartTimestamp(1)
+			sp.Attributes().PutInt("i", int64(i))
+
+			if i%2 == 0 {
+				sp.Events().AppendEmpty().SetName("ev")
+			}
+
+			if i%3 == 0 {
+				sp.Links().AppendEmpty().SetTraceID([16]byte{byte(i)})
+			}
+		}
+	})
+
+	f.Add([]byte{})
+	f.Add([]byte{0xff, 0xff, 0xff, 0xff})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var c otlpdirect.TracesConverter
+
+		got, err := c.Convert(data)
+		if err != nil {
+			return
+		}
+
+		for i := range got.Resources {
+			rs := &got.Resources[i]
+			_ = len(rs.Resource.SchemaURL) + len(rs.Resource.Attributes)
+
+			for j := range rs.Scopes {
+				ss := &rs.Scopes[j]
+				_ = len(ss.Scope.Name)
+
+				for k := range ss.Spans {
+					sp := &ss.Spans[k]
+					_ = len(sp.Name) + len(sp.TraceID) + len(sp.SpanID) + len(sp.ParentSpanID) +
+						len(sp.TraceState) + len(sp.StatusMessage) + len(sp.Attributes)
+
+					for e := range sp.Events {
+						_ = len(sp.Events[e].Name) + len(sp.Events[e].Attributes)
+					}
+
+					for l := range sp.Links {
+						_ = len(sp.Links[l].TraceID) + len(sp.Links[l].Attributes)
+					}
+				}
+			}
+		}
+
+		// The collectors are reused across spans and across calls; a second pass over the same
+		// bytes must produce the same batch, not one contaminated by the first.
+		again, err := c.Convert(data)
+		if err != nil {
+			t.Fatalf("second convert of the same input failed: %v", err)
+		}
+
+		if len(again.Resources) != len(got.Resources) {
+			t.Fatalf("reuse changed the batch: %d resources then %d", len(got.Resources), len(again.Resources))
+		}
+	})
+}

--- a/internal/otlpdirect/grpc.go
+++ b/internal/otlpdirect/grpc.go
@@ -1,0 +1,193 @@
+package otlpdirect
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/mem"
+	"google.golang.org/grpc/status"
+
+	"github.com/oteldb/storage/signal"
+)
+
+// gRPC is what an OTLP exporter speaks by default — the OTel SDKs and the collector's own exporter
+// both target 4317 before 4318 — so serving only OTLP/HTTP would leave most senders unable to
+// reach an ingester without being reconfigured.
+//
+// The services are registered by hand rather than from generated stubs: the generated server
+// would unmarshal each request into a pdata (or gogo) struct, which is the allocation this package
+// exists to avoid. Instead a raw codec hands the request's bytes straight to the same converters
+// the HTTP endpoints use, so the two transports share one decode path and one aliasing contract.
+
+// Fully-qualified OTLP service names. They are part of the wire contract, so a client's method
+// string must match these exactly.
+const (
+	logsService     = "opentelemetry.proto.collector.logs.v1.LogsService"
+	tracesService   = "opentelemetry.proto.collector.trace.v1.TraceService"
+	metricsService  = "opentelemetry.proto.collector.metrics.v1.MetricsService"
+	profilesService = "opentelemetry.proto.collector.profiles.v1development.ProfilesService"
+
+	exportMethod = "Export"
+)
+
+// rawCodecName is the content subtype the raw codec registers under. gRPC resolves a codec by the
+// subtype in the request's content-type, and an OTLP client sends "proto" — so the server is
+// given this codec explicitly with [grpc.ForceServerCodecV2] rather than registering it globally,
+// which would hijack every other proto service in the process.
+const rawCodecName = "proto"
+
+// GRPCServerOptions returns the options an OTLP gRPC server needs: the raw codec that skips
+// unmarshaling, and a message-size limit matching the HTTP body limit.
+//
+// Pass them to [grpc.NewServer], then call [Handler.RegisterGRPC] on the result.
+func (h *Handler) GRPCServerOptions() []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.ForceServerCodecV2(rawCodec{}),
+		grpc.MaxRecvMsgSize(int(h.maxBody)),
+	}
+}
+
+// RegisterGRPC registers the four OTLP export services on srv. The server must have been built
+// with [Handler.GRPCServerOptions].
+func (h *Handler) RegisterGRPC(srv grpc.ServiceRegistrar) {
+	for _, s := range []struct {
+		name   string
+		sig    signal.Signal
+		ingest ingestFunc
+	}{
+		{logsService, signal.Log, h.ingestLogs},
+		{tracesService, signal.Trace, h.ingestTraces},
+		{metricsService, signal.Metric, h.ingestMetrics},
+		{profilesService, signal.Profile, h.ingestProfiles},
+	} {
+		srv.RegisterService(&grpc.ServiceDesc{
+			ServiceName: s.name,
+			HandlerType: (*any)(nil),
+			Methods: []grpc.MethodDesc{{
+				MethodName: exportMethod,
+				Handler:    h.exportHandler(s.sig, s.ingest),
+			}},
+			Metadata: s.name,
+		}, struct{}{})
+	}
+}
+
+// exportHandler builds the unary handler for one signal's Export method.
+func (h *Handler) exportHandler(sig signal.Signal, ingest ingestFunc) grpc.MethodHandler {
+	return func(
+		_ any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor,
+	) (any, error) {
+		msg, _ := grpcMessages.Get().(*rawMessage)
+		defer grpcMessages.Put(msg)
+
+		if err := dec(msg); err != nil {
+			return nil, err
+		}
+
+		export := func(ctx context.Context, req any) (any, error) {
+			m, ok := req.(*rawMessage)
+			if !ok {
+				return nil, status.Error(codes.Internal, "unexpected request type")
+			}
+
+			items, rejected, err := ingest(ctx, m.data)
+			if err != nil {
+				return nil, h.grpcError(sig, err)
+			}
+
+			if h.observe != nil {
+				h.observe(Stats{Signal: sig, Bytes: len(m.data), Items: items, Rejected: rejected})
+			}
+
+			if rejected == 0 {
+				return &rawMessage{}, nil
+			}
+
+			return &rawMessage{data: encodePartialSuccess(sig, rejected)}, nil
+		}
+
+		if interceptor == nil {
+			return export(ctx, msg)
+		}
+
+		return interceptor(ctx, msg, &grpc.UnaryServerInfo{
+			Server:     struct{}{},
+			FullMethod: "/" + serviceOf(sig) + "/" + exportMethod,
+		}, export)
+	}
+}
+
+// grpcError maps a failure to the status code that tells the client what to do with it: a write
+// that may not have landed is Unavailable so the client retries, and a request it encoded wrong is
+// InvalidArgument so it does not.
+func (h *Handler) grpcError(sig signal.Signal, err error) error {
+	code := codes.InvalidArgument
+	if we := new(writeError); errors.As(err, we) {
+		code = codes.Unavailable
+	}
+
+	h.lg.Debug("Reject OTLP gRPC export",
+		zap.Stringer("signal", sig), zap.Error(err), zap.Stringer("code", code))
+
+	return status.Error(code, err.Error())
+}
+
+func serviceOf(sig signal.Signal) string {
+	switch sig {
+	case signal.Log:
+		return logsService
+	case signal.Trace:
+		return tracesService
+	case signal.Profile:
+		return profilesService
+	default:
+		return metricsService
+	}
+}
+
+// rawMessage carries a request or response body without a generated type behind it.
+type rawMessage struct{ data []byte }
+
+var grpcMessages = sync.Pool{New: func() any { return new(rawMessage) }}
+
+// rawCodec hands a request's bytes to the converters unchanged, and writes a response's bytes
+// unchanged. It is the whole reason the gRPC path costs the same as the HTTP one.
+type rawCodec struct{}
+
+func (rawCodec) Name() string { return rawCodecName }
+
+func (rawCodec) Marshal(v any) (mem.BufferSlice, error) {
+	m, ok := v.(*rawMessage)
+	if !ok {
+		return nil, errors.Errorf("otlpdirect: cannot marshal %T", v)
+	}
+
+	if len(m.data) == 0 {
+		return nil, nil
+	}
+
+	return mem.BufferSlice{mem.SliceBuffer(m.data)}, nil
+}
+
+func (rawCodec) Unmarshal(data mem.BufferSlice, v any) error {
+	m, ok := v.(*rawMessage)
+	if !ok {
+		return errors.Errorf("otlpdirect: cannot unmarshal into %T", v)
+	}
+
+	// gRPC frees data as soon as this returns, so the bytes are copied into the message's own
+	// buffer — which is pooled, making this the same single copy the HTTP path pays reading a body.
+	n := data.Len()
+	if cap(m.data) < n {
+		m.data = make([]byte, n)
+	}
+
+	m.data = m.data[:n]
+	data.CopyTo(m.data)
+
+	return nil
+}

--- a/internal/otlpdirect/grpc_test.go
+++ b/internal/otlpdirect/grpc_test.go
@@ -1,0 +1,228 @@
+package otlpdirect_test
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/mem"
+	"google.golang.org/grpc/status"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// serveGRPC runs the OTLP gRPC services over a real connection, so the tests exercise the wire
+// contract an exporter actually speaks rather than the handler in isolation.
+func serveGRPC(t *testing.T, sink otlpdirect.Sink) *grpc.ClientConn {
+	t.Helper()
+
+	h := otlpdirect.NewHandler(sink, otlpdirect.HandlerConfig{})
+
+	srv := grpc.NewServer(h.GRPCServerOptions()...)
+	h.RegisterGRPC(srv)
+
+	var lc net.ListenConfig
+
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() { _ = srv.Serve(ln) }()
+
+	t.Cleanup(srv.Stop)
+
+	cc, err := grpc.NewClient(ln.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = cc.Close() })
+
+	return cc
+}
+
+// TestGRPCExportsEverySignal drives the server with the generated OTLP clients — the same stubs a
+// real exporter uses — so the hand-registered services and the raw codec are checked against the
+// actual protocol, not against our own encoder.
+func TestGRPCExportsEverySignal(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	cc := serveGRPC(t, sink)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	ld := plog.NewLogs()
+	lr := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetTimestamp(1)
+	lr.Body().SetStr("hello")
+
+	logsResp, err := plogotlp.NewGRPCClient(cc).Export(ctx, plogotlp.NewExportRequestFromLogs(ld))
+	require.NoError(t, err)
+	assert.Zero(t, logsResp.PartialSuccess().RejectedLogRecords())
+
+	td := ptrace.NewTraces()
+	sp := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	sp.SetName("op")
+	sp.SetStartTimestamp(1)
+
+	tracesResp, err := ptraceotlp.NewGRPCClient(cc).Export(ctx, ptraceotlp.NewExportRequestFromTraces(td))
+	require.NoError(t, err)
+	assert.Zero(t, tracesResp.PartialSuccess().RejectedSpans())
+
+	md := pmetric.NewMetrics()
+	mt := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	mt.SetName("g")
+
+	gp := mt.SetEmptyGauge().DataPoints().AppendEmpty()
+	gp.SetTimestamp(1)
+	gp.SetDoubleValue(1)
+
+	metricsResp, err := pmetricotlp.NewGRPCClient(cc).Export(ctx, pmetricotlp.NewExportRequestFromMetrics(md))
+	require.NoError(t, err)
+	assert.Zero(t, metricsResp.PartialSuccess().RejectedDataPoints())
+
+	assert.Equal(t, 1, sink.logs)
+	assert.Equal(t, 1, sink.spans)
+	assert.Equal(t, 1, sink.points)
+}
+
+// TestGRPCPartialSuccess pins that the partial-success response survives the round trip and is
+// read back by the generated client — the count is what tells an exporter to stop retrying.
+func TestGRPCPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	cc := serveGRPC(t, sink)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	md := pmetric.NewMetrics()
+
+	m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("g")
+
+	dps := m.SetEmptyGauge().DataPoints()
+	dps.AppendEmpty().SetTimestamp(1) // no value: unrepresentable
+
+	valued := dps.AppendEmpty()
+	valued.SetTimestamp(2)
+	valued.SetDoubleValue(1)
+
+	resp, err := pmetricotlp.NewGRPCClient(cc).Export(ctx, pmetricotlp.NewExportRequestFromMetrics(md))
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), resp.PartialSuccess().RejectedDataPoints())
+	assert.NotEmpty(t, resp.PartialSuccess().ErrorMessage())
+	assert.Equal(t, 1, sink.points, "the representable point is still stored")
+}
+
+// TestGRPCWriteFailureIsRetryable pins the status codes an exporter keys off: a write that may not
+// have landed is Unavailable so it retries, and a malformed request is InvalidArgument so it does
+// not.
+func TestGRPCWriteFailureIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{failWith: errors.New("no primary")}
+	cc := serveGRPC(t, sink)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	ld := plog.NewLogs()
+	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().SetTimestamp(1)
+
+	_, err := plogotlp.NewGRPCClient(cc).Export(ctx, plogotlp.NewExportRequestFromLogs(ld))
+	require.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+func TestGRPCMalformedIsNotRetryable(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	cc := serveGRPC(t, sink)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	// Invoke the method directly with bytes no decoder can read, bypassing the generated client.
+	err := cc.Invoke(ctx, "/opentelemetry.proto.collector.trace.v1.TraceService/Export",
+		&rawRequest{data: []byte{0xff, 0xff, 0xff, 0xff}}, &rawRequest{},
+		grpc.ForceCodecV2(passthroughCodec{}))
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestGRPCConcurrent drives the server from many goroutines, since the converters and the message
+// buffers are pooled across calls.
+func TestGRPCConcurrent(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	cc := serveGRPC(t, sink)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+
+	ld := plog.NewLogs()
+	lr := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetTimestamp(1)
+	lr.Body().SetStr("x")
+
+	client := plogotlp.NewGRPCClient(cc)
+	req := plogotlp.NewExportRequestFromLogs(ld)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			_, err := client.Export(ctx, req)
+			assert.NoError(t, err)
+		})
+	}
+
+	wg.Wait()
+	assert.Equal(t, 50, sink.logs)
+}
+
+// rawRequest and passthroughCodec let a test send bytes the generated clients cannot construct.
+type rawRequest struct{ data []byte }
+
+type passthroughCodec struct{}
+
+func (passthroughCodec) Name() string { return "proto" }
+
+func (passthroughCodec) Marshal(v any) (mem.BufferSlice, error) {
+	m, ok := v.(*rawRequest)
+	if !ok {
+		return nil, errors.Errorf("cannot marshal %T", v)
+	}
+
+	return mem.BufferSlice{mem.SliceBuffer(m.data)}, nil
+}
+
+func (passthroughCodec) Unmarshal(data mem.BufferSlice, v any) error {
+	m, ok := v.(*rawRequest)
+	if !ok {
+		return errors.Errorf("cannot unmarshal into %T", v)
+	}
+
+	m.data = data.Materialize()
+
+	return nil
+}

--- a/internal/otlpdirect/handler.go
+++ b/internal/otlpdirect/handler.go
@@ -1,0 +1,376 @@
+package otlpdirect
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/signal/log"
+	"github.com/oteldb/storage/signal/metric"
+	"github.com/oteldb/storage/signal/profile"
+	"github.com/oteldb/storage/signal/trace"
+)
+
+// Sink ingests a converted batch. Only the signals a deployment serves need to be implemented; a
+// nil method's endpoint answers 501.
+//
+// Every batch aliases the request buffer, which the handler recycles as soon as the call returns:
+// an implementation retaining any of its bytes must copy them.
+type Sink interface {
+	WriteLogs(ctx context.Context, batch log.Logs) error
+	WriteTraces(ctx context.Context, batch trace.Traces) error
+	WriteMetrics(ctx context.Context, batch metric.Metrics) error
+	WriteProfiles(ctx context.Context, batch *profile.Profiles) error
+}
+
+// Paths are where OTLP/HTTP expects each signal to be served.
+const (
+	LogsPath     = "/v1/logs"
+	TracesPath   = "/v1/traces"
+	MetricsPath  = "/v1/metrics"
+	ProfilesPath = "/v1/profiles"
+)
+
+const (
+	// defaultMaxBodyBytes bounds the request body as it arrives.
+	defaultMaxBodyBytes = 64 << 20
+	// defaultMaxDecodedBytes bounds what a gzip body may expand to. gzip's ratio is unbounded, so
+	// the compressed limit alone does not bound the allocation.
+	defaultMaxDecodedBytes = 256 << 20
+
+	protobufContentType = "application/x-protobuf"
+)
+
+// Stats is what one accepted request ingested.
+type Stats struct {
+	// Signal names which endpoint served the request.
+	Signal signal.Signal
+	// Bytes is the decompressed request size.
+	Bytes int
+	// Items is the number of records, spans, points or samples the request carried.
+	Items int
+	// Rejected is the number the request carried that were not stored.
+	Rejected int
+}
+
+// HandlerConfig configures a [Handler].
+type HandlerConfig struct {
+	// MaxBodyBytes limits the request body. Zero means 64 MiB.
+	MaxBodyBytes int64
+	// MaxDecodedBytes limits what a compressed body may expand to. Zero means 256 MiB.
+	MaxDecodedBytes int64
+	// Logger receives rejected-request diagnostics. Nil means no logging.
+	Logger *zap.Logger
+	// Observer, when set, is called once per accepted request. It runs on the ingest path, so it
+	// must be cheap and must not block.
+	Observer func(Stats)
+}
+
+// Handler serves OTLP/HTTP, decoding each signal straight into the engine's ingest model.
+//
+// Mount it with [Handler.Register], or mount [Handler.Logs] and its siblings individually.
+type Handler struct {
+	sink       Sink
+	maxBody    int64
+	maxDecoded int64
+	lg         *zap.Logger
+	observe    func(Stats)
+
+	logs     sync.Pool
+	traces   sync.Pool
+	metrics  sync.Pool
+	profiles sync.Pool
+	bodies   sync.Pool
+}
+
+// NewHandler creates an OTLP/HTTP handler writing to sink.
+func NewHandler(sink Sink, cfg HandlerConfig) *Handler {
+	h := &Handler{
+		sink:       sink,
+		maxBody:    cfg.MaxBodyBytes,
+		maxDecoded: cfg.MaxDecodedBytes,
+		lg:         cfg.Logger,
+		observe:    cfg.Observer,
+	}
+
+	if h.maxBody == 0 {
+		h.maxBody = defaultMaxBodyBytes
+	}
+
+	if h.maxDecoded == 0 {
+		h.maxDecoded = defaultMaxDecodedBytes
+	}
+
+	if h.lg == nil {
+		h.lg = zap.NewNop()
+	}
+
+	h.logs.New = func() any { return new(LogsConverter) }
+	h.traces.New = func() any { return new(TracesConverter) }
+	h.metrics.New = func() any { return new(MetricsConverter) }
+	h.profiles.New = func() any { return new(ProfilesConverter) }
+	h.bodies.New = func() any { return new(body) }
+
+	return h
+}
+
+// Register mounts every signal endpoint on mux at its OTLP/HTTP path.
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.Handle("POST "+LogsPath, h.Logs())
+	mux.Handle("POST "+TracesPath, h.Traces())
+	mux.Handle("POST "+MetricsPath, h.Metrics())
+	mux.Handle("POST "+ProfilesPath, h.Profiles())
+}
+
+func (h *Handler) Logs() http.Handler {
+	return h.serve(signal.Log, func(ctx context.Context, src []byte) (int, int, error) {
+		c, _ := h.logs.Get().(*LogsConverter)
+		defer h.logs.Put(c)
+
+		batch, err := c.Convert(src)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		if err := h.sink.WriteLogs(ctx, *batch); err != nil {
+			return 0, 0, writeError{err: err}
+		}
+
+		return countRecords(batch), 0, nil
+	})
+}
+
+func (h *Handler) Traces() http.Handler {
+	return h.serve(signal.Trace, func(ctx context.Context, src []byte) (int, int, error) {
+		c, _ := h.traces.Get().(*TracesConverter)
+		defer h.traces.Put(c)
+
+		batch, err := c.Convert(src)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		if err := h.sink.WriteTraces(ctx, *batch); err != nil {
+			return 0, 0, writeError{err: err}
+		}
+
+		return countSpans(batch), 0, nil
+	})
+}
+
+func (h *Handler) Metrics() http.Handler {
+	return h.serve(signal.Metric, func(ctx context.Context, src []byte) (int, int, error) {
+		c, _ := h.metrics.Get().(*MetricsConverter)
+		defer h.metrics.Put(c)
+
+		batch, dropped, err := c.Convert(src)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		if err := h.sink.WriteMetrics(ctx, *batch); err != nil {
+			return 0, 0, writeError{err: err}
+		}
+
+		return countPoints(batch), dropped, nil
+	})
+}
+
+func (h *Handler) Profiles() http.Handler {
+	return h.serve(signal.Profile, func(ctx context.Context, src []byte) (int, int, error) {
+		c, _ := h.profiles.Get().(*ProfilesConverter)
+		defer h.profiles.Put(c)
+
+		batch, err := c.Convert(src)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		if err := h.sink.WriteProfiles(ctx, batch); err != nil {
+			return 0, 0, writeError{err: err}
+		}
+
+		return countSamples(batch), 0, nil
+	})
+}
+
+// ingestFunc decodes one request body and writes it, returning what it ingested and what it could
+// not represent.
+type ingestFunc func(ctx context.Context, src []byte) (items, rejected int, _ error)
+
+// writeError marks a sink failure, answered with 5xx so the client retries rather than drops the
+// batch. Everything else is the request's own fault and answered with 4xx.
+type writeError struct{ err error }
+
+func (e writeError) Error() string { return e.err.Error() }
+func (e writeError) Unwrap() error { return e.err }
+
+func (h *Handler) serve(sig signal.Signal, ingest ingestFunc) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ct := r.Header.Get("Content-Type"); ct != "" && !isProtobuf(ct) {
+			// JSON-encoded OTLP is a valid part of the spec this handler does not implement, so it
+			// must be refused rather than parsed as protobuf and rejected as malformed.
+			http.Error(w, "only "+protobufContentType+" is supported", http.StatusUnsupportedMediaType)
+
+			return
+		}
+
+		b, _ := h.bodies.Get().(*body)
+		defer h.bodies.Put(b)
+
+		src, err := b.read(r, h.maxBody, h.maxDecoded)
+		if err == nil {
+			var items, rejected int
+
+			items, rejected, err = ingest(r.Context(), src)
+			if err == nil {
+				h.respond(w, sig, len(src), items, rejected)
+
+				return
+			}
+		}
+
+		code := http.StatusBadRequest
+		if we := new(writeError); errors.As(err, we) {
+			code = http.StatusInternalServerError
+		}
+
+		h.lg.Debug("Reject OTLP request",
+			zap.Stringer("signal", sig), zap.Error(err), zap.Int("code", code))
+		http.Error(w, err.Error(), code)
+	})
+}
+
+// respond answers a successful export. OTLP wants a serialized ExportXServiceResponse, and an
+// empty message is the full-success form for every signal — the partial-success submessage is
+// simply absent, which is what a rejected count of zero means.
+func (h *Handler) respond(w http.ResponseWriter, sig signal.Signal, size, items, rejected int) {
+	if h.observe != nil {
+		h.observe(Stats{Signal: sig, Bytes: size, Items: items, Rejected: rejected})
+	}
+
+	w.Header().Set("Content-Type", protobufContentType)
+	w.WriteHeader(http.StatusOK)
+
+	if rejected == 0 {
+		return
+	}
+
+	_, _ = w.Write(encodePartialSuccess(sig, rejected))
+}
+
+// body is the per-request read buffer, recycled across requests.
+type body struct {
+	raw      []byte
+	expanded []byte
+}
+
+// read returns the request's decoded protobuf bytes, transparently un-gzipping when the sender
+// compressed them.
+func (b *body) read(r *http.Request, maxBody, maxDecoded int64) ([]byte, error) {
+	var err error
+	if b.raw, err = readAll(b.raw[:0], http.MaxBytesReader(nil, r.Body, maxBody)); err != nil {
+		return nil, errors.Wrap(err, "read body")
+	}
+
+	if !strings.EqualFold(strings.TrimSpace(r.Header.Get("Content-Encoding")), "gzip") {
+		return b.raw, nil
+	}
+
+	zr, err := gzip.NewReader(bytes.NewReader(b.raw))
+	if err != nil {
+		return nil, errors.Wrap(err, "read gzip header")
+	}
+
+	defer func() { _ = zr.Close() }()
+
+	// gzip's expansion ratio is unbounded and the sender chooses it, so the decompressed size is
+	// capped independently of the body limit.
+	if b.expanded, err = readAll(b.expanded[:0], io.LimitReader(zr, maxDecoded+1)); err != nil {
+		return nil, errors.Wrap(err, "decompress body")
+	}
+
+	if int64(len(b.expanded)) > maxDecoded {
+		return nil, errors.Errorf("body decompresses past the %d byte limit", maxDecoded)
+	}
+
+	return b.expanded, nil
+}
+
+func countRecords(batch *log.Logs) (n int) {
+	for i := range batch.Resources {
+		for j := range batch.Resources[i].Scopes {
+			n += len(batch.Resources[i].Scopes[j].Records)
+		}
+	}
+
+	return n
+}
+
+func countSpans(batch *trace.Traces) (n int) {
+	for i := range batch.Resources {
+		for j := range batch.Resources[i].Scopes {
+			n += len(batch.Resources[i].Scopes[j].Spans)
+		}
+	}
+
+	return n
+}
+
+func countPoints(batch *metric.Metrics) (n int) {
+	for i := range batch.Resources {
+		for j := range batch.Resources[i].Scopes {
+			for _, mt := range batch.Resources[i].Scopes[j].Metrics {
+				n += len(mt.Points)
+			}
+		}
+	}
+
+	return n
+}
+
+func countSamples(batch *profile.Profiles) (n int) {
+	for i := range batch.Resources {
+		for j := range batch.Resources[i].Scopes {
+			for _, pr := range batch.Resources[i].Scopes[j].Profiles {
+				n += len(pr.Samples)
+			}
+		}
+	}
+
+	return n
+}
+
+func isProtobuf(contentType string) bool {
+	media, _, _ := strings.Cut(contentType, ";")
+
+	return strings.EqualFold(strings.TrimSpace(media), protobufContentType)
+}
+
+// readAll reads r into dst, reusing its capacity.
+func readAll(dst []byte, r io.Reader) ([]byte, error) {
+	for {
+		if len(dst) == cap(dst) {
+			dst = append(dst, 0)[:len(dst)]
+		}
+
+		n, err := r.Read(dst[len(dst):cap(dst)])
+		dst = dst[:len(dst)+n]
+
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return dst, nil
+			}
+
+			return dst, err
+		}
+	}
+}

--- a/internal/otlpdirect/handler.go
+++ b/internal/otlpdirect/handler.go
@@ -130,76 +130,76 @@ func (h *Handler) Register(mux *http.ServeMux) {
 	mux.Handle("POST "+ProfilesPath, h.Profiles())
 }
 
-func (h *Handler) Logs() http.Handler {
-	return h.serve(signal.Log, func(ctx context.Context, src []byte) (int, int, error) {
-		c, _ := h.logs.Get().(*LogsConverter)
-		defer h.logs.Put(c)
+func (h *Handler) Logs() http.Handler { return h.serve(signal.Log, h.ingestLogs) }
 
-		batch, err := c.Convert(src)
-		if err != nil {
-			return 0, 0, err
-		}
+func (h *Handler) ingestLogs(ctx context.Context, src []byte) (items, rejected int, _ error) {
+	c, _ := h.logs.Get().(*LogsConverter)
+	defer h.logs.Put(c)
 
-		if err := h.sink.WriteLogs(ctx, *batch); err != nil {
-			return 0, 0, writeError{err: err}
-		}
+	batch, err := c.Convert(src)
+	if err != nil {
+		return 0, 0, err
+	}
 
-		return countRecords(batch), 0, nil
-	})
+	if err := h.sink.WriteLogs(ctx, *batch); err != nil {
+		return 0, 0, writeError{err: err}
+	}
+
+	return countRecords(batch), 0, nil
 }
 
-func (h *Handler) Traces() http.Handler {
-	return h.serve(signal.Trace, func(ctx context.Context, src []byte) (int, int, error) {
-		c, _ := h.traces.Get().(*TracesConverter)
-		defer h.traces.Put(c)
+func (h *Handler) Traces() http.Handler { return h.serve(signal.Trace, h.ingestTraces) }
 
-		batch, err := c.Convert(src)
-		if err != nil {
-			return 0, 0, err
-		}
+func (h *Handler) ingestTraces(ctx context.Context, src []byte) (items, rejected int, _ error) {
+	c, _ := h.traces.Get().(*TracesConverter)
+	defer h.traces.Put(c)
 
-		if err := h.sink.WriteTraces(ctx, *batch); err != nil {
-			return 0, 0, writeError{err: err}
-		}
+	batch, err := c.Convert(src)
+	if err != nil {
+		return 0, 0, err
+	}
 
-		return countSpans(batch), 0, nil
-	})
+	if err := h.sink.WriteTraces(ctx, *batch); err != nil {
+		return 0, 0, writeError{err: err}
+	}
+
+	return countSpans(batch), 0, nil
 }
 
-func (h *Handler) Metrics() http.Handler {
-	return h.serve(signal.Metric, func(ctx context.Context, src []byte) (int, int, error) {
-		c, _ := h.metrics.Get().(*MetricsConverter)
-		defer h.metrics.Put(c)
+func (h *Handler) Metrics() http.Handler { return h.serve(signal.Metric, h.ingestMetrics) }
 
-		batch, dropped, err := c.Convert(src)
-		if err != nil {
-			return 0, 0, err
-		}
+func (h *Handler) ingestMetrics(ctx context.Context, src []byte) (items, rejected int, _ error) {
+	c, _ := h.metrics.Get().(*MetricsConverter)
+	defer h.metrics.Put(c)
 
-		if err := h.sink.WriteMetrics(ctx, *batch); err != nil {
-			return 0, 0, writeError{err: err}
-		}
+	batch, dropped, err := c.Convert(src)
+	if err != nil {
+		return 0, 0, err
+	}
 
-		return countPoints(batch), dropped, nil
-	})
+	if err := h.sink.WriteMetrics(ctx, *batch); err != nil {
+		return 0, 0, writeError{err: err}
+	}
+
+	return countPoints(batch), dropped, nil
 }
 
-func (h *Handler) Profiles() http.Handler {
-	return h.serve(signal.Profile, func(ctx context.Context, src []byte) (int, int, error) {
-		c, _ := h.profiles.Get().(*ProfilesConverter)
-		defer h.profiles.Put(c)
+func (h *Handler) Profiles() http.Handler { return h.serve(signal.Profile, h.ingestProfiles) }
 
-		batch, err := c.Convert(src)
-		if err != nil {
-			return 0, 0, err
-		}
+func (h *Handler) ingestProfiles(ctx context.Context, src []byte) (items, rejected int, _ error) {
+	c, _ := h.profiles.Get().(*ProfilesConverter)
+	defer h.profiles.Put(c)
 
-		if err := h.sink.WriteProfiles(ctx, batch); err != nil {
-			return 0, 0, writeError{err: err}
-		}
+	batch, err := c.Convert(src)
+	if err != nil {
+		return 0, 0, err
+	}
 
-		return countSamples(batch), 0, nil
-	})
+	if err := h.sink.WriteProfiles(ctx, batch); err != nil {
+		return 0, 0, writeError{err: err}
+	}
+
+	return countSamples(batch), 0, nil
 }
 
 // ingestFunc decodes one request body and writes it, returning what it ingested and what it could

--- a/internal/otlpdirect/handler_test.go
+++ b/internal/otlpdirect/handler_test.go
@@ -1,0 +1,409 @@
+package otlpdirect_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/signal/log"
+	"github.com/oteldb/storage/signal/metric"
+	"github.com/oteldb/storage/signal/profile"
+	"github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// recordingSink captures what each endpoint wrote. It copies nothing, so it must only be read
+// after the request returns — which is what the aliasing contract permits.
+type recordingSink struct {
+	mu sync.Mutex
+
+	logs     int
+	spans    int
+	points   int
+	samples  int
+	failWith error
+}
+
+func (s *recordingSink) WriteLogs(_ context.Context, batch log.Logs) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range batch.Resources {
+		for j := range batch.Resources[i].Scopes {
+			s.logs += len(batch.Resources[i].Scopes[j].Records)
+		}
+	}
+
+	return s.failWith
+}
+
+func (s *recordingSink) WriteTraces(_ context.Context, batch trace.Traces) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range batch.Resources {
+		for j := range batch.Resources[i].Scopes {
+			s.spans += len(batch.Resources[i].Scopes[j].Spans)
+		}
+	}
+
+	return s.failWith
+}
+
+func (s *recordingSink) WriteMetrics(_ context.Context, batch metric.Metrics) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range batch.Resources {
+		for j := range batch.Resources[i].Scopes {
+			for _, mt := range batch.Resources[i].Scopes[j].Metrics {
+				s.points += len(mt.Points)
+			}
+		}
+	}
+
+	return s.failWith
+}
+
+func (s *recordingSink) WriteProfiles(_ context.Context, batch *profile.Profiles) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i := range batch.Resources {
+		for j := range batch.Resources[i].Scopes {
+			for _, pr := range batch.Resources[i].Scopes[j].Profiles {
+				s.samples += len(pr.Samples)
+			}
+		}
+	}
+
+	return s.failWith
+}
+
+func serveOTLP(tb testing.TB, sink otlpdirect.Sink) (*http.ServeMux, *[]otlpdirect.Stats) {
+	tb.Helper()
+
+	var (
+		mu    sync.Mutex
+		stats []otlpdirect.Stats
+	)
+
+	h := otlpdirect.NewHandler(sink, otlpdirect.HandlerConfig{
+		Observer: func(s otlpdirect.Stats) {
+			mu.Lock()
+			defer mu.Unlock()
+
+			stats = append(stats, s)
+		},
+	})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	return mux, &stats
+}
+
+func post(mux *http.ServeMux, path string, raw []byte, hdr map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	for k, v := range hdr {
+		req.Header.Set(k, v)
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	return rec
+}
+
+// TestHandlerServesEverySignal drives all four endpoints with real OTLP bytes.
+func TestHandlerServesEverySignal(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	mux, stats := serveOTLP(t, sink)
+
+	ld := plog.NewLogs()
+	lr := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetTimestamp(1)
+	lr.Body().SetStr("hello")
+
+	td := ptrace.NewTraces()
+	sp := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	sp.SetName("op")
+	sp.SetStartTimestamp(1)
+
+	md := pmetric.NewMetrics()
+	mp := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	mp.SetName("g")
+
+	gp := mp.SetEmptyGauge().DataPoints().AppendEmpty()
+	gp.SetTimestamp(1)
+	gp.SetDoubleValue(1)
+
+	for _, tt := range []struct {
+		path string
+		raw  []byte
+	}{
+		{otlpdirect.LogsPath, marshal(t, ld)},
+		{otlpdirect.TracesPath, marshalTraces(t, td)},
+		{otlpdirect.MetricsPath, marshalMetrics(t, md)},
+	} {
+		rec := post(mux, tt.path, tt.raw, nil)
+		require.Equal(t, http.StatusOK, rec.Code, tt.path)
+		assert.Equal(t, "application/x-protobuf", rec.Header().Get("Content-Type"))
+
+		// Full success is an empty ExportXServiceResponse, not an absent body.
+		assert.Empty(t, rec.Body.Bytes(), "%s: full success carries no partial_success", tt.path)
+	}
+
+	assert.Equal(t, 1, sink.logs)
+	assert.Equal(t, 1, sink.spans)
+	assert.Equal(t, 1, sink.points)
+	assert.Len(t, *stats, 3)
+}
+
+// TestHandlerGzip pins that a gzip-encoded body is transparently decompressed, which every real
+// OTLP exporter sends by default.
+func TestHandlerGzip(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	mux, _ := serveOTLP(t, sink)
+
+	ld := plog.NewLogs()
+	for range 3 {
+		r := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		r.SetTimestamp(1)
+		r.Body().SetStr("compressed")
+	}
+
+	var buf bytes.Buffer
+
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(marshal(t, ld))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	rec := post(mux, otlpdirect.LogsPath, buf.Bytes(), map[string]string{"Content-Encoding": "gzip"})
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body)
+	assert.Equal(t, 3, sink.logs)
+}
+
+// TestHandlerPartialSuccess pins the response OTLP requires when some items could not be stored:
+// 200 with a partial_success body, not an error. A client cannot fix these by retrying, so an
+// error status would make it resend forever.
+func TestHandlerPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	mux, stats := serveOTLP(t, sink)
+
+	md := pmetric.NewMetrics()
+
+	m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("g")
+
+	dps := m.SetEmptyGauge().DataPoints()
+
+	valueless := dps.AppendEmpty()
+	valueless.SetTimestamp(1)
+
+	valued := dps.AppendEmpty()
+	valued.SetTimestamp(2)
+	valued.SetDoubleValue(1)
+
+	rec := post(mux, otlpdirect.MetricsPath, marshalMetrics(t, md), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rejected, message := decodePartialSuccess(t, rec.Body.Bytes())
+	assert.Equal(t, int64(1), rejected)
+	assert.NotEmpty(t, message, "a partial success must say what happened")
+
+	assert.Equal(t, 1, sink.points, "the representable point is still stored")
+	require.Len(t, *stats, 1)
+	assert.Equal(t, 1, (*stats)[0].Rejected)
+	assert.Equal(t, signal.Metric, (*stats)[0].Signal)
+}
+
+// TestHandlerSinkFailureIsRetryable pins that a write failure answers 5xx: the data may not have
+// landed, so the sender must retry rather than move on.
+func TestHandlerSinkFailureIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{failWith: errors.New("no primary")}
+	mux, stats := serveOTLP(t, sink)
+
+	ld := plog.NewLogs()
+	r := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	r.SetTimestamp(1)
+
+	rec := post(mux, otlpdirect.LogsPath, marshal(t, ld), nil)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Empty(t, *stats, "a failed write is not observed as ingested")
+}
+
+// TestHandlerMalformedBodyIsNotRetryable pins the other direction: bytes the sender got wrong are
+// 4xx, since resending them cannot help.
+func TestHandlerMalformedBodyIsNotRetryable(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	mux, _ := serveOTLP(t, sink)
+
+	rec := post(mux, otlpdirect.TracesPath, []byte{0xff, 0xff, 0xff, 0xff}, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandlerRejectsNonProtobuf(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	mux, _ := serveOTLP(t, sink)
+
+	// JSON-encoded OTLP is valid per spec but unimplemented here; it must be refused rather than
+	// parsed as protobuf and reported as malformed.
+	rec := post(mux, otlpdirect.LogsPath, []byte(`{}`), map[string]string{"Content-Type": "application/json"})
+	assert.Equal(t, http.StatusUnsupportedMediaType, rec.Code)
+}
+
+func TestHandlerRejectsNonPost(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	mux, _ := serveOTLP(t, sink)
+
+	req := httptest.NewRequest(http.MethodGet, otlpdirect.LogsPath, http.NoBody)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// TestHandlerBodyLimit pins that an oversized body is refused rather than buffered.
+func TestHandlerBodyLimit(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+
+	h := otlpdirect.NewHandler(sink, otlpdirect.HandlerConfig{MaxBodyBytes: 16})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	ld := plog.NewLogs()
+	for range 50 {
+		r := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		r.SetTimestamp(1)
+		r.Body().SetStr("padding padding padding")
+	}
+
+	rec := post(mux, otlpdirect.LogsPath, marshal(t, ld), nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Zero(t, sink.logs)
+}
+
+// TestHandlerGzipBombIsBounded pins that the decompressed size is capped independently of the body
+// limit: gzip's ratio is unbounded and the sender picks it.
+func TestHandlerGzipBombIsBounded(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+
+	h := otlpdirect.NewHandler(sink, otlpdirect.HandlerConfig{MaxDecodedBytes: 1 << 10})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	var buf bytes.Buffer
+
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(make([]byte, 1<<20))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	require.Less(t, buf.Len(), 1<<12, "the compressed bomb is small")
+
+	rec := post(mux, otlpdirect.LogsPath, buf.Bytes(), map[string]string{"Content-Encoding": "gzip"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestHandlerConcurrent drives every endpoint at once, since the converters are pooled and shared
+// across requests.
+func TestHandlerConcurrent(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	mux, _ := serveOTLP(t, sink)
+
+	ld := plog.NewLogs()
+	lr := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetTimestamp(1)
+	lr.Body().SetStr("x")
+
+	raw := marshal(t, ld)
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			rec := post(mux, otlpdirect.LogsPath, raw, nil)
+			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+
+	wg.Wait()
+	assert.Equal(t, 50, sink.logs)
+}
+
+// decodePartialSuccess reads an ExportXServiceResponse's partial_success submessage.
+func decodePartialSuccess(t *testing.T, src []byte) (rejected int64, message string) {
+	t.Helper()
+
+	var fc easyproto.FieldContext
+
+	for len(src) > 0 {
+		var err error
+
+		src, err = fc.NextField(src)
+		require.NoError(t, err)
+
+		if fc.FieldNum != 1 {
+			continue
+		}
+
+		data, ok := fc.MessageData()
+		require.True(t, ok)
+
+		var inner easyproto.FieldContext
+		for len(data) > 0 {
+			data, err = inner.NextField(data)
+			require.NoError(t, err)
+
+			switch inner.FieldNum {
+			case 1:
+				rejected, ok = inner.Int64()
+				require.True(t, ok)
+			case 2:
+				message, ok = inner.String()
+				require.True(t, ok)
+			}
+		}
+	}
+
+	return rejected, message
+}

--- a/internal/otlpdirect/histogram.go
+++ b/internal/otlpdirect/histogram.go
@@ -1,0 +1,617 @@
+package otlpdirect
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/go-faster/errors"
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/signal/metric"
+)
+
+// Histogram, exponential-histogram and summary points are stored by classic decomposition into
+// ordinary float series — `_count`, `_sum` and cumulative `_bucket{le=…}` for histograms, and
+// `_count`/`_sum`/`{quantile=…}` for summaries. The engine has no histogram code; this is where the
+// shape is chosen, and it must match otlp/pdataconv exactly, since the two paths ingest the same
+// requests into the same series.
+
+// posInf is the Prometheus `le` value of the catch-all overflow bucket.
+var posInf = []byte("+Inf")
+
+var (
+	leKey       = []byte("le")
+	quantileKey = []byte("quantile")
+)
+
+func (c *MetricsConverter) histogram(sm *metric.ScopeMetrics, name, unit, src []byte) error {
+	var (
+		fc   easyproto.FieldContext
+		temp metric.Temporality
+		err  error
+	)
+
+	points := c.dataPoints[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read histogram field")
+		}
+
+		switch fc.FieldNum {
+		case fieldDataPoints:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read histogram data point")
+			}
+
+			points = append(points, data)
+		case fieldTemporality:
+			v, ok := fc.Enum()
+			if !ok {
+				return errors.New("read histogram temporality")
+			}
+
+			temp = temporalityOf(v)
+		}
+	}
+
+	c.dataPoints = points
+
+	for _, data := range points {
+		if err := c.histogramPoint(sm, name, unit, temp, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *MetricsConverter) histogramPoint(
+	sm *metric.ScopeMetrics, name, unit []byte, temp metric.Temporality, src []byte,
+) error {
+	var (
+		fc        easyproto.FieldContext
+		start, ts int64
+		count     uint64
+		sum       float64
+		hasSum    bool
+		err       error
+	)
+
+	kvs := c.pointAttrs[:0]
+	bounds := c.bounds[:0]
+	counts := c.counts[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read histogram data point field")
+		}
+
+		switch fc.FieldNum {
+		case fieldHistStart:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read histogram start")
+			}
+
+			start = int64(v)
+		case fieldHistTime:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read histogram time")
+			}
+
+			ts = int64(v)
+		case fieldHistCount:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read histogram count")
+			}
+
+			count = v
+		case fieldHistSum:
+			v, ok := fc.Double()
+			if !ok {
+				return errors.New("read histogram sum")
+			}
+
+			// sum is an optional scalar, so it is on the wire only when set — which is exactly
+			// what pdata's HasSum reports, and what decides whether a _sum series exists.
+			sum, hasSum = v, true
+		case fieldHistBuckets:
+			// A packed repeated field may arrive as several occurrences, so each appends.
+			v, ok := fc.UnpackFixed64s(counts)
+			if !ok {
+				return errors.New("read histogram bucket counts")
+			}
+
+			counts = v
+		case fieldHistBounds:
+			v, ok := fc.UnpackDoubles(bounds)
+			if !ok {
+				return errors.New("read histogram explicit bounds")
+			}
+
+			bounds = v
+		case fieldHistAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read histogram attribute")
+			}
+
+			kvs = append(kvs, data)
+		}
+	}
+
+	c.pointAttrs, c.bounds, c.counts = kvs, bounds, counts
+
+	base, err := c.dec.attributes(kvs)
+	if err != nil {
+		return err
+	}
+
+	cumulative := temp == metric.TemporalityCumulative
+
+	c.addSeries(sm, c.suffix(name, "_count"), unit, temp, cumulative, base, start, ts, float64(count))
+
+	if hasSum {
+		c.addSeries(sm, c.suffix(name, "_sum"), unit, temp, false, base, start, ts, sum)
+	}
+
+	bucketName := c.suffix(name, "_bucket")
+
+	var cum uint64
+
+	for b, n := range counts {
+		cum += n
+
+		le := posInf
+		if b < len(bounds) {
+			le = c.formatBound(bounds[b])
+		}
+
+		c.addSeries(sm, bucketName, unit, temp, cumulative,
+			c.withLabel(base, leKey, le), start, ts, float64(cum))
+	}
+
+	return nil
+}
+
+func (c *MetricsConverter) summary(sm *metric.ScopeMetrics, name, unit, src []byte) error {
+	points, err := collectInto(c.dataPoints[:0], src, fieldDataPoints, "summary data point")
+	if err != nil {
+		return err
+	}
+
+	c.dataPoints = points
+
+	for _, data := range points {
+		if err := c.summaryPoint(sm, name, unit, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *MetricsConverter) summaryPoint(sm *metric.ScopeMetrics, name, unit, src []byte) error {
+	var (
+		fc        easyproto.FieldContext
+		start, ts int64
+		count     uint64
+		sum       float64
+		quantiles [][]byte
+		err       error
+	)
+
+	kvs := c.pointAttrs[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read summary data point field")
+		}
+
+		switch fc.FieldNum {
+		case fieldSummaryStart:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read summary start")
+			}
+
+			start = int64(v)
+		case fieldSummaryTime:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read summary time")
+			}
+
+			ts = int64(v)
+		case fieldSummaryCount:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read summary count")
+			}
+
+			count = v
+		case fieldSummarySum:
+			v, ok := fc.Double()
+			if !ok {
+				return errors.New("read summary sum")
+			}
+
+			sum = v
+		case fieldSummaryQuantiles:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read summary quantile")
+			}
+
+			quantiles = append(quantiles, data)
+		case fieldSummaryAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read summary attribute")
+			}
+
+			kvs = append(kvs, data)
+		}
+	}
+
+	c.pointAttrs = kvs
+
+	base, err := c.dec.attributes(kvs)
+	if err != nil {
+		return err
+	}
+
+	// A summary has no temporality; its count and sum are cumulative counters.
+	c.addSeries(sm, c.suffix(name, "_count"), unit, metric.TemporalityCumulative, true, base, start, ts, float64(count))
+	c.addSeries(sm, c.suffix(name, "_sum"), unit, metric.TemporalityCumulative, false, base, start, ts, sum)
+
+	for _, data := range quantiles {
+		q, v, err := quantileOf(data)
+		if err != nil {
+			return err
+		}
+
+		// The estimate is an instantaneous gauge under the base name with a quantile label.
+		mt := sm.AddMetric()
+		mt.Name, mt.Unit, mt.Kind = name, unit, metric.KindGauge
+
+		p := mt.AddPoint()
+		p.Attributes = c.withLabel(base, quantileKey, c.formatBound(q))
+		p.StartTs, p.Ts, p.Value = start, ts, v
+	}
+
+	return nil
+}
+
+func quantileOf(src []byte) (quantile, value float64, _ error) {
+	var (
+		fc  easyproto.FieldContext
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return 0, 0, errors.Wrap(err, "read quantile field")
+		}
+
+		switch fc.FieldNum {
+		case fieldQuantileQuantile:
+			v, ok := fc.Double()
+			if !ok {
+				return 0, 0, errors.New("read quantile")
+			}
+
+			quantile = v
+		case fieldQuantileValue:
+			v, ok := fc.Double()
+			if !ok {
+				return 0, 0, errors.New("read quantile value")
+			}
+
+			value = v
+		}
+	}
+
+	return quantile, value, nil
+}
+
+func (c *MetricsConverter) expHistogram(sm *metric.ScopeMetrics, name, unit, src []byte) error {
+	var (
+		fc   easyproto.FieldContext
+		temp metric.Temporality
+		err  error
+	)
+
+	points := c.dataPoints[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read exponential histogram field")
+		}
+
+		switch fc.FieldNum {
+		case fieldDataPoints:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read exponential histogram data point")
+			}
+
+			points = append(points, data)
+		case fieldTemporality:
+			v, ok := fc.Enum()
+			if !ok {
+				return errors.New("read exponential histogram temporality")
+			}
+
+			temp = temporalityOf(v)
+		}
+	}
+
+	c.dataPoints = points
+
+	for _, data := range points {
+		if err := c.expHistogramPoint(sm, name, unit, temp, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *MetricsConverter) expHistogramPoint(
+	sm *metric.ScopeMetrics, name, unit []byte, temp metric.Temporality, src []byte,
+) error {
+	var (
+		fc           easyproto.FieldContext
+		start, ts    int64
+		count        uint64
+		sum          float64
+		hasSum       bool
+		scale        int32
+		zeroCount    uint64
+		positiveData []byte
+		negativeData []byte
+		err          error
+	)
+
+	kvs := c.pointAttrs[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read exponential histogram point field")
+		}
+
+		switch fc.FieldNum {
+		case fieldExpStart:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read exponential histogram start")
+			}
+
+			start = int64(v)
+		case fieldExpTime:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read exponential histogram time")
+			}
+
+			ts = int64(v)
+		case fieldExpCount:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read exponential histogram count")
+			}
+
+			count = v
+		case fieldExpSum:
+			v, ok := fc.Double()
+			if !ok {
+				return errors.New("read exponential histogram sum")
+			}
+
+			sum, hasSum = v, true
+		case fieldExpScale:
+			v, ok := fc.Sint32()
+			if !ok {
+				return errors.New("read exponential histogram scale")
+			}
+
+			scale = v
+		case fieldExpZeroCount:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read exponential histogram zero count")
+			}
+
+			zeroCount = v
+		case fieldExpPositive:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read exponential histogram positive buckets")
+			}
+
+			positiveData = data
+		case fieldExpNegative:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read exponential histogram negative buckets")
+			}
+
+			negativeData = data
+		case fieldExpAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read exponential histogram attribute")
+			}
+
+			kvs = append(kvs, data)
+		}
+	}
+
+	c.pointAttrs = kvs
+
+	base, err := c.dec.attributes(kvs)
+	if err != nil {
+		return err
+	}
+
+	cumulative := temp == metric.TemporalityCumulative
+
+	c.addSeries(sm, c.suffix(name, "_count"), unit, temp, cumulative, base, start, ts, float64(count))
+
+	if hasSum {
+		c.addSeries(sm, c.suffix(name, "_sum"), unit, temp, false, base, start, ts, sum)
+	}
+
+	buckets, err := c.expBuckets(scale, zeroCount, count, negativeData, positiveData)
+	if err != nil {
+		return err
+	}
+
+	bucketName := c.suffix(name, "_bucket")
+
+	for _, b := range buckets {
+		le := posInf
+		if !math.IsInf(b.le, 1) {
+			le = c.formatBound(b.le)
+		}
+
+		c.addSeries(sm, bucketName, unit, temp, cumulative,
+			c.withLabel(base, leKey, le), start, ts, float64(b.cumulative))
+	}
+
+	return nil
+}
+
+// expBucket is a derived classic bucket: an upper bound and the cumulative count at or below it.
+type expBucket struct {
+	le         float64
+	cumulative uint64
+}
+
+// expBuckets converts a point's negative/zero/positive buckets into classic `le` buckets in
+// ascending bound order with cumulative counts, ending at +Inf carrying the full count.
+func (c *MetricsConverter) expBuckets(
+	scale int32, zeroCount, total uint64, negativeData, positiveData []byte,
+) ([]expBucket, error) {
+	factor := math.Exp2(math.Exp2(-float64(scale)))
+	bound := func(index int) float64 { return math.Pow(factor, float64(index)) }
+
+	negOffset, negCounts, err := bucketsOf(negativeData, c.deltas[:0])
+	if err != nil {
+		return nil, err
+	}
+
+	c.deltas = negCounts
+
+	// The negative counts must be read out before the positive ones reuse the scratch.
+	out := make([]expBucket, 0, len(negCounts)+2)
+
+	var cum uint64
+
+	// A negative bucket at index i holds values in [-base^(i+1), -base^i); its upper bound, the one
+	// closest to zero, is -base^i.
+	for k, n := range negCounts {
+		if n == 0 {
+			continue
+		}
+
+		cum += n
+		out = append(out, expBucket{le: -bound(int(negOffset) + k), cumulative: cum})
+	}
+
+	if zeroCount > 0 {
+		cum += zeroCount
+		out = append(out, expBucket{le: 0, cumulative: cum})
+	}
+
+	posOffset, posCounts, err := bucketsOf(positiveData, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// A positive bucket at index i holds values in (base^i, base^(i+1)]; its upper bound is
+	// base^(i+1).
+	for k, n := range posCounts {
+		if n == 0 {
+			continue
+		}
+
+		cum += n
+		out = append(out, expBucket{le: bound(int(posOffset) + k + 1), cumulative: cum})
+	}
+
+	// The +Inf bucket carries the full count, covering anything the buckets did not (a NaN
+	// observation, say).
+	return append(out, expBucket{le: math.Inf(1), cumulative: total}), nil
+}
+
+func bucketsOf(src []byte, dst []uint64) (offset int32, counts []uint64, _ error) {
+	var (
+		fc  easyproto.FieldContext
+		err error
+	)
+
+	counts = dst
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return 0, nil, errors.Wrap(err, "read buckets field")
+		}
+
+		switch fc.FieldNum {
+		case fieldBucketsOffset:
+			v, ok := fc.Sint32()
+			if !ok {
+				return 0, nil, errors.New("read buckets offset")
+			}
+
+			offset = v
+		case fieldBucketsCounts:
+			v, ok := fc.UnpackUint64s(counts)
+			if !ok {
+				return 0, nil, errors.New("read buckets counts")
+			}
+
+			counts = v
+		}
+	}
+
+	return offset, counts, nil
+}
+
+// addSeries appends a one-point synthetic sum series — a decomposed _count/_sum/_bucket.
+func (c *MetricsConverter) addSeries(
+	sm *metric.ScopeMetrics, name, unit []byte, temp metric.Temporality, monotonic bool,
+	attrs signal.Attributes, startTS, ts int64, value float64,
+) {
+	mt := sm.AddMetric()
+	mt.Name, mt.Unit = name, unit
+	mt.Kind, mt.Temporality, mt.Monotonic = metric.KindSum, temp, monotonic
+
+	p := mt.AddPoint()
+	p.Attributes = attrs
+	p.StartTs, p.Ts, p.Value = startTS, ts, value
+}
+
+// withLabel returns base plus one string label, re-sorted by key. The result is carved from the
+// arena, so the decomposed series do not allocate per bucket.
+func (c *MetricsConverter) withLabel(base signal.Attributes, key, value []byte) signal.Attributes {
+	kvs := c.dec.attrs.Alloc(len(base) + 1)
+	kvs = append(kvs, base...)
+	kvs = append(kvs, signal.KeyValue{Key: key, Value: signal.StringValue(value)})
+
+	return signal.NewAttributes(kvs...)
+}
+
+func (c *MetricsConverter) suffix(name []byte, s string) []byte {
+	return c.dec.scratch.Concat(name, []byte(s))
+}
+
+func (c *MetricsConverter) formatBound(f float64) []byte {
+	return strconv.AppendFloat(c.dec.scratch.Alloc(32), f, 'g', -1, 64)
+}

--- a/internal/otlpdirect/logs.go
+++ b/internal/otlpdirect/logs.go
@@ -1,0 +1,292 @@
+package otlpdirect
+
+import (
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/go-faster/errors"
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/signal/log"
+)
+
+// Field numbers of logs.proto and collector/logs/v1/logs_service.proto.
+const (
+	// opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+	fieldExportResourceLogs = 1
+
+	// opentelemetry.proto.logs.v1.ResourceLogs
+	fieldResourceLogsResource  = 1
+	fieldResourceLogsScope     = 2
+	fieldResourceLogsSchemaURL = 3
+
+	// opentelemetry.proto.logs.v1.ScopeLogs
+	fieldScopeLogsScope     = 1
+	fieldScopeLogsRecords   = 2
+	fieldScopeLogsSchemaURL = 3
+
+	// opentelemetry.proto.logs.v1.LogRecord
+	fieldLogTime         = 1
+	fieldLogSeverityNum  = 2
+	fieldLogSeverityText = 3
+	fieldLogBody         = 5
+	fieldLogAttributes   = 6
+	fieldLogDropped      = 7
+	fieldLogFlags        = 8
+	fieldLogTraceID      = 9
+	fieldLogSpanID       = 10
+	fieldLogObservedTime = 11
+)
+
+// LogsConverter decodes an OTLP ExportLogsServiceRequest into [log.Logs]. It retains the batch and
+// the scratch it is built from, so a converter reused across requests allocates nothing in steady
+// state. It is not safe for concurrent use; pool one per in-flight request.
+type LogsConverter struct {
+	batch log.Logs
+	dec   decoder
+
+	// kvScratch collects a record's attribute submessages during its walk. A record's attributes
+	// are decoded before the next record starts and never retained, so one buffer serves them all
+	// — which is what keeps the per-record cost off the allocator.
+	kvScratch [][]byte
+}
+
+// Convert decodes a serialized ExportLogsServiceRequest.
+//
+// The returned batch aliases src: every key, string value, body and id is a sub-slice of it. It
+// stays valid until the next Convert on this converter, and src must not be recycled until the
+// write consuming the batch has returned.
+func (c *LogsConverter) Convert(src []byte) (*log.Logs, error) {
+	c.batch.Reset()
+	c.dec.reset()
+
+	resources, err := collect(src, fieldExportResourceLogs, "resource logs")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, data := range resources {
+		if err := c.resourceLogs(data); err != nil {
+			return nil, err
+		}
+	}
+
+	return &c.batch, nil
+}
+
+func (c *LogsConverter) resourceLogs(src []byte) error {
+	var (
+		fc     easyproto.FieldContext
+		res    signal.Resource
+		scopes [][]byte
+		err    error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read resource logs field")
+		}
+
+		switch fc.FieldNum {
+		case fieldResourceLogsResource:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read resource")
+			}
+
+			if res.Attributes, err = c.dec.resource(data); err != nil {
+				return err
+			}
+		case fieldResourceLogsScope:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read scope logs")
+			}
+
+			scopes = append(scopes, data)
+		case fieldResourceLogsSchemaURL:
+			v, ok := fc.Bytes()
+			if !ok {
+				return errors.New("read resource schema url")
+			}
+
+			res.SchemaURL = v
+		}
+	}
+
+	rl := c.batch.AddResource()
+	rl.Resource = res
+
+	for _, data := range scopes {
+		if err := c.scopeLogs(rl, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *LogsConverter) scopeLogs(rl *log.ResourceLogs, src []byte) error {
+	var (
+		fc        easyproto.FieldContext
+		scopeData []byte
+		schemaURL []byte
+		records   [][]byte
+		err       error
+	)
+
+	// Fields arrive in whatever order the producer wrote them — pdata's marshaler emits them
+	// descending, so schema_url lands before scope. Nothing here may depend on the order, which is
+	// why the scope submessage is decoded after the walk rather than during it: decoding it in
+	// place would overwrite a schema_url already read.
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read scope logs field")
+		}
+
+		switch fc.FieldNum {
+		case fieldScopeLogsScope:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read scope")
+			}
+
+			scopeData = data
+		case fieldScopeLogsRecords:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read log record")
+			}
+
+			records = append(records, data)
+		case fieldScopeLogsSchemaURL:
+			v, ok := fc.Bytes()
+			if !ok {
+				return errors.New("read scope schema url")
+			}
+
+			schemaURL = v
+		}
+	}
+
+	sc, err := c.dec.scope(scopeData)
+	if err != nil {
+		return err
+	}
+
+	sc.SchemaURL = schemaURL
+
+	sl := rl.AddScope()
+	sl.Scope = sc
+
+	for _, data := range records {
+		if err := c.record(sl, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *LogsConverter) record(sl *log.ScopeLogs, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		rec log.Record
+		err error
+	)
+
+	kvs := c.kvScratch[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read log record field")
+		}
+
+		switch fc.FieldNum {
+		case fieldLogTime:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read log timestamp")
+			}
+
+			rec.Timestamp = int64(v)
+		case fieldLogObservedTime:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read log observed timestamp")
+			}
+
+			rec.ObservedTimestamp = int64(v)
+		case fieldLogSeverityNum:
+			v, ok := fc.Enum()
+			if !ok {
+				return errors.New("read log severity number")
+			}
+
+			rec.SeverityNumber = v
+		case fieldLogSeverityText:
+			v, ok := fc.Bytes()
+			if !ok {
+				return errors.New("read log severity text")
+			}
+
+			rec.SeverityText = v
+		case fieldLogBody:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read log body")
+			}
+
+			body, err := c.dec.anyValue(data)
+			if err != nil {
+				return err
+			}
+
+			// The model stores a body as text, so a non-string body is rendered the way the pdata
+			// path renders it.
+			rec.Body = c.dec.renderText(body)
+		case fieldLogAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read log attribute")
+			}
+
+			kvs = append(kvs, data)
+		case fieldLogDropped:
+			v, ok := fc.Uint32()
+			if !ok {
+				return errors.New("read log dropped count")
+			}
+
+			rec.Dropped = v
+		case fieldLogFlags:
+			v, ok := fc.Fixed32()
+			if !ok {
+				return errors.New("read log flags")
+			}
+
+			rec.Flags = v
+		case fieldLogTraceID:
+			v, ok := fc.Bytes()
+			if !ok {
+				return errors.New("read log trace id")
+			}
+
+			rec.TraceID = v
+		case fieldLogSpanID:
+			v, ok := fc.Bytes()
+			if !ok {
+				return errors.New("read log span id")
+			}
+
+			rec.SpanID = v
+		}
+	}
+
+	c.kvScratch = kvs // keep the grown capacity for the next record
+
+	if rec.Attributes, err = c.dec.attributes(kvs); err != nil {
+		return err
+	}
+
+	*sl.AddRecord() = rec
+
+	return nil
+}

--- a/internal/otlpdirect/logs_test.go
+++ b/internal/otlpdirect/logs_test.go
@@ -1,0 +1,272 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage/otlp/pdataconv"
+	"github.com/oteldb/storage/signal/log"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// marshal serializes a plog.Logs as an ExportLogsServiceRequest — the bytes a real OTLP client
+// puts on the wire.
+func marshal(tb testing.TB, ld plog.Logs) []byte {
+	tb.Helper()
+
+	raw, err := (&plog.ProtoMarshaler{}).MarshalLogs(ld)
+	require.NoError(tb, err)
+
+	return raw
+}
+
+// convertBoth decodes src directly and via the pdata path, returning both batches for comparison.
+func convertBoth(tb testing.TB, ld plog.Logs) (direct, viaPdata *log.Logs) {
+	tb.Helper()
+
+	var c otlpdirect.LogsConverter
+
+	direct, err := c.Convert(marshal(tb, ld))
+	require.NoError(tb, err)
+
+	viaPdata = &log.Logs{}
+	require.Zero(tb, pdataconv.AppendLogs(viaPdata, ld))
+
+	return canonical(direct), canonical(viaPdata)
+}
+
+// TestConvertLogsMatchesPdata is the contract: decoding the wire bytes directly must produce
+// exactly what the receiver → pdata → pdataconv path produces. Anything else is a silent
+// divergence between two ingest paths for the same request.
+func TestConvertLogsMatchesPdata(t *testing.T) {
+	t.Parallel()
+
+	ld := plog.NewLogs()
+
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.SetSchemaUrl("https://schema.example/1.0")
+	rl.Resource().Attributes().PutStr("service.name", "api")
+	rl.Resource().Attributes().PutInt("service.instance", 7)
+
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.SetSchemaUrl("https://schema.example/scope")
+	sl.Scope().SetName("go.opentelemetry.io/example")
+	sl.Scope().SetVersion("1.2.3")
+	sl.Scope().Attributes().PutBool("experimental", true)
+
+	r := sl.LogRecords().AppendEmpty()
+	r.SetTimestamp(1_700_000_000_000_000_000)
+	r.SetObservedTimestamp(1_700_000_000_000_000_001)
+	r.SetSeverityNumber(plog.SeverityNumberError)
+	r.SetSeverityText("ERROR")
+	r.Body().SetStr("connection refused")
+	r.SetFlags(plog.LogRecordFlags(1))
+	r.SetDroppedAttributesCount(3)
+	r.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	r.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	r.Attributes().PutStr("host", "node-1")
+	r.Attributes().PutDouble("latency", 12.5)
+	r.Attributes().PutBool("retried", false)
+	r.Attributes().PutEmptyBytes("payload").Append(0xde, 0xad)
+
+	direct, viaPdata := convertBoth(t, ld)
+	assert.Equal(t, viaPdata, direct)
+}
+
+// TestConvertLogsBodyKinds pins the body rendering: the model stores a body as text, so every
+// non-string AnyValue must render exactly as the pdata path renders it.
+func TestConvertLogsBodyKinds(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		set  func(pcommon.Value)
+		want string
+	}{
+		{"string", func(v pcommon.Value) { v.SetStr("plain") }, "plain"},
+		{"bool", func(v pcommon.Value) { v.SetBool(true) }, "true"},
+		{"int", func(v pcommon.Value) { v.SetInt(-42) }, "-42"},
+		{"double", func(v pcommon.Value) { v.SetDouble(1.5) }, "1.5"},
+		{"empty", func(pcommon.Value) {}, ""},
+		{"bytes", func(v pcommon.Value) { v.SetEmptyBytes().Append(0xde, 0xad) }, "3q0="},
+		{"slice", func(v pcommon.Value) {
+			s := v.SetEmptySlice()
+			s.AppendEmpty().SetInt(1)
+			s.AppendEmpty().SetStr("two")
+		}, `[1,"two"]`},
+		{"map", func(v pcommon.Value) { v.SetEmptyMap().PutStr("k", "v") }, `{"k":"v"}`},
+		{"html in string", func(v pcommon.Value) { v.SetEmptyMap().PutStr("k", "a<b&c") }, `{"k":"a<b&c"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ld := plog.NewLogs()
+			r := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+			r.SetTimestamp(1)
+			tt.set(r.Body())
+
+			direct, viaPdata := convertBoth(t, ld)
+			require.Equal(t, viaPdata, direct)
+
+			got := direct.Resources[0].Scopes[0].Records[0].Body
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// TestConvertLogsNestedAttributes covers the recursive value kinds, where a decoder is easiest to
+// get subtly wrong.
+func TestConvertLogsNestedAttributes(t *testing.T) {
+	t.Parallel()
+
+	ld := plog.NewLogs()
+	r := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	r.SetTimestamp(1)
+
+	m := r.Attributes().PutEmptyMap("nested")
+	m.PutStr("inner", "value")
+	m.PutInt("count", 2)
+
+	inner := m.PutEmptySlice("list")
+	inner.AppendEmpty().SetStr("a")
+	inner.AppendEmpty().SetDouble(0.5)
+
+	// Keys deliberately out of order: the decoder must sort them, or identity hashes diverge.
+	r.Attributes().PutStr("zeta", "last")
+	r.Attributes().PutStr("alpha", "first")
+
+	direct, viaPdata := convertBoth(t, ld)
+	assert.Equal(t, viaPdata, direct)
+}
+
+// TestConvertLogsMultipleResourcesAndScopes pins the hierarchy walk.
+func TestConvertLogsMultipleResourcesAndScopes(t *testing.T) {
+	t.Parallel()
+
+	ld := plog.NewLogs()
+
+	for i := range 3 {
+		rl := ld.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutInt("idx", int64(i))
+
+		for j := range 2 {
+			sl := rl.ScopeLogs().AppendEmpty()
+			sl.Scope().SetName("scope")
+			sl.Scope().SetVersion(string(rune('a' + j)))
+
+			for k := range 4 {
+				r := sl.LogRecords().AppendEmpty()
+				r.SetTimestamp(pcommon.Timestamp(1_000 + k))
+				r.Body().SetStr("body")
+			}
+		}
+	}
+
+	direct, viaPdata := convertBoth(t, ld)
+	require.Equal(t, viaPdata, direct)
+
+	assert.Len(t, direct.Resources, 3)
+	assert.Len(t, direct.Resources[0].Scopes, 2)
+	assert.Len(t, direct.Resources[0].Scopes[0].Records, 4)
+}
+
+// TestConvertLogsEmpty covers the degenerate inputs a real sender does produce.
+func TestConvertLogsEmpty(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.LogsConverter
+
+	got, err := c.Convert(nil)
+	require.NoError(t, err)
+	assert.Empty(t, got.Resources)
+
+	direct, viaPdata := convertBoth(t, plog.NewLogs())
+	assert.Equal(t, viaPdata, direct)
+}
+
+// TestConvertLogsReuseIsIsolated pins that a converter reused across requests does not leak the
+// previous batch's contents — the risk of retaining scratch across calls.
+func TestConvertLogsReuseIsIsolated(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.LogsConverter
+
+	first := plog.NewLogs()
+	fr := first.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	fr.SetTimestamp(1)
+	fr.Body().SetStr("first")
+	fr.Attributes().PutStr("a", "1")
+
+	second := plog.NewLogs()
+	sr := second.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	sr.SetTimestamp(2)
+	sr.Body().SetStr("second")
+	sr.Attributes().PutStr("b", "2")
+
+	_, err := c.Convert(marshal(t, first))
+	require.NoError(t, err)
+
+	got, err := c.Convert(marshal(t, second))
+	require.NoError(t, err)
+
+	want := &log.Logs{}
+	require.Zero(t, pdataconv.AppendLogs(want, second))
+	assert.Equal(t, canonical(want), canonical(got))
+}
+
+func BenchmarkConvertLogs(b *testing.B) {
+	ld := plog.NewLogs()
+
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "api")
+
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.Scope().SetName("bench")
+
+	for i := range 1_000 {
+		r := sl.LogRecords().AppendEmpty()
+		r.SetTimestamp(pcommon.Timestamp(1_700_000_000_000_000_000 + i))
+		r.SetSeverityNumber(plog.SeverityNumberInfo)
+		r.SetSeverityText("INFO")
+		r.Body().SetStr("request completed")
+		r.Attributes().PutStr("http.route", "/api/v1/things")
+		r.Attributes().PutInt("http.status_code", 200)
+	}
+
+	raw := marshal(b, ld)
+
+	b.Run("Direct", func(b *testing.B) {
+		var c otlpdirect.LogsConverter
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(raw)))
+
+		for b.Loop() {
+			if _, err := c.Convert(raw); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Pdata", func(b *testing.B) {
+		var u plog.ProtoUnmarshaler
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(raw)))
+
+		for b.Loop() {
+			decoded, err := u.UnmarshalLogs(raw)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			dst := &log.Logs{}
+			pdataconv.AppendLogs(dst, decoded)
+		}
+	})
+}

--- a/internal/otlpdirect/metricorder_test.go
+++ b/internal/otlpdirect/metricorder_test.go
@@ -1,0 +1,178 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage/signal/metric"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// otlpCumulative is AGGREGATION_TEMPORALITY_CUMULATIVE on the wire.
+const otlpCumulative = 2
+
+// encodeScopeMetrics builds one ExportMetricsServiceRequest carrying a histogram metric, writing
+// each message's fields ascending or descending. A metric's name and unit are siblings of the
+// oneof arm that holds its points, so the ordering hazard reaches the metric identity itself here,
+// not just a schema URL.
+func encodeScopeMetrics(ascending bool) []byte {
+	var m easyproto.Marshaler
+
+	req := m.MessageMarshaler()
+	rm := req.AppendMessage(1) // resource_metrics
+
+	writeResource := func() {
+		res := rm.AppendMessage(1)
+		kv := res.AppendMessage(1)
+		kv.AppendString(1, "service.name")
+		kv.AppendMessage(2).AppendString(1, "api")
+	}
+
+	writeScopes := func() {
+		sm := rm.AppendMessage(2) // scope_metrics
+
+		writeScope := func() {
+			sc := sm.AppendMessage(1)
+			sc.AppendString(1, "scope-name")
+			sc.AppendString(2, "1.0.0")
+		}
+
+		writeMetrics := func() {
+			mt := sm.AppendMessage(2) // metrics
+
+			writeIdentity := func() {
+				mt.AppendString(1, "http.server.duration") // name
+				mt.AppendString(3, "ms")                   // unit
+			}
+
+			writeHistogram := func() {
+				h := mt.AppendMessage(9) // histogram
+
+				dp := h.AppendMessage(1) // data_points
+				dp.AppendFixed64(2, 1_700_000_000_000_000_000)
+				dp.AppendFixed64(3, 1_700_000_000_000_000_001)
+				dp.AppendFixed64(4, 6) // count
+				dp.AppendDouble(5, 1.5)
+				dp.AppendFixed64s(6, []uint64{1, 2, 3}) // bucket_counts
+				dp.AppendDoubles(7, []float64{1, 2})    // explicit_bounds
+
+				kv := dp.AppendMessage(9) // attributes
+				kv.AppendString(1, "http.route")
+				kv.AppendMessage(2).AppendString(1, "/things")
+
+				h.AppendInt64(2, otlpCumulative)
+			}
+
+			if ascending {
+				writeIdentity()
+				writeHistogram()
+			} else {
+				writeHistogram()
+				writeIdentity()
+			}
+		}
+
+		writeSchema := func() { sm.AppendString(3, "https://schema.example/scope") }
+
+		if ascending {
+			writeScope()
+			writeMetrics()
+			writeSchema()
+		} else {
+			writeSchema()
+			writeMetrics()
+			writeScope()
+		}
+	}
+
+	writeSchema := func() { rm.AppendString(3, "https://schema.example/resource") }
+
+	if ascending {
+		writeResource()
+		writeScopes()
+		writeSchema()
+	} else {
+		writeSchema()
+		writeScopes()
+		writeResource()
+	}
+
+	return m.Marshal(nil)
+}
+
+// TestConvertMetricsIsFieldOrderIndependent pins that the two wire orderings decode identically.
+// A metric decoded before its name is read would produce correctly-shaped series under an empty
+// name — data that looks fine until someone queries for it.
+func TestConvertMetricsIsFieldOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	var asc, desc otlpdirect.MetricsConverter
+
+	up, _, err := asc.Convert(encodeScopeMetrics(true))
+	require.NoError(t, err)
+
+	down, _, err := desc.Convert(encodeScopeMetrics(false))
+	require.NoError(t, err)
+
+	require.Equal(t, canonicalMetrics(down), canonicalMetrics(up))
+
+	sm := up.Resources[0].Scopes[0]
+	assert.Equal(t, "https://schema.example/scope", string(sm.Scope.SchemaURL))
+	assert.Equal(t, "scope-name", string(sm.Scope.Name))
+	assert.Equal(t, "https://schema.example/resource", string(up.Resources[0].Resource.SchemaURL))
+
+	// The decomposed series must carry the metric's own name and unit, which arrive on the far
+	// side of the histogram body in the descending encoding.
+	require.Len(t, sm.Metrics, 1+1+3) // _count, _sum, three buckets
+
+	for _, mt := range sm.Metrics {
+		assert.Equal(t, "ms", string(mt.Unit))
+		assert.Contains(t, string(mt.Name), "http.server.duration")
+		assert.Equal(t, metric.TemporalityCumulative, mt.Temporality)
+	}
+
+	assert.Equal(t, "http.server.duration_count", string(sm.Metrics[0].Name))
+	assert.Equal(t, "http.server.duration_sum", string(sm.Metrics[1].Name))
+	assert.Equal(t, "http.server.duration_bucket", string(sm.Metrics[2].Name))
+}
+
+// canonicalMetrics is [canonical] for the metrics model. See canonical_test.go.
+func canonicalMetrics(m *metric.Metrics) *metric.Metrics {
+	for i := range m.Resources {
+		rm := &m.Resources[i]
+		rm.Resource.SchemaURL = canonBytes(rm.Resource.SchemaURL)
+		rm.Resource.Attributes = canonAttrs(rm.Resource.Attributes)
+
+		for j := range rm.Scopes {
+			sm := &rm.Scopes[j]
+			sm.Scope.Name = canonBytes(sm.Scope.Name)
+			sm.Scope.Version = canonBytes(sm.Scope.Version)
+			sm.Scope.SchemaURL = canonBytes(sm.Scope.SchemaURL)
+			sm.Scope.Attributes = canonAttrs(sm.Scope.Attributes)
+
+			for k := range sm.Metrics {
+				mt := &sm.Metrics[k]
+				mt.Name = canonBytes(mt.Name)
+				mt.Unit = canonBytes(mt.Unit)
+
+				for p := range mt.Points {
+					mt.Points[p].Attributes = canonAttrs(mt.Points[p].Attributes)
+				}
+
+				if len(mt.Points) == 0 {
+					mt.Points = nil
+				}
+			}
+
+			if len(sm.Metrics) == 0 {
+				sm.Metrics = nil
+			}
+		}
+	}
+
+	return m
+}

--- a/internal/otlpdirect/metrics.go
+++ b/internal/otlpdirect/metrics.go
@@ -1,0 +1,474 @@
+package otlpdirect
+
+import (
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/go-faster/errors"
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/signal/metric"
+)
+
+// Field numbers of metrics.proto and collector/metrics/v1/metrics_service.proto.
+const (
+	// opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest
+	fieldExportResourceMetrics = 1
+
+	// opentelemetry.proto.metrics.v1.ResourceMetrics
+	fieldResourceMetricsResource  = 1
+	fieldResourceMetricsScope     = 2
+	fieldResourceMetricsSchemaURL = 3
+
+	// opentelemetry.proto.metrics.v1.ScopeMetrics
+	fieldScopeMetricsScope     = 1
+	fieldScopeMetricsMetrics   = 2
+	fieldScopeMetricsSchemaURL = 3
+
+	// opentelemetry.proto.metrics.v1.Metric — 4 (data) is the oneof the five below inhabit.
+	fieldMetricName    = 1
+	fieldMetricUnit    = 3
+	fieldMetricGauge   = 5
+	fieldMetricSum     = 7
+	fieldMetricHist    = 9
+	fieldMetricExpHist = 10
+	fieldMetricSummary = 11
+
+	// opentelemetry.proto.metrics.v1.{Gauge,Sum,Histogram,ExponentialHistogram,Summary}
+	fieldDataPoints     = 1
+	fieldTemporality    = 2
+	fieldSumIsMonotonic = 3
+
+	// opentelemetry.proto.metrics.v1.NumberDataPoint
+	fieldNumberStart      = 2
+	fieldNumberTime       = 3
+	fieldNumberAsDouble   = 4
+	fieldNumberAsInt      = 6
+	fieldNumberAttributes = 7
+
+	// opentelemetry.proto.metrics.v1.HistogramDataPoint
+	fieldHistStart      = 2
+	fieldHistTime       = 3
+	fieldHistCount      = 4
+	fieldHistSum        = 5
+	fieldHistBuckets    = 6
+	fieldHistBounds     = 7
+	fieldHistAttributes = 9
+
+	// opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint
+	fieldExpAttributes = 1
+	fieldExpStart      = 2
+	fieldExpTime       = 3
+	fieldExpCount      = 4
+	fieldExpSum        = 5
+	fieldExpScale      = 6
+	fieldExpZeroCount  = 7
+	fieldExpPositive   = 8
+	fieldExpNegative   = 9
+
+	// opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint.Buckets
+	fieldBucketsOffset = 1
+	fieldBucketsCounts = 2
+
+	// opentelemetry.proto.metrics.v1.SummaryDataPoint
+	fieldSummaryStart      = 2
+	fieldSummaryTime       = 3
+	fieldSummaryCount      = 4
+	fieldSummarySum        = 5
+	fieldSummaryQuantiles  = 6
+	fieldSummaryAttributes = 7
+
+	// opentelemetry.proto.metrics.v1.SummaryDataPoint.ValueAtQuantile
+	fieldQuantileQuantile = 1
+	fieldQuantileValue    = 2
+)
+
+// OTLP aggregation temporality, which the model spells with its own constants.
+const (
+	otlpTemporalityDelta      = 1
+	otlpTemporalityCumulative = 2
+)
+
+// MetricsConverter decodes an OTLP ExportMetricsServiceRequest into [metric.Metrics]. It retains
+// the batch and the scratch it is built from, so a converter reused across requests allocates
+// nothing in steady state. It is not safe for concurrent use; pool one per in-flight request.
+type MetricsConverter struct {
+	batch metric.Metrics
+	dec   decoder
+
+	// Scratch reused across the data points of a request; each is consumed before the next point
+	// reaches it.
+	pointAttrs [][]byte
+	dataPoints [][]byte
+	bounds     []float64
+	counts     []uint64
+	deltas     []uint64
+}
+
+// Convert decodes a serialized ExportMetricsServiceRequest, returning how many points it could not
+// represent (a number point carrying no value — the only unrepresentable case).
+//
+// The returned batch aliases src: every attribute key, string value, metric name and unit is a
+// sub-slice of it. It stays valid until the next Convert on this converter, and src must not be
+// recycled until the write consuming the batch has returned.
+func (c *MetricsConverter) Convert(src []byte) (_ *metric.Metrics, dropped int, _ error) {
+	c.batch.Reset()
+	c.dec.reset()
+
+	resources, err := collect(src, fieldExportResourceMetrics, "resource metrics")
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for _, data := range resources {
+		n, err := c.resourceMetrics(data)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		dropped += n
+	}
+
+	return &c.batch, dropped, nil
+}
+
+func (c *MetricsConverter) resourceMetrics(src []byte) (dropped int, _ error) {
+	var (
+		fc     easyproto.FieldContext
+		res    signal.Resource
+		scopes [][]byte
+		err    error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return 0, errors.Wrap(err, "read resource metrics field")
+		}
+
+		switch fc.FieldNum {
+		case fieldResourceMetricsResource:
+			data, ok := fc.MessageData()
+			if !ok {
+				return 0, errors.New("read resource")
+			}
+
+			if res.Attributes, err = c.dec.resource(data); err != nil {
+				return 0, err
+			}
+		case fieldResourceMetricsScope:
+			data, ok := fc.MessageData()
+			if !ok {
+				return 0, errors.New("read scope metrics")
+			}
+
+			scopes = append(scopes, data)
+		case fieldResourceMetricsSchemaURL:
+			v, ok := fc.Bytes()
+			if !ok {
+				return 0, errors.New("read resource schema url")
+			}
+
+			res.SchemaURL = v
+		}
+	}
+
+	rm := c.batch.AddResource()
+	rm.Resource = res
+
+	for _, data := range scopes {
+		n, err := c.scopeMetrics(rm, data)
+		if err != nil {
+			return dropped, err
+		}
+
+		dropped += n
+	}
+
+	return dropped, nil
+}
+
+func (c *MetricsConverter) scopeMetrics(rm *metric.ResourceMetrics, src []byte) (dropped int, _ error) {
+	var (
+		fc        easyproto.FieldContext
+		scopeData []byte
+		schemaURL []byte
+		metrics   [][]byte
+		err       error
+	)
+
+	// Field order is the producer's choice — pdata writes them descending, so schema_url arrives
+	// before scope. The scope submessage is decoded after the walk, never during it: decoding in
+	// place would overwrite a schema_url already read.
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return 0, errors.Wrap(err, "read scope metrics field")
+		}
+
+		switch fc.FieldNum {
+		case fieldScopeMetricsScope:
+			data, ok := fc.MessageData()
+			if !ok {
+				return 0, errors.New("read scope")
+			}
+
+			scopeData = data
+		case fieldScopeMetricsMetrics:
+			data, ok := fc.MessageData()
+			if !ok {
+				return 0, errors.New("read metric")
+			}
+
+			metrics = append(metrics, data)
+		case fieldScopeMetricsSchemaURL:
+			v, ok := fc.Bytes()
+			if !ok {
+				return 0, errors.New("read scope schema url")
+			}
+
+			schemaURL = v
+		}
+	}
+
+	sc, err := c.dec.scope(scopeData)
+	if err != nil {
+		return 0, err
+	}
+
+	sc.SchemaURL = schemaURL
+
+	sm := rm.AddScope()
+	sm.Scope = sc
+
+	for _, data := range metrics {
+		n, err := c.metric(sm, data)
+		if err != nil {
+			return dropped, err
+		}
+
+		dropped += n
+	}
+
+	return dropped, nil
+}
+
+// metric dispatches on which arm of the Metric `data` oneof is present. The name and unit are
+// siblings of that arm and may arrive on either side of it, so the arm is decoded after the walk.
+func (c *MetricsConverter) metric(sm *metric.ScopeMetrics, src []byte) (dropped int, _ error) {
+	var (
+		fc       easyproto.FieldContext
+		name     []byte
+		unit     []byte
+		body     []byte
+		bodyKind uint32
+		err      error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return 0, errors.Wrap(err, "read metric field")
+		}
+
+		switch fc.FieldNum {
+		case fieldMetricName:
+			if name, err = takeBytes(&fc, "metric name"); err != nil {
+				return 0, err
+			}
+		case fieldMetricUnit:
+			if unit, err = takeBytes(&fc, "metric unit"); err != nil {
+				return 0, err
+			}
+		case fieldMetricGauge, fieldMetricSum, fieldMetricHist, fieldMetricExpHist, fieldMetricSummary:
+			data, ok := fc.MessageData()
+			if !ok {
+				return 0, errors.New("read metric data")
+			}
+
+			body, bodyKind = data, fc.FieldNum
+		}
+	}
+
+	switch bodyKind {
+	case fieldMetricGauge:
+		return c.numbers(sm, name, unit, body, metric.KindGauge, 0, false)
+	case fieldMetricSum:
+		return c.sum(sm, name, unit, body)
+	case fieldMetricHist:
+		return 0, c.histogram(sm, name, unit, body)
+	case fieldMetricExpHist:
+		return 0, c.expHistogram(sm, name, unit, body)
+	case fieldMetricSummary:
+		return 0, c.summary(sm, name, unit, body)
+	default: // a metric with no data arm carries no points
+		return 0, nil
+	}
+}
+
+// sum reads the temporality and monotonicity that qualify a sum's identity, then its points.
+func (c *MetricsConverter) sum(sm *metric.ScopeMetrics, name, unit, src []byte) (dropped int, _ error) {
+	var (
+		fc        easyproto.FieldContext
+		temp      metric.Temporality
+		monotonic bool
+		err       error
+	)
+
+	points := c.dataPoints[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return 0, errors.Wrap(err, "read sum field")
+		}
+
+		switch fc.FieldNum {
+		case fieldDataPoints:
+			data, ok := fc.MessageData()
+			if !ok {
+				return 0, errors.New("read sum data point")
+			}
+
+			points = append(points, data)
+		case fieldTemporality:
+			v, ok := fc.Enum()
+			if !ok {
+				return 0, errors.New("read sum temporality")
+			}
+
+			temp = temporalityOf(v)
+		case fieldSumIsMonotonic:
+			v, ok := fc.Bool()
+			if !ok {
+				return 0, errors.New("read sum monotonicity")
+			}
+
+			monotonic = v
+		}
+	}
+
+	c.dataPoints = points
+
+	mt := sm.AddMetric()
+	mt.Name, mt.Unit = name, unit
+	mt.Kind, mt.Temporality, mt.Monotonic = metric.KindSum, temp, monotonic
+
+	for _, data := range points {
+		n, err := c.numberPoint(mt, data)
+		if err != nil {
+			return dropped, err
+		}
+
+		dropped += n
+	}
+
+	return dropped, nil
+}
+
+// numbers reads a gauge's points under one metric entry.
+func (c *MetricsConverter) numbers(
+	sm *metric.ScopeMetrics, name, unit, src []byte,
+	kind metric.PointKind, temp metric.Temporality, monotonic bool,
+) (dropped int, _ error) {
+	points, err := collectInto(c.dataPoints[:0], src, fieldDataPoints, "number data point")
+	if err != nil {
+		return 0, err
+	}
+
+	c.dataPoints = points
+
+	mt := sm.AddMetric()
+	mt.Name, mt.Unit = name, unit
+	mt.Kind, mt.Temporality, mt.Monotonic = kind, temp, monotonic
+
+	for _, data := range points {
+		n, err := c.numberPoint(mt, data)
+		if err != nil {
+			return dropped, err
+		}
+
+		dropped += n
+	}
+
+	return dropped, nil
+}
+
+// numberPoint appends one gauge/sum point. A point carrying neither as_double nor as_int has no
+// value to store, so it is dropped and counted rather than stored as zero.
+func (c *MetricsConverter) numberPoint(mt *metric.Metric, src []byte) (dropped int, _ error) {
+	var (
+		fc        easyproto.FieldContext
+		start, ts int64
+		value     float64
+		hasValue  bool
+		err       error
+	)
+
+	kvs := c.pointAttrs[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return 0, errors.Wrap(err, "read number data point field")
+		}
+
+		switch fc.FieldNum {
+		case fieldNumberStart:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return 0, errors.New("read point start")
+			}
+
+			start = int64(v)
+		case fieldNumberTime:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return 0, errors.New("read point time")
+			}
+
+			ts = int64(v)
+		case fieldNumberAsDouble:
+			v, ok := fc.Double()
+			if !ok {
+				return 0, errors.New("read point double value")
+			}
+
+			value, hasValue = v, true
+		case fieldNumberAsInt:
+			v, ok := fc.Sfixed64()
+			if !ok {
+				return 0, errors.New("read point int value")
+			}
+
+			value, hasValue = float64(v), true
+		case fieldNumberAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return 0, errors.New("read point attribute")
+			}
+
+			kvs = append(kvs, data)
+		}
+	}
+
+	c.pointAttrs = kvs
+
+	if !hasValue {
+		return 1, nil
+	}
+
+	attrs, err := c.dec.attributes(kvs)
+	if err != nil {
+		return 0, err
+	}
+
+	p := mt.AddPoint()
+	p.Attributes = attrs
+	p.StartTs, p.Ts, p.Value = start, ts, value
+
+	return 0, nil
+}
+
+func temporalityOf(v int32) metric.Temporality {
+	switch v {
+	case otlpTemporalityDelta:
+		return metric.TemporalityDelta
+	case otlpTemporalityCumulative:
+		return metric.TemporalityCumulative
+	default:
+		return metric.TemporalityUnspecified
+	}
+}

--- a/internal/otlpdirect/metrics_test.go
+++ b/internal/otlpdirect/metrics_test.go
@@ -1,0 +1,484 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/oteldb/storage/otlp/pdataconv"
+	"github.com/oteldb/storage/signal/metric"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+func marshalMetrics(tb testing.TB, md pmetric.Metrics) []byte {
+	tb.Helper()
+
+	raw, err := (&pmetric.ProtoMarshaler{}).MarshalMetrics(md)
+	require.NoError(tb, err)
+
+	return raw
+}
+
+// convertBothMetrics decodes md directly and via the pdata path, canonicalized for comparison.
+func convertBothMetrics(tb testing.TB, md pmetric.Metrics) (direct, viaPdata *metric.Metrics, dropped, pdataDropped int) {
+	tb.Helper()
+
+	var c otlpdirect.MetricsConverter
+
+	direct, dropped, err := c.Convert(marshalMetrics(tb, md))
+	require.NoError(tb, err)
+
+	viaPdata = &metric.Metrics{}
+	pdataDropped = pdataconv.AppendMetrics(viaPdata, md)
+
+	return canonicalMetrics(direct), canonicalMetrics(viaPdata), dropped, pdataDropped
+}
+
+// requireSameMetrics asserts both paths agree on the batch and on what they dropped.
+func requireSameMetrics(tb testing.TB, md pmetric.Metrics) *metric.Metrics {
+	tb.Helper()
+
+	direct, viaPdata, dropped, pdataDropped := convertBothMetrics(tb, md)
+	require.Equal(tb, viaPdata, direct)
+	require.Equal(tb, pdataDropped, dropped, "dropped counts must agree")
+
+	return direct
+}
+
+func newGauge(md pmetric.Metrics, name string) pmetric.Metric {
+	m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName(name)
+
+	return m
+}
+
+func TestConvertMetricsGaugeAndSum(t *testing.T) {
+	t.Parallel()
+
+	md := pmetric.NewMetrics()
+
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.SetSchemaUrl("https://schema.example/resource")
+	rm.Resource().Attributes().PutStr("service.name", "api")
+
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.SetSchemaUrl("https://schema.example/scope")
+	sm.Scope().SetName("go.opentelemetry.io/example")
+	sm.Scope().SetVersion("1.2.3")
+
+	g := sm.Metrics().AppendEmpty()
+	g.SetName("process.cpu.utilization")
+	g.SetUnit("1")
+
+	gp := g.SetEmptyGauge().DataPoints().AppendEmpty()
+	gp.SetStartTimestamp(1_700_000_000_000_000_000)
+	gp.SetTimestamp(1_700_000_000_000_000_001)
+	gp.SetDoubleValue(0.42)
+	gp.Attributes().PutStr("cpu", "0")
+
+	s := sm.Metrics().AppendEmpty()
+	s.SetName("http.server.request.count")
+	s.SetUnit("{request}")
+
+	sum := s.SetEmptySum()
+	sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	sum.SetIsMonotonic(true)
+
+	sp := sum.DataPoints().AppendEmpty()
+	sp.SetStartTimestamp(1_700_000_000_000_000_000)
+	sp.SetTimestamp(1_700_000_000_000_000_002)
+	sp.SetIntValue(1234)
+	sp.Attributes().PutStr("http.route", "/things")
+
+	requireSameMetrics(t, md)
+}
+
+// TestConvertMetricsTemporalityAndMonotonicity walks the qualifiers that are part of a sum's
+// identity, so a mix-up changes which series a point lands in.
+func TestConvertMetricsTemporalityAndMonotonicity(t *testing.T) {
+	t.Parallel()
+
+	for _, temp := range []pmetric.AggregationTemporality{
+		pmetric.AggregationTemporalityUnspecified,
+		pmetric.AggregationTemporalityDelta,
+		pmetric.AggregationTemporalityCumulative,
+	} {
+		for _, monotonic := range []bool{false, true} {
+			md := pmetric.NewMetrics()
+
+			m := newGauge(md, "counter")
+			sum := m.SetEmptySum()
+			sum.SetAggregationTemporality(temp)
+			sum.SetIsMonotonic(monotonic)
+
+			p := sum.DataPoints().AppendEmpty()
+			p.SetTimestamp(1)
+			p.SetIntValue(7)
+
+			requireSameMetrics(t, md)
+		}
+	}
+}
+
+// TestConvertMetricsDropsValuelessPoint pins the one unrepresentable case: a number point with
+// neither as_double nor as_int is counted, not stored as zero.
+func TestConvertMetricsDropsValuelessPoint(t *testing.T) {
+	t.Parallel()
+
+	md := pmetric.NewMetrics()
+
+	m := newGauge(md, "empty")
+	dps := m.SetEmptyGauge().DataPoints()
+
+	none := dps.AppendEmpty()
+	none.SetTimestamp(1)
+
+	valued := dps.AppendEmpty()
+	valued.SetTimestamp(2)
+	valued.SetDoubleValue(1)
+
+	direct, viaPdata, dropped, pdataDropped := convertBothMetrics(t, md)
+	require.Equal(t, viaPdata, direct)
+	assert.Equal(t, 1, dropped)
+	assert.Equal(t, pdataDropped, dropped)
+
+	assert.Len(t, direct.Resources[0].Scopes[0].Metrics[0].Points, 1)
+}
+
+// TestConvertMetricsHistogram covers classic decomposition into _count/_sum/_bucket{le}.
+func TestConvertMetricsHistogram(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		hasSum bool
+		temp   pmetric.AggregationTemporality
+	}{
+		{"cumulative with sum", true, pmetric.AggregationTemporalityCumulative},
+		{"delta with sum", true, pmetric.AggregationTemporalityDelta},
+		{"cumulative without sum", false, pmetric.AggregationTemporalityCumulative},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			md := pmetric.NewMetrics()
+
+			m := newGauge(md, "http.server.duration")
+			m.SetUnit("ms")
+
+			h := m.SetEmptyHistogram()
+			h.SetAggregationTemporality(tt.temp)
+
+			dp := h.DataPoints().AppendEmpty()
+			dp.SetStartTimestamp(1_700_000_000_000_000_000)
+			dp.SetTimestamp(1_700_000_000_000_000_001)
+			dp.SetCount(10)
+			dp.Attributes().PutStr("http.route", "/things")
+			dp.ExplicitBounds().FromRaw([]float64{0.005, 0.01, 0.025, 2.5})
+			dp.BucketCounts().FromRaw([]uint64{1, 2, 3, 3, 1})
+
+			if tt.hasSum {
+				dp.SetSum(1.5)
+			}
+
+			got := requireSameMetrics(t, md)
+
+			// The decomposition must produce _count, optionally _sum, and one _bucket per bucket
+			// count — the last of which is the +Inf overflow.
+			want := 1 + len(dp.BucketCounts().AsRaw())
+			if tt.hasSum {
+				want++
+			}
+
+			assert.Len(t, got.Resources[0].Scopes[0].Metrics, want)
+		})
+	}
+}
+
+// TestConvertMetricsExpHistogram covers the exponential form, whose buckets are derived from the
+// scale rather than carried explicitly.
+func TestConvertMetricsExpHistogram(t *testing.T) {
+	t.Parallel()
+
+	for _, scale := range []int32{-2, 0, 1, 3} {
+		md := pmetric.NewMetrics()
+
+		m := newGauge(md, "rpc.duration")
+		m.SetUnit("s")
+
+		eh := m.SetEmptyExponentialHistogram()
+		eh.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+		dp := eh.DataPoints().AppendEmpty()
+		dp.SetTimestamp(1)
+		dp.SetCount(12)
+		dp.SetSum(3.5)
+		dp.SetScale(scale)
+		dp.SetZeroCount(2)
+		dp.Positive().SetOffset(1)
+		dp.Positive().BucketCounts().FromRaw([]uint64{3, 0, 4})
+		dp.Negative().SetOffset(-2)
+		dp.Negative().BucketCounts().FromRaw([]uint64{2, 1})
+		dp.Attributes().PutStr("rpc.method", "Get")
+
+		requireSameMetrics(t, md)
+	}
+}
+
+// TestConvertMetricsExpHistogramEmptyBuckets covers the degenerate point a real SDK emits before
+// it has observed anything.
+func TestConvertMetricsExpHistogramEmptyBuckets(t *testing.T) {
+	t.Parallel()
+
+	md := pmetric.NewMetrics()
+
+	m := newGauge(md, "rpc.duration")
+
+	eh := m.SetEmptyExponentialHistogram()
+	eh.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+
+	dp := eh.DataPoints().AppendEmpty()
+	dp.SetTimestamp(1)
+
+	requireSameMetrics(t, md)
+}
+
+// TestConvertMetricsSummary covers _count/_sum plus the per-quantile gauges.
+func TestConvertMetricsSummary(t *testing.T) {
+	t.Parallel()
+
+	md := pmetric.NewMetrics()
+
+	m := newGauge(md, "rpc.duration")
+	m.SetUnit("ms")
+
+	dp := m.SetEmptySummary().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(1)
+	dp.SetTimestamp(2)
+	dp.SetCount(9)
+	dp.SetSum(2.25)
+	dp.Attributes().PutStr("rpc.service", "Things")
+
+	for _, q := range []struct{ quantile, value float64 }{
+		{0, 0.1}, {0.5, 1.0}, {0.99, 9.5}, {1, 12},
+	} {
+		qv := dp.QuantileValues().AppendEmpty()
+		qv.SetQuantile(q.quantile)
+		qv.SetValue(q.value)
+	}
+
+	got := requireSameMetrics(t, md)
+	assert.Len(t, got.Resources[0].Scopes[0].Metrics, 2+4)
+}
+
+// TestConvertMetricsHistogramBoundFormatting pins the `le` label text, which is what a query
+// matches on — a different float rendering silently makes a different series.
+func TestConvertMetricsHistogramBoundFormatting(t *testing.T) {
+	t.Parallel()
+
+	md := pmetric.NewMetrics()
+
+	m := newGauge(md, "h")
+
+	h := m.SetEmptyHistogram()
+	h.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+	dp := h.DataPoints().AppendEmpty()
+	dp.SetTimestamp(1)
+	dp.SetCount(4)
+	dp.ExplicitBounds().FromRaw([]float64{0.0001, 1, 1e21, 0.30000000000000004})
+	dp.BucketCounts().FromRaw([]uint64{1, 1, 1, 1, 0})
+
+	got := requireSameMetrics(t, md)
+
+	var les []string
+
+	for _, mt := range got.Resources[0].Scopes[0].Metrics {
+		if string(mt.Name) != "h_bucket" {
+			continue
+		}
+
+		v, ok := mt.Points[0].Attributes.Get([]byte("le"))
+		require.True(t, ok)
+		les = append(les, string(v.Str()))
+	}
+
+	assert.Equal(t, []string{"0.0001", "1", "1e+21", "0.30000000000000004", "+Inf"}, les)
+}
+
+// TestConvertMetricsMixedAndReuse pins that the scratch reused across points does not bleed one
+// point's attributes, bounds or bucket counts into the next.
+func TestConvertMetricsMixedAndReuse(t *testing.T) {
+	t.Parallel()
+
+	md := pmetric.NewMetrics()
+	sm := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+
+	for i := range 5 {
+		g := sm.Metrics().AppendEmpty()
+		g.SetName("g")
+
+		gp := g.SetEmptyGauge().DataPoints().AppendEmpty()
+		gp.SetTimestamp(pcommon.Timestamp(i + 1))
+		gp.SetDoubleValue(float64(i))
+		gp.Attributes().PutInt("i", int64(i))
+
+		h := sm.Metrics().AppendEmpty()
+		h.SetName("h")
+
+		hist := h.SetEmptyHistogram()
+		hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+		hp := hist.DataPoints().AppendEmpty()
+		hp.SetTimestamp(pcommon.Timestamp(i + 1))
+		hp.SetCount(uint64(i))
+
+		// Bucket counts of differing length, so a leaked scratch shows up as a bucket the point
+		// never had.
+		bounds := make([]float64, i)
+		counts := make([]uint64, i+1)
+
+		for b := range i {
+			bounds[b] = float64(b + 1)
+			counts[b] = uint64(b)
+		}
+
+		hp.ExplicitBounds().FromRaw(bounds)
+		hp.BucketCounts().FromRaw(counts)
+	}
+
+	requireSameMetrics(t, md)
+}
+
+func TestConvertMetricsEmpty(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.MetricsConverter
+
+	got, dropped, err := c.Convert(nil)
+	require.NoError(t, err)
+	assert.Zero(t, dropped)
+	assert.Empty(t, got.Resources)
+
+	requireSameMetrics(t, pmetric.NewMetrics())
+}
+
+// TestConvertMetricsNoDataArm covers a Metric whose oneof is unset, which carries no points.
+func TestConvertMetricsNoDataArm(t *testing.T) {
+	t.Parallel()
+
+	md := pmetric.NewMetrics()
+	newGauge(md, "nothing")
+
+	requireSameMetrics(t, md)
+}
+
+func TestConvertMetricsReuseIsIsolated(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.MetricsConverter
+
+	first := pmetric.NewMetrics()
+
+	fh := newGauge(first, "h")
+	fhist := fh.SetEmptyHistogram()
+	fhist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+	fp := fhist.DataPoints().AppendEmpty()
+	fp.SetTimestamp(1)
+	fp.SetCount(3)
+	fp.SetSum(1)
+	fp.ExplicitBounds().FromRaw([]float64{1, 2, 3})
+	fp.BucketCounts().FromRaw([]uint64{1, 1, 1, 0})
+	fp.Attributes().PutStr("a", "1")
+
+	second := pmetric.NewMetrics()
+
+	sg := newGauge(second, "g")
+
+	sp := sg.SetEmptyGauge().DataPoints().AppendEmpty()
+	sp.SetTimestamp(2)
+	sp.SetDoubleValue(5)
+
+	_, _, err := c.Convert(marshalMetrics(t, first))
+	require.NoError(t, err)
+
+	got, _, err := c.Convert(marshalMetrics(t, second))
+	require.NoError(t, err)
+
+	want := &metric.Metrics{}
+	pdataconv.AppendMetrics(want, second)
+	assert.Equal(t, canonicalMetrics(want), canonicalMetrics(got))
+}
+
+func BenchmarkConvertMetrics(b *testing.B) {
+	md := pmetric.NewMetrics()
+
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "api")
+
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("bench")
+
+	for i := range 500 {
+		g := sm.Metrics().AppendEmpty()
+		g.SetName("process.cpu.utilization")
+		g.SetUnit("1")
+
+		gp := g.SetEmptyGauge().DataPoints().AppendEmpty()
+		gp.SetTimestamp(pcommon.Timestamp(1_700_000_000_000_000_000 + i))
+		gp.SetDoubleValue(float64(i))
+		gp.Attributes().PutStr("cpu", "0")
+
+		h := sm.Metrics().AppendEmpty()
+		h.SetName("http.server.duration")
+		h.SetUnit("ms")
+
+		hist := h.SetEmptyHistogram()
+		hist.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+		hp := hist.DataPoints().AppendEmpty()
+		hp.SetTimestamp(pcommon.Timestamp(1_700_000_000_000_000_000 + i))
+		hp.SetCount(uint64(i))
+		hp.SetSum(float64(i))
+		hp.ExplicitBounds().FromRaw([]float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10})
+		hp.BucketCounts().FromRaw([]uint64{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1})
+		hp.Attributes().PutStr("http.route", "/api/v1/things")
+	}
+
+	raw := marshalMetrics(b, md)
+
+	b.Run("Direct", func(b *testing.B) {
+		var c otlpdirect.MetricsConverter
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(raw)))
+
+		for b.Loop() {
+			if _, _, err := c.Convert(raw); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Pdata", func(b *testing.B) {
+		var u pmetric.ProtoUnmarshaler
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(raw)))
+
+		for b.Loop() {
+			decoded, err := u.UnmarshalMetrics(raw)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			dst := &metric.Metrics{}
+			pdataconv.AppendMetrics(dst, decoded)
+		}
+	})
+}

--- a/internal/otlpdirect/order_test.go
+++ b/internal/otlpdirect/order_test.go
@@ -1,0 +1,98 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// Protobuf puts no ordering on the fields of a message, and producers disagree: pdata's marshaler
+// emits them descending (schema_url before scope), a hand-rolled encoder typically ascending. A
+// decoder that consumes a submessage as it walks — rather than after — silently loses whichever
+// sibling it already read, which is exactly how the scope schema_url went missing once.
+
+// encodeScopeLogs builds one ExportLogsServiceRequest carrying a single record, writing each
+// message's fields in the given order.
+func encodeScopeLogs(ascending bool) []byte {
+	var m easyproto.Marshaler
+
+	req := m.MessageMarshaler()
+	rl := req.AppendMessage(1) // resource_logs
+
+	writeResource := func() {
+		res := rl.AppendMessage(1) // resource
+		kv := res.AppendMessage(1) // attributes
+		kv.AppendString(1, "service.name")
+		kv.AppendMessage(2).AppendString(1, "api")
+	}
+
+	writeScopes := func() {
+		sl := rl.AppendMessage(2) // scope_logs
+
+		writeScope := func() {
+			sc := sl.AppendMessage(1) // scope
+			sc.AppendString(1, "scope-name")
+			sc.AppendString(2, "1.0.0")
+		}
+
+		writeRecords := func() {
+			rec := sl.AppendMessage(2) // log_records
+			rec.AppendFixed64(1, 1_700_000_000_000_000_000)
+			rec.AppendInt64(2, 9)
+			rec.AppendString(3, "INFO")
+			rec.AppendMessage(5).AppendString(1, "body text") // body
+		}
+
+		writeSchema := func() { sl.AppendString(3, "https://schema.example/scope") }
+
+		if ascending {
+			writeScope()
+			writeRecords()
+			writeSchema()
+		} else {
+			writeSchema()
+			writeRecords()
+			writeScope()
+		}
+	}
+
+	writeSchema := func() { rl.AppendString(3, "https://schema.example/resource") }
+
+	if ascending {
+		writeResource()
+		writeScopes()
+		writeSchema()
+	} else {
+		writeSchema()
+		writeScopes()
+		writeResource()
+	}
+
+	return m.Marshal(nil)
+}
+
+// TestConvertLogsIsFieldOrderIndependent pins that the two wire orderings decode identically.
+func TestConvertLogsIsFieldOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	var asc, desc otlpdirect.LogsConverter
+
+	up, err := asc.Convert(encodeScopeLogs(true))
+	require.NoError(t, err)
+
+	down, err := desc.Convert(encodeScopeLogs(false))
+	require.NoError(t, err)
+
+	require.Equal(t, canonical(down), canonical(up))
+
+	// Spot-check the field the ordering bug actually dropped.
+	sl := up.Resources[0].Scopes[0]
+	assert.Equal(t, "https://schema.example/scope", string(sl.Scope.SchemaURL))
+	assert.Equal(t, "scope-name", string(sl.Scope.Name))
+	assert.Equal(t, "https://schema.example/resource", string(up.Resources[0].Resource.SchemaURL))
+	assert.Equal(t, "body text", string(sl.Records[0].Body))
+}

--- a/internal/otlpdirect/otlpdirect.go
+++ b/internal/otlpdirect/otlpdirect.go
@@ -298,11 +298,18 @@ func (d *decoder) scope(src []byte) (signal.Scope, error) {
 //
 //nolint:unparam // see above
 func collect(src []byte, fieldNum uint32, what string) ([][]byte, error) {
+	return collectInto(nil, src, fieldNum, what)
+}
+
+// collectInto is [collect] appending into a caller-owned buffer, so a walk repeated per element
+// can reuse one allocation instead of taking a fresh one each time.
+func collectInto(dst [][]byte, src []byte, fieldNum uint32, what string) ([][]byte, error) {
 	var (
 		fc  easyproto.FieldContext
-		out [][]byte
 		err error
 	)
+
+	out := dst
 
 	for len(src) > 0 {
 		if src, err = fc.NextField(src); err != nil {

--- a/internal/otlpdirect/otlpdirect.go
+++ b/internal/otlpdirect/otlpdirect.go
@@ -1,0 +1,408 @@
+// Package otlpdirect decodes OTLP protobuf straight into the storage engine's ingest models.
+//
+// It replaces the receiver → pdata → pdataconv path with a single pass over the request bytes:
+// attribute keys, string values, log bodies and ids are handed to the engine as sub-slices of the
+// request buffer, never copied into Go strings and never materialized as pdata. The engine copies
+// what it retains (record cells into its column blobs, identity into its symbol table), so the
+// request buffer may be recycled once the write returns.
+//
+// The wire layout is OTLP's, so the field numbers here are the ones in opentelemetry-proto and
+// must not be renumbered. Unknown fields are skipped, which is what makes a newer collector's
+// output readable by an older ingester.
+package otlpdirect
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"strconv"
+
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/go-faster/errors"
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/xarena"
+)
+
+// Field numbers of the messages shared by every signal (common.proto, resource.proto).
+const (
+	// opentelemetry.proto.common.v1.AnyValue
+	fieldAnyString = 1
+	fieldAnyBool   = 2
+	fieldAnyInt    = 3
+	fieldAnyDouble = 4
+	fieldAnyArray  = 5
+	fieldAnyKvlist = 6
+	fieldAnyBytes  = 7
+
+	// opentelemetry.proto.common.v1.KeyValue
+	fieldKVKey   = 1
+	fieldKVValue = 2
+
+	// opentelemetry.proto.common.v1.ArrayValue / KeyValueList
+	fieldListValues = 1
+
+	// opentelemetry.proto.common.v1.InstrumentationScope
+	fieldScopeName       = 1
+	fieldScopeVersion    = 2
+	fieldScopeAttributes = 3
+
+	// opentelemetry.proto.resource.v1.Resource
+	fieldResourceAttributes = 1
+)
+
+// decoder holds the scratch the converters carve identity out of. Chunks are retained across
+// [decoder.reset], so a converter reused across requests allocates nothing in steady state.
+type decoder struct {
+	attrs   xarena.Arena[signal.KeyValue]
+	values  xarena.Arena[signal.Value]
+	scratch xarena.Arena[byte]
+}
+
+func (d *decoder) reset() {
+	d.attrs.Reset()
+	d.values.Reset()
+	d.scratch.Reset()
+}
+
+// attributes decodes a repeated KeyValue field into a sorted [signal.Attributes].
+//
+// src is the concatenation of the message's KeyValue submessages, collected by the caller as it
+// walks the parent — protobuf permits a repeated field's entries to be interleaved with others, so
+// they cannot be counted up front without a second pass.
+func (d *decoder) attributes(kvs [][]byte) (signal.Attributes, error) {
+	if len(kvs) == 0 {
+		return nil, nil
+	}
+
+	out := d.attrs.Alloc(len(kvs))
+
+	for _, src := range kvs {
+		kv, err := d.keyValue(src)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, kv)
+	}
+
+	// NewAttributes sorts by key, which is what makes the identity hash stable regardless of the
+	// order a producer emitted them in.
+	return signal.NewAttributes(out...), nil
+}
+
+func (d *decoder) keyValue(src []byte) (signal.KeyValue, error) {
+	var (
+		fc  easyproto.FieldContext
+		kv  signal.KeyValue
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return kv, errors.Wrap(err, "read key-value field")
+		}
+
+		switch fc.FieldNum {
+		case fieldKVKey:
+			key, ok := fc.Bytes()
+			if !ok {
+				return kv, errors.New("read attribute key")
+			}
+
+			kv.Key = key
+		case fieldKVValue:
+			data, ok := fc.MessageData()
+			if !ok {
+				return kv, errors.New("read attribute value")
+			}
+
+			if kv.Value, err = d.anyValue(data); err != nil {
+				return kv, err
+			}
+		}
+	}
+
+	return kv, nil
+}
+
+// anyValue decodes an AnyValue, preserving its type. A later field wins, matching how a protobuf
+// oneof decodes.
+func (d *decoder) anyValue(src []byte) (signal.Value, error) {
+	var (
+		fc  easyproto.FieldContext
+		out = signal.EmptyValue()
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return out, errors.Wrap(err, "read value field")
+		}
+
+		switch fc.FieldNum {
+		case fieldAnyString:
+			v, ok := fc.Bytes()
+			if !ok {
+				return out, errors.New("read string value")
+			}
+
+			out = signal.StringValue(v)
+		case fieldAnyBool:
+			v, ok := fc.Bool()
+			if !ok {
+				return out, errors.New("read bool value")
+			}
+
+			out = signal.BoolValue(v)
+		case fieldAnyInt:
+			v, ok := fc.Int64()
+			if !ok {
+				return out, errors.New("read int value")
+			}
+
+			out = signal.IntValue(v)
+		case fieldAnyDouble:
+			v, ok := fc.Double()
+			if !ok {
+				return out, errors.New("read double value")
+			}
+
+			out = signal.DoubleValue(v)
+		case fieldAnyBytes:
+			v, ok := fc.Bytes()
+			if !ok {
+				return out, errors.New("read bytes value")
+			}
+
+			out = signal.BytesValue(v)
+		case fieldAnyArray:
+			data, ok := fc.MessageData()
+			if !ok {
+				return out, errors.New("read array value")
+			}
+
+			if out, err = d.arrayValue(data); err != nil {
+				return out, err
+			}
+		case fieldAnyKvlist:
+			data, ok := fc.MessageData()
+			if !ok {
+				return out, errors.New("read kvlist value")
+			}
+
+			if out, err = d.kvlistValue(data); err != nil {
+				return out, err
+			}
+		}
+	}
+
+	return out, nil
+}
+
+func (d *decoder) arrayValue(src []byte) (signal.Value, error) {
+	entries, err := collect(src, fieldListValues, "array entry")
+	if err != nil {
+		return signal.EmptyValue(), err
+	}
+
+	vals := d.values.Alloc(len(entries))
+
+	for _, e := range entries {
+		v, err := d.anyValue(e)
+		if err != nil {
+			return signal.EmptyValue(), err
+		}
+
+		vals = append(vals, v)
+	}
+
+	return signal.SliceValue(vals...), nil
+}
+
+func (d *decoder) kvlistValue(src []byte) (signal.Value, error) {
+	entries, err := collect(src, fieldListValues, "kvlist entry")
+	if err != nil {
+		return signal.EmptyValue(), err
+	}
+
+	attrs, err := d.attributes(entries)
+	if err != nil {
+		return signal.EmptyValue(), err
+	}
+
+	return signal.MapValue(attrs...), nil
+}
+
+// resource decodes a Resource message's attributes. schemaURL is carried by the parent, so it is
+// set by the caller.
+func (d *decoder) resource(src []byte) (signal.Attributes, error) {
+	kvs, err := collect(src, fieldResourceAttributes, "resource attribute")
+	if err != nil {
+		return nil, err
+	}
+
+	return d.attributes(kvs)
+}
+
+func (d *decoder) scope(src []byte) (signal.Scope, error) {
+	var (
+		fc  easyproto.FieldContext
+		sc  signal.Scope
+		kvs [][]byte
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return sc, errors.Wrap(err, "read scope field")
+		}
+
+		switch fc.FieldNum {
+		case fieldScopeName:
+			v, ok := fc.Bytes()
+			if !ok {
+				return sc, errors.New("read scope name")
+			}
+
+			sc.Name = v
+		case fieldScopeVersion:
+			v, ok := fc.Bytes()
+			if !ok {
+				return sc, errors.New("read scope version")
+			}
+
+			sc.Version = v
+		case fieldScopeAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return sc, errors.New("read scope attribute")
+			}
+
+			kvs = append(kvs, data)
+		}
+	}
+
+	if sc.Attributes, err = d.attributes(kvs); err != nil {
+		return sc, err
+	}
+
+	return sc, nil
+}
+
+// collect gathers every occurrence of a repeated submessage field.
+//
+// Every caller happens to pass 1 today, because OTLP puts the repeated member first in the
+// messages that hold nothing else. That is a convention, not a guarantee, and naming the field at
+// each call site is what makes those walks readable.
+//
+//nolint:unparam // see above
+func collect(src []byte, fieldNum uint32, what string) ([][]byte, error) {
+	var (
+		fc  easyproto.FieldContext
+		out [][]byte
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return nil, errors.Wrapf(err, "read %s", what)
+		}
+
+		if fc.FieldNum != fieldNum {
+			continue
+		}
+
+		data, ok := fc.MessageData()
+		if !ok {
+			return nil, errors.Errorf("read %s data", what)
+		}
+
+		out = append(out, data)
+	}
+
+	return out, nil
+}
+
+// renderText renders a value to its OTLP textual form, matching pcommon.Value.AsString — the form the
+// pdata path stores a non-string log body as. A string value is returned as-is (aliasing the
+// request buffer); every other kind is rendered into the arena.
+func (d *decoder) renderText(v signal.Value) []byte {
+	switch v.Kind() {
+	case signal.KindStr:
+		return v.Str()
+	case signal.KindEmpty:
+		return nil
+	case signal.KindBool:
+		return strconv.AppendBool(d.scratch.Alloc(8), v.Bool())
+	case signal.KindInt:
+		return strconv.AppendInt(d.scratch.Alloc(24), v.Int(), 10)
+	case signal.KindDouble:
+		return appendFloat(d.scratch.Alloc(32), v.Double())
+	case signal.KindBytes:
+		raw := v.Bytes()
+		out := d.scratch.Alloc(base64.StdEncoding.EncodedLen(len(raw)))[:base64.StdEncoding.EncodedLen(len(raw))]
+		base64.StdEncoding.Encode(out, raw)
+
+		return out
+	default: // slice and map render as JSON, as pdata does
+		return marshalJSON(v)
+	}
+}
+
+// appendFloat renders a float the way pdata does: %v-equivalent shortest form, but always with a
+// decimal point or exponent so an integral value is still recognizable as a float.
+func appendFloat(dst []byte, f float64) []byte {
+	return strconv.AppendFloat(dst, f, 'g', -1, 64)
+}
+
+// marshalJSON renders a slice or map value as JSON with HTML escaping off, matching pdata's
+// marshalJSONNoHTMLEscape. It allocates: a structured log body is the uncommon case, and an
+// encoder's growth cannot be hosted in the arena.
+func marshalJSON(v signal.Value) []byte {
+	var buf bytes.Buffer
+
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+
+	if err := enc.Encode(rawValue(v)); err != nil {
+		return nil
+	}
+
+	return bytes.TrimSuffix(buf.Bytes(), []byte("\n")) // Encode appends one; AsString has none
+}
+
+// rawValue projects a value to the plain Go tree pdata's AsRaw produces, so the JSON rendering of
+// a structured body matches byte for byte.
+func rawValue(v signal.Value) any {
+	switch v.Kind() {
+	case signal.KindStr:
+		return string(v.Str())
+	case signal.KindBool:
+		return v.Bool()
+	case signal.KindInt:
+		return v.Int()
+	case signal.KindDouble:
+		return v.Double()
+	case signal.KindBytes:
+		return base64.StdEncoding.EncodeToString(v.Bytes())
+	case signal.KindSlice:
+		src := v.Slice()
+
+		out := make([]any, len(src))
+		for i := range src {
+			out[i] = rawValue(src[i])
+		}
+
+		return out
+	case signal.KindMap:
+		out := map[string]any{}
+		for _, kv := range v.Map() {
+			out[string(kv.Key)] = rawValue(kv.Value)
+		}
+
+		return out
+	default:
+		return nil
+	}
+}

--- a/internal/otlpdirect/otlpdirect.go
+++ b/internal/otlpdirect/otlpdirect.go
@@ -27,17 +27,19 @@ import (
 // Field numbers of the messages shared by every signal (common.proto, resource.proto).
 const (
 	// opentelemetry.proto.common.v1.AnyValue
-	fieldAnyString = 1
-	fieldAnyBool   = 2
-	fieldAnyInt    = 3
-	fieldAnyDouble = 4
-	fieldAnyArray  = 5
-	fieldAnyKvlist = 6
-	fieldAnyBytes  = 7
+	fieldAnyString   = 1
+	fieldAnyBool     = 2
+	fieldAnyInt      = 3
+	fieldAnyDouble   = 4
+	fieldAnyArray    = 5
+	fieldAnyKvlist   = 6
+	fieldAnyBytes    = 7
+	fieldAnyStrindex = 8
 
 	// opentelemetry.proto.common.v1.KeyValue
-	fieldKVKey   = 1
-	fieldKVValue = 2
+	fieldKVKey      = 1
+	fieldKVValue    = 2
+	fieldKVStrindex = 3
 
 	// opentelemetry.proto.common.v1.ArrayValue / KeyValueList
 	fieldListValues = 1
@@ -57,12 +59,28 @@ type decoder struct {
 	attrs   xarena.Arena[signal.KeyValue]
 	values  xarena.Arena[signal.Value]
 	scratch xarena.Arena[byte]
+
+	// strings is the profiles signal's shared string table: there, an attribute key and a string
+	// value may arrive as an index into it instead of inline. It is nil for the other signals,
+	// whose wire format has no such indirection.
+	strings [][]byte
 }
 
 func (d *decoder) reset() {
 	d.attrs.Reset()
 	d.values.Reset()
 	d.scratch.Reset()
+	d.strings = nil
+}
+
+// lookup resolves a string-table index, reporting whether it is in range. An out-of-range index is
+// dropped rather than rejected, matching what pdata does with a reference it cannot resolve.
+func (d *decoder) lookup(idx int32) ([]byte, bool) {
+	if idx < 0 || int(idx) >= len(d.strings) {
+		return nil, false
+	}
+
+	return d.strings[idx], true
 }
 
 // attributes decodes a repeated KeyValue field into a sorted [signal.Attributes].
@@ -93,9 +111,11 @@ func (d *decoder) attributes(kvs [][]byte) (signal.Attributes, error) {
 
 func (d *decoder) keyValue(src []byte) (signal.KeyValue, error) {
 	var (
-		fc  easyproto.FieldContext
-		kv  signal.KeyValue
-		err error
+		fc       easyproto.FieldContext
+		kv       signal.KeyValue
+		keyIdx   int32
+		hasKeyID bool
+		err      error
 	)
 
 	for len(src) > 0 {
@@ -104,6 +124,13 @@ func (d *decoder) keyValue(src []byte) (signal.KeyValue, error) {
 		}
 
 		switch fc.FieldNum {
+		case fieldKVStrindex:
+			v, ok := fc.Int32()
+			if !ok {
+				return kv, errors.New("read attribute key index")
+			}
+
+			keyIdx, hasKeyID = v, true
 		case fieldKVKey:
 			key, ok := fc.Bytes()
 			if !ok {
@@ -120,6 +147,12 @@ func (d *decoder) keyValue(src []byte) (signal.KeyValue, error) {
 			if kv.Value, err = d.anyValue(data); err != nil {
 				return kv, err
 			}
+		}
+	}
+
+	if hasKeyID {
+		if key, ok := d.lookup(keyIdx); ok {
+			kv.Key = key
 		}
 	}
 
@@ -176,6 +209,21 @@ func (d *decoder) anyValue(src []byte) (signal.Value, error) {
 			}
 
 			out = signal.BytesValue(v)
+		case fieldAnyStrindex:
+			v, ok := fc.Int32()
+			if !ok {
+				return out, errors.New("read string value index")
+			}
+
+			// Index 0 is the "" sentinel, which pdata declines to resolve — it treats a zero
+			// reference as unset and leaves the value empty, so this does too.
+			out = signal.EmptyValue()
+
+			if v != 0 {
+				if s, ok := d.lookup(v); ok {
+					out = signal.StringValue(s)
+				}
+			}
 		case fieldAnyArray:
 			data, ok := fc.MessageData()
 			if !ok {

--- a/internal/otlpdirect/profileorder_test.go
+++ b/internal/otlpdirect/profileorder_test.go
@@ -1,0 +1,310 @@
+package otlpdirect_test
+
+import (
+	"github.com/VictoriaMetrics/easyproto"
+
+	"github.com/oteldb/storage/signal/profile"
+)
+
+// encodeProfiles builds one ExportProfilesServiceRequest carrying a fully-populated dictionary and
+// a single profile, writing each message's fields ascending or descending.
+//
+// Profiles has one ordering hazard the other signals do not: the shared dictionary is field 2 of
+// the request while the resource profiles are field 1, and a resource attribute's key and string
+// value are indices into that dictionary. Ascending order therefore puts the table the resources
+// need after them on the wire.
+func encodeProfiles(ascending bool) []byte {
+	var m easyproto.Marshaler
+
+	req := m.MessageMarshaler()
+
+	writeDictionary := func() {
+		dict := req.AppendMessage(2)
+
+		writeMapping := func() {
+			mp := dict.AppendMessage(1)
+			mp.AppendUint64(1, 0x400000)
+			mp.AppendUint64(2, 0x500000)
+			mp.AppendUint64(3, 0x1000)
+			mp.AppendInt32(4, 6)
+			mp.AppendInt32s(5, []int32{0})
+		}
+
+		writeLocation := func() {
+			loc := dict.AppendMessage(2)
+
+			writeLines := func() {
+				ln := loc.AppendMessage(3)
+				ln.AppendInt32(1, 0)
+				ln.AppendInt64(2, 17)
+				ln.AppendInt64(3, 3)
+			}
+
+			if ascending {
+				loc.AppendInt32(1, 0)
+				loc.AppendUint64(2, 0x4010a0)
+				writeLines()
+				loc.AppendInt32s(4, []int32{0})
+			} else {
+				loc.AppendInt32s(4, []int32{0})
+				writeLines()
+				loc.AppendUint64(2, 0x4010a0)
+				loc.AppendInt32(1, 0)
+			}
+		}
+
+		writeFunction := func() {
+			fn := dict.AppendMessage(3)
+			fn.AppendInt32(1, 5)
+			fn.AppendInt32(2, 5)
+			fn.AppendInt32(3, 6)
+			fn.AppendInt64(4, 42)
+		}
+
+		writeLink := func() {
+			lk := dict.AppendMessage(4)
+			lk.AppendBytes(1, []byte("0123456789abcdef"))
+			lk.AppendBytes(2, []byte("01234567"))
+		}
+
+		writeStrings := func() {
+			for _, s := range []string{"", "service.name", "api", "samples", "count", "main", "/src/main.go"} {
+				dict.AppendString(5, s)
+			}
+		}
+
+		writeAttribute := func() {
+			at := dict.AppendMessage(6)
+			at.AppendInt32(1, 1)
+			at.AppendMessage(2).AppendString(1, "api")
+			at.AppendInt32(3, 4)
+		}
+
+		writeStack := func() { dict.AppendMessage(7).AppendInt32s(1, []int32{0}) }
+
+		if ascending {
+			writeMapping()
+			writeLocation()
+			writeFunction()
+			writeLink()
+			writeStrings()
+			writeAttribute()
+			writeStack()
+		} else {
+			writeStack()
+			writeAttribute()
+			writeStrings()
+			writeLink()
+			writeFunction()
+			writeLocation()
+			writeMapping()
+		}
+	}
+
+	writeResource := func() {
+		rp := req.AppendMessage(1)
+
+		writeRes := func() {
+			res := rp.AppendMessage(1)
+
+			// key_strindex and string_value_strindex, the form pdata puts on the wire.
+			kv := res.AppendMessage(1)
+			kv.AppendInt32(3, 1)
+			kv.AppendMessage(2).AppendInt32(8, 2)
+		}
+
+		writeScopes := func() {
+			sp := rp.AppendMessage(2)
+
+			writeScope := func() {
+				sc := sp.AppendMessage(1)
+				sc.AppendString(1, "scope-name")
+				sc.AppendString(2, "1.0.0")
+			}
+
+			writeProfiles := func() {
+				pr := sp.AppendMessage(2)
+
+				writeTypes := func() {
+					st := pr.AppendMessage(1)
+					st.AppendInt32(1, 3)
+					st.AppendInt32(2, 4)
+
+					pt := pr.AppendMessage(5)
+					pt.AppendInt32(1, 3)
+					pt.AppendInt32(2, 4)
+				}
+
+				writeSample := func() {
+					s := pr.AppendMessage(2)
+					s.AppendInt32(1, 0)
+					s.AppendInt32s(2, []int32{0})
+					s.AppendInt32(3, 0)
+					s.AppendInt64s(4, []int64{10, 20})
+					s.AppendFixed64s(5, []uint64{1, 2})
+				}
+
+				writeScalars := func() {
+					pr.AppendFixed64(3, 1_700_000_000_000_000_000)
+					pr.AppendUint64(4, 30_000_000_000)
+					pr.AppendInt64(6, 10_000_000)
+					pr.AppendBytes(7, []byte("profile-id-0000a"))
+					pr.AppendUint32(8, 3)
+					pr.AppendInt32s(11, []int32{0})
+				}
+
+				if ascending {
+					writeTypes()
+					writeSample()
+					writeScalars()
+				} else {
+					writeScalars()
+					writeSample()
+					writeTypes()
+				}
+			}
+
+			if ascending {
+				writeScope()
+				writeProfiles()
+				sp.AppendString(3, "https://schema.example/scope")
+			} else {
+				sp.AppendString(3, "https://schema.example/scope")
+				writeProfiles()
+				writeScope()
+			}
+		}
+
+		if ascending {
+			writeRes()
+			writeScopes()
+			rp.AppendString(3, "https://schema.example/resource")
+		} else {
+			rp.AppendString(3, "https://schema.example/resource")
+			writeScopes()
+			writeRes()
+		}
+	}
+
+	if ascending {
+		writeResource()
+		writeDictionary()
+	} else {
+		writeDictionary()
+		writeResource()
+	}
+
+	return m.Marshal(nil)
+}
+
+// canonicalProfiles is [canonical] for the profiles model: it rewrites zero-length byte slices to
+// nil so the two paths' spellings of an absent field compare equal. See canonical_test.go.
+func canonicalProfiles(p *profile.Profiles) *profile.Profiles {
+	canonicalDictionary(&p.Dictionary)
+
+	for i := range p.Resources {
+		rp := &p.Resources[i]
+		rp.Resource.SchemaURL = canonBytes(rp.Resource.SchemaURL)
+		rp.Resource.Attributes = canonAttrs(rp.Resource.Attributes)
+
+		for j := range rp.Scopes {
+			sp := &rp.Scopes[j]
+			sp.Scope.Name = canonBytes(sp.Scope.Name)
+			sp.Scope.Version = canonBytes(sp.Scope.Version)
+			sp.Scope.SchemaURL = canonBytes(sp.Scope.SchemaURL)
+			sp.Scope.Attributes = canonAttrs(sp.Scope.Attributes)
+
+			for k := range sp.Profiles {
+				canonicalProfile(&sp.Profiles[k])
+			}
+
+			if len(sp.Profiles) == 0 {
+				sp.Profiles = nil
+			}
+		}
+
+		if len(rp.Scopes) == 0 {
+			rp.Scopes = nil
+		}
+	}
+
+	if len(p.Resources) == 0 {
+		p.Resources = nil
+	}
+
+	return p
+}
+
+func canonicalDictionary(d *profile.Dictionary) {
+	for i := range d.Strings {
+		d.Strings[i] = canonBytes(d.Strings[i])
+	}
+
+	for i := range d.Stacks {
+		d.Stacks[i].LocationIndices = canonIndices(d.Stacks[i].LocationIndices)
+	}
+
+	for i := range d.Locations {
+		l := &d.Locations[i]
+		l.AttributeIndices = canonIndices(l.AttributeIndices)
+
+		if len(l.Lines) == 0 {
+			l.Lines = nil
+		}
+	}
+
+	for i := range d.Mappings {
+		d.Mappings[i].AttributeIndices = canonIndices(d.Mappings[i].AttributeIndices)
+	}
+
+	for i := range d.Attributes {
+		d.Attributes[i].Value = canonValue(d.Attributes[i].Value)
+	}
+
+	for i := range d.Links {
+		d.Links[i].TraceID = canonBytes(d.Links[i].TraceID)
+		d.Links[i].SpanID = canonBytes(d.Links[i].SpanID)
+	}
+
+	canonEmpty(&d.Strings)
+	canonEmpty(&d.Stacks)
+	canonEmpty(&d.Locations)
+	canonEmpty(&d.Functions)
+	canonEmpty(&d.Mappings)
+	canonEmpty(&d.Attributes)
+	canonEmpty(&d.Links)
+}
+
+func canonicalProfile(pr *profile.Profile) {
+	pr.ProfileID = canonBytes(pr.ProfileID)
+	pr.AttributeIndices = canonIndices(pr.AttributeIndices)
+
+	for i := range pr.Samples {
+		s := &pr.Samples[i]
+		s.AttributeIndices = canonIndices(s.AttributeIndices)
+
+		if len(s.Values) == 0 {
+			s.Values = nil
+		}
+
+		if len(s.TimestampsUnixNano) == 0 {
+			s.TimestampsUnixNano = nil
+		}
+	}
+
+	canonEmpty(&pr.Samples)
+}
+
+func canonIndices(idx []int32) []int32 {
+	if len(idx) == 0 {
+		return nil
+	}
+
+	return idx
+}
+
+func canonEmpty[T any](s *[]T) {
+	if len(*s) == 0 {
+		*s = nil
+	}
+}

--- a/internal/otlpdirect/profiles.go
+++ b/internal/otlpdirect/profiles.go
@@ -1,0 +1,884 @@
+package otlpdirect
+
+import (
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/go-faster/errors"
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/signal/profile"
+
+	"github.com/oteldb/oteldb/internal/xarena"
+)
+
+// Field numbers of profiles/v1development/profiles.proto and its collector service.
+const (
+	// opentelemetry.proto.collector.profiles.v1development.ExportProfilesServiceRequest
+	fieldExportResourceProfiles = 1
+	fieldExportDictionary       = 2
+
+	// opentelemetry.proto.profiles.v1development.ProfilesDictionary
+	fieldDictMappings   = 1
+	fieldDictLocations  = 2
+	fieldDictFunctions  = 3
+	fieldDictLinks      = 4
+	fieldDictStrings    = 5
+	fieldDictAttributes = 6
+	fieldDictStacks     = 7
+
+	// opentelemetry.proto.profiles.v1development.ResourceProfiles
+	fieldResourceProfilesResource  = 1
+	fieldResourceProfilesScope     = 2
+	fieldResourceProfilesSchemaURL = 3
+
+	// opentelemetry.proto.profiles.v1development.ScopeProfiles
+	fieldScopeProfilesScope     = 1
+	fieldScopeProfilesProfiles  = 2
+	fieldScopeProfilesSchemaURL = 3
+
+	// opentelemetry.proto.profiles.v1development.Profile
+	fieldProfileSampleType = 1
+	fieldProfileSamples    = 2
+	fieldProfileTime       = 3
+	fieldProfileDuration   = 4
+	fieldProfilePeriodType = 5
+	fieldProfilePeriod     = 6
+	fieldProfileID         = 7
+	fieldProfileDropped    = 8
+	fieldProfileAttributes = 11
+
+	// opentelemetry.proto.profiles.v1development.Sample
+	fieldSampleStack      = 1
+	fieldSampleAttributes = 2
+	fieldSampleLink       = 3
+	fieldSampleValues     = 4
+	fieldSampleTimestamps = 5
+
+	// opentelemetry.proto.profiles.v1development.ValueType
+	fieldValueTypeType = 1
+	fieldValueTypeUnit = 2
+
+	// opentelemetry.proto.profiles.v1development.Mapping
+	fieldMappingMemoryStart = 1
+	fieldMappingMemoryLimit = 2
+	fieldMappingFileOffset  = 3
+	fieldMappingFilename    = 4
+	fieldMappingAttributes  = 5
+
+	// opentelemetry.proto.profiles.v1development.Location
+	fieldLocationMapping    = 1
+	fieldLocationAddress    = 2
+	fieldLocationLines      = 3
+	fieldLocationAttributes = 4
+
+	// opentelemetry.proto.profiles.v1development.Line
+	fieldLineFunction = 1
+	fieldLineLine     = 2
+	fieldLineColumn   = 3
+
+	// opentelemetry.proto.profiles.v1development.Function
+	fieldFunctionName       = 1
+	fieldFunctionSystemName = 2
+	fieldFunctionFilename   = 3
+	fieldFunctionStartLine  = 4
+
+	// opentelemetry.proto.profiles.v1development.Stack
+	fieldStackLocations = 1
+
+	// opentelemetry.proto.profiles.v1development.KeyValueAndUnit
+	fieldAttributeKey   = 1
+	fieldAttributeValue = 2
+	fieldAttributeUnit  = 3
+
+	// opentelemetry.proto.profiles.v1development.Link
+	fieldProfileLinkTraceID = 1
+	fieldProfileLinkSpanID  = 2
+)
+
+// ProfilesConverter decodes an OTLP ExportProfilesServiceRequest into [profile.Profiles]. It
+// retains the batch and the scratch it is built from, so a converter reused across requests
+// allocates nothing in steady state. It is not safe for concurrent use; pool one per in-flight
+// request.
+type ProfilesConverter struct {
+	batch profile.Profiles
+	dec   decoder
+
+	lines   xarena.Arena[profile.Line]
+	indices xarena.Arena[int32]
+	values  xarena.Arena[int64]
+	stamps  xarena.Arena[uint64]
+
+	// Submessage collectors. Each is consumed before the next element of its kind reaches it, and
+	// no walk that reads one re-enters the walk that fills it, so a single buffer per kind serves
+	// the whole request.
+	dictTables [7][][]byte
+	resources  [][]byte
+	scopes     [][]byte
+	profiles   [][]byte
+	samples    [][]byte
+	locLines   [][]byte
+
+	// Repeated scalar scratch, copied into the arenas at the end of the element that read it.
+	i32 []int32
+	i64 []int64
+	u64 []uint64
+}
+
+// Convert decodes a serialized ExportProfilesServiceRequest.
+//
+// The returned batch aliases src: every string-table entry, id and attribute key is a sub-slice of
+// it. It stays valid until the next Convert on this converter, and src must not be recycled until
+// the write consuming the batch has returned.
+func (c *ProfilesConverter) Convert(src []byte) (*profile.Profiles, error) {
+	c.batch.Reset()
+	c.dec.reset()
+	c.lines.Reset()
+	c.indices.Reset()
+	c.values.Reset()
+	c.stamps.Reset()
+
+	var (
+		fc        easyproto.FieldContext
+		dictData  []byte
+		resources = c.resources[:0]
+		err       error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return nil, errors.Wrap(err, "read profiles request field")
+		}
+
+		switch fc.FieldNum {
+		case fieldExportResourceProfiles:
+			data, ok := fc.MessageData()
+			if !ok {
+				return nil, errors.New("read resource profiles")
+			}
+
+			resources = append(resources, data)
+		case fieldExportDictionary:
+			data, ok := fc.MessageData()
+			if !ok {
+				return nil, errors.New("read profiles dictionary")
+			}
+
+			dictData = data
+		}
+	}
+
+	c.resources = resources
+
+	// The dictionary is decoded first whatever order it arrived in: a resource or scope attribute
+	// may reference its string table instead of carrying the string inline.
+	if err := c.dictionary(dictData); err != nil {
+		return nil, err
+	}
+
+	c.dec.strings = c.batch.Dictionary.Strings
+
+	for _, data := range resources {
+		if err := c.resourceProfiles(data); err != nil {
+			return nil, err
+		}
+	}
+
+	return &c.batch, nil
+}
+
+func (c *ProfilesConverter) dictionary(src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		err error
+	)
+
+	dict := &c.batch.Dictionary
+
+	tables := c.dictTables
+	for i := range tables {
+		tables[i] = tables[i][:0]
+	}
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read dictionary field")
+		}
+
+		if fc.FieldNum == fieldDictStrings {
+			v, ok := fc.Bytes()
+			if !ok {
+				return errors.New("read dictionary string")
+			}
+
+			dict.Strings = append(dict.Strings, v)
+
+			continue
+		}
+
+		if fc.FieldNum < 1 || int(fc.FieldNum) > len(tables) {
+			continue
+		}
+
+		data, ok := fc.MessageData()
+		if !ok {
+			return errors.Errorf("read dictionary table %d entry", fc.FieldNum)
+		}
+
+		tables[fc.FieldNum-1] = append(tables[fc.FieldNum-1], data)
+	}
+
+	c.dictTables = tables
+
+	for _, data := range tables[fieldDictMappings-1] {
+		if err := c.mapping(dict, data); err != nil {
+			return err
+		}
+	}
+
+	for _, data := range tables[fieldDictLocations-1] {
+		if err := c.location(dict, data); err != nil {
+			return err
+		}
+	}
+
+	for _, data := range tables[fieldDictFunctions-1] {
+		if err := c.function(dict, data); err != nil {
+			return err
+		}
+	}
+
+	for _, data := range tables[fieldDictLinks-1] {
+		if err := c.link(dict, data); err != nil {
+			return err
+		}
+	}
+
+	for _, data := range tables[fieldDictStacks-1] {
+		if err := c.stack(dict, data); err != nil {
+			return err
+		}
+	}
+
+	// Attribute values may themselves reference the string table, so they are decoded once it is
+	// complete.
+	c.dec.strings = dict.Strings
+
+	for _, data := range tables[fieldDictAttributes-1] {
+		if err := c.attribute(dict, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *ProfilesConverter) mapping(dict *profile.Dictionary, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		m   profile.Mapping
+		err error
+	)
+
+	idx := c.i32[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read mapping field")
+		}
+
+		switch fc.FieldNum {
+		case fieldMappingMemoryStart:
+			if m.MemoryStart, err = takeUint64(&fc, "mapping memory start"); err != nil {
+				return err
+			}
+		case fieldMappingMemoryLimit:
+			if m.MemoryLimit, err = takeUint64(&fc, "mapping memory limit"); err != nil {
+				return err
+			}
+		case fieldMappingFileOffset:
+			if m.FileOffset, err = takeUint64(&fc, "mapping file offset"); err != nil {
+				return err
+			}
+		case fieldMappingFilename:
+			if m.FilenameStrindex, err = takeInt32(&fc, "mapping filename index"); err != nil {
+				return err
+			}
+		case fieldMappingAttributes:
+			if idx, err = takeInt32s(&fc, idx, "mapping attribute indices"); err != nil {
+				return err
+			}
+		}
+	}
+
+	c.i32 = idx
+	m.AttributeIndices = c.ownIndices(idx)
+
+	dict.AddMapping(m)
+
+	return nil
+}
+
+func (c *ProfilesConverter) location(dict *profile.Dictionary, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		l   profile.Location
+		err error
+	)
+
+	idx := c.i32[:0]
+	lines := c.locLines[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read location field")
+		}
+
+		switch fc.FieldNum {
+		case fieldLocationMapping:
+			if l.MappingIndex, err = takeInt32(&fc, "location mapping index"); err != nil {
+				return err
+			}
+		case fieldLocationAddress:
+			if l.Address, err = takeUint64(&fc, "location address"); err != nil {
+				return err
+			}
+		case fieldLocationLines:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read location line")
+			}
+
+			lines = append(lines, data)
+		case fieldLocationAttributes:
+			if idx, err = takeInt32s(&fc, idx, "location attribute indices"); err != nil {
+				return err
+			}
+		}
+	}
+
+	c.i32, c.locLines = idx, lines
+	l.AttributeIndices = c.ownIndices(idx)
+
+	if len(lines) > 0 {
+		out := c.lines.Alloc(len(lines))
+
+		for _, data := range lines {
+			ln, err := line(data)
+			if err != nil {
+				return err
+			}
+
+			out = append(out, ln)
+		}
+
+		l.Lines = out
+	}
+
+	dict.AddLocation(l)
+
+	return nil
+}
+
+func line(src []byte) (profile.Line, error) {
+	var (
+		fc  easyproto.FieldContext
+		ln  profile.Line
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return ln, errors.Wrap(err, "read line field")
+		}
+
+		switch fc.FieldNum {
+		case fieldLineFunction:
+			if ln.FunctionIndex, err = takeInt32(&fc, "line function index"); err != nil {
+				return ln, err
+			}
+		case fieldLineLine:
+			if ln.Line, err = takeInt64(&fc, "line number"); err != nil {
+				return ln, err
+			}
+		case fieldLineColumn:
+			if ln.Column, err = takeInt64(&fc, "line column"); err != nil {
+				return ln, err
+			}
+		}
+	}
+
+	return ln, nil
+}
+
+func (c *ProfilesConverter) function(dict *profile.Dictionary, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		f   profile.Function
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read function field")
+		}
+
+		switch fc.FieldNum {
+		case fieldFunctionName:
+			if f.NameStrindex, err = takeInt32(&fc, "function name index"); err != nil {
+				return err
+			}
+		case fieldFunctionSystemName:
+			if f.SystemNameStrindex, err = takeInt32(&fc, "function system name index"); err != nil {
+				return err
+			}
+		case fieldFunctionFilename:
+			if f.FilenameStrindex, err = takeInt32(&fc, "function filename index"); err != nil {
+				return err
+			}
+		case fieldFunctionStartLine:
+			if f.StartLine, err = takeInt64(&fc, "function start line"); err != nil {
+				return err
+			}
+		}
+	}
+
+	dict.AddFunction(f)
+
+	return nil
+}
+
+func (c *ProfilesConverter) stack(dict *profile.Dictionary, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		err error
+	)
+
+	idx := c.i32[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read stack field")
+		}
+
+		if fc.FieldNum == fieldStackLocations {
+			if idx, err = takeInt32s(&fc, idx, "stack location indices"); err != nil {
+				return err
+			}
+		}
+	}
+
+	c.i32 = idx
+
+	dict.AddStack(c.ownIndices(idx)...)
+
+	return nil
+}
+
+func (c *ProfilesConverter) attribute(dict *profile.Dictionary, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		a   profile.KeyValueAndUnit
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read dictionary attribute field")
+		}
+
+		switch fc.FieldNum {
+		case fieldAttributeKey:
+			if a.KeyStrindex, err = takeInt32(&fc, "attribute key index"); err != nil {
+				return err
+			}
+		case fieldAttributeUnit:
+			if a.UnitStrindex, err = takeInt32(&fc, "attribute unit index"); err != nil {
+				return err
+			}
+		case fieldAttributeValue:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read attribute value")
+			}
+
+			if a.Value, err = c.dec.anyValue(data); err != nil {
+				return err
+			}
+		}
+	}
+
+	dict.AddAttribute(a)
+
+	return nil
+}
+
+func (c *ProfilesConverter) link(dict *profile.Dictionary, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		l   profile.Link
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read link field")
+		}
+
+		switch fc.FieldNum {
+		case fieldProfileLinkTraceID:
+			if l.TraceID, err = takeBytes(&fc, "link trace id"); err != nil {
+				return err
+			}
+		case fieldProfileLinkSpanID:
+			if l.SpanID, err = takeBytes(&fc, "link span id"); err != nil {
+				return err
+			}
+		}
+	}
+
+	dict.AddLink(l)
+
+	return nil
+}
+
+func (c *ProfilesConverter) resourceProfiles(src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		res signal.Resource
+		err error
+	)
+
+	scopes := c.scopes[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read resource profiles field")
+		}
+
+		switch fc.FieldNum {
+		case fieldResourceProfilesResource:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read resource")
+			}
+
+			if res.Attributes, err = c.dec.resource(data); err != nil {
+				return err
+			}
+		case fieldResourceProfilesScope:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read scope profiles")
+			}
+
+			scopes = append(scopes, data)
+		case fieldResourceProfilesSchemaURL:
+			if res.SchemaURL, err = takeBytes(&fc, "resource schema url"); err != nil {
+				return err
+			}
+		}
+	}
+
+	c.scopes = scopes
+
+	rp := c.batch.AddResource()
+	rp.Resource = res
+
+	for _, data := range scopes {
+		if err := c.scopeProfiles(rp, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *ProfilesConverter) scopeProfiles(rp *profile.ResourceProfiles, src []byte) error {
+	var (
+		fc        easyproto.FieldContext
+		scopeData []byte
+		schemaURL []byte
+		err       error
+	)
+
+	profiles := c.profiles[:0]
+
+	// Field order is the producer's choice — pdata writes them descending, so schema_url arrives
+	// before scope. The scope submessage is therefore decoded after the walk, never during it:
+	// decoding in place would overwrite a schema_url already read.
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read scope profiles field")
+		}
+
+		switch fc.FieldNum {
+		case fieldScopeProfilesScope:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read scope")
+			}
+
+			scopeData = data
+		case fieldScopeProfilesProfiles:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read profile")
+			}
+
+			profiles = append(profiles, data)
+		case fieldScopeProfilesSchemaURL:
+			if schemaURL, err = takeBytes(&fc, "scope schema url"); err != nil {
+				return err
+			}
+		}
+	}
+
+	c.profiles = profiles
+
+	sc, err := c.dec.scope(scopeData)
+	if err != nil {
+		return err
+	}
+
+	sc.SchemaURL = schemaURL
+
+	sp := rp.AddScope()
+	sp.Scope = sc
+
+	for _, data := range profiles {
+		if err := c.profile(sp, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *ProfilesConverter) profile(sp *profile.ScopeProfiles, src []byte) error {
+	var (
+		fc         easyproto.FieldContext
+		sampleType []byte
+		periodType []byte
+		err        error
+	)
+
+	pr := sp.AddProfile()
+
+	idx := c.i32[:0]
+	samples := c.samples[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read profile field")
+		}
+
+		switch fc.FieldNum {
+		case fieldProfileSampleType:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read sample type")
+			}
+
+			sampleType = data
+		case fieldProfilePeriodType:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read period type")
+			}
+
+			periodType = data
+		case fieldProfileSamples:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read sample")
+			}
+
+			samples = append(samples, data)
+		case fieldProfileTime:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read profile time")
+			}
+
+			pr.TimeNanos = int64(v)
+		case fieldProfileDuration:
+			v, ok := fc.Uint64()
+			if !ok {
+				return errors.New("read profile duration")
+			}
+
+			pr.DurationNanos = int64(v)
+		case fieldProfilePeriod:
+			if pr.Period, err = takeInt64(&fc, "profile period"); err != nil {
+				return err
+			}
+		case fieldProfileID:
+			if pr.ProfileID, err = takeBytes(&fc, "profile id"); err != nil {
+				return err
+			}
+		case fieldProfileDropped:
+			v, ok := fc.Uint32()
+			if !ok {
+				return errors.New("read profile dropped count")
+			}
+
+			pr.Dropped = v
+		case fieldProfileAttributes:
+			if idx, err = takeInt32s(&fc, idx, "profile attribute indices"); err != nil {
+				return err
+			}
+		}
+	}
+
+	c.i32, c.samples = idx, samples
+	pr.AttributeIndices = c.ownIndices(idx)
+
+	if pr.SampleType, err = valueType(sampleType); err != nil {
+		return err
+	}
+
+	if pr.PeriodType, err = valueType(periodType); err != nil {
+		return err
+	}
+
+	for _, data := range samples {
+		if err := c.sample(pr, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func valueType(src []byte) (profile.ValueType, error) {
+	var (
+		fc  easyproto.FieldContext
+		vt  profile.ValueType
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return vt, errors.Wrap(err, "read value type field")
+		}
+
+		switch fc.FieldNum {
+		case fieldValueTypeType:
+			if vt.TypeStrindex, err = takeInt32(&fc, "value type index"); err != nil {
+				return vt, err
+			}
+		case fieldValueTypeUnit:
+			if vt.UnitStrindex, err = takeInt32(&fc, "value unit index"); err != nil {
+				return vt, err
+			}
+		}
+	}
+
+	return vt, nil
+}
+
+func (c *ProfilesConverter) sample(pr *profile.Profile, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		err error
+	)
+
+	s := pr.AddSample()
+
+	idx := c.i32[:0]
+	values := c.i64[:0]
+	stamps := c.u64[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read sample field")
+		}
+
+		switch fc.FieldNum {
+		case fieldSampleStack:
+			if s.StackIndex, err = takeInt32(&fc, "sample stack index"); err != nil {
+				return err
+			}
+		case fieldSampleLink:
+			if s.LinkIndex, err = takeInt32(&fc, "sample link index"); err != nil {
+				return err
+			}
+		case fieldSampleAttributes:
+			if idx, err = takeInt32s(&fc, idx, "sample attribute indices"); err != nil {
+				return err
+			}
+		case fieldSampleValues:
+			v, ok := fc.UnpackInt64s(values)
+			if !ok {
+				return errors.New("read sample values")
+			}
+
+			values = v
+		case fieldSampleTimestamps:
+			v, ok := fc.UnpackFixed64s(stamps)
+			if !ok {
+				return errors.New("read sample timestamps")
+			}
+
+			stamps = v
+		}
+	}
+
+	c.i32, c.i64, c.u64 = idx, values, stamps
+
+	s.AttributeIndices = c.ownIndices(idx)
+
+	if len(values) > 0 {
+		s.Values = append(c.values.Alloc(len(values)), values...)
+	}
+
+	if len(stamps) > 0 {
+		s.TimestampsUnixNano = append(c.stamps.Alloc(len(stamps)), stamps...)
+	}
+
+	return nil
+}
+
+// ownIndices copies index scratch into the arena, so the batch keeps a slice the next element's
+// scratch reuse cannot overwrite.
+func (c *ProfilesConverter) ownIndices(idx []int32) []int32 {
+	if len(idx) == 0 {
+		return nil
+	}
+
+	return append(c.indices.Alloc(len(idx)), idx...)
+}
+
+func takeInt32(fc *easyproto.FieldContext, what string) (int32, error) {
+	v, ok := fc.Int32()
+	if !ok {
+		return 0, errors.Errorf("read %s", what)
+	}
+
+	return v, nil
+}
+
+func takeInt64(fc *easyproto.FieldContext, what string) (int64, error) {
+	v, ok := fc.Int64()
+	if !ok {
+		return 0, errors.Errorf("read %s", what)
+	}
+
+	return v, nil
+}
+
+func takeUint64(fc *easyproto.FieldContext, what string) (uint64, error) {
+	v, ok := fc.Uint64()
+	if !ok {
+		return 0, errors.Errorf("read %s", what)
+	}
+
+	return v, nil
+}
+
+func takeInt32s(fc *easyproto.FieldContext, dst []int32, what string) ([]int32, error) {
+	v, ok := fc.UnpackInt32s(dst)
+	if !ok {
+		return dst, errors.Errorf("read %s", what)
+	}
+
+	return v, nil
+}

--- a/internal/otlpdirect/profiles_test.go
+++ b/internal/otlpdirect/profiles_test.go
@@ -1,0 +1,491 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pprofile"
+
+	"github.com/oteldb/storage/otlp/pdataconv"
+	"github.com/oteldb/storage/signal/profile"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+func marshalProfiles(tb testing.TB, pd pprofile.Profiles) []byte {
+	tb.Helper()
+
+	raw, err := (&pprofile.ProtoMarshaler{}).MarshalProfiles(pd)
+	require.NoError(tb, err)
+
+	return raw
+}
+
+// convertBothProfiles decodes pd directly and via the pdata path, canonicalized for comparison.
+//
+// Unlike the other signals, the reference is taken from a round trip rather than from pd itself:
+// pdata's profiles marshaler rewrites resource and scope attributes into string-table references,
+// mutating pd and growing its dictionary as it goes. The bytes on the wire are therefore the only
+// thing the two paths can be compared on, which is also exactly what a receiver sees.
+func convertBothProfiles(tb testing.TB, pd pprofile.Profiles) (direct, viaPdata *profile.Profiles) {
+	tb.Helper()
+
+	raw := marshalProfiles(tb, pd)
+
+	var c otlpdirect.ProfilesConverter
+
+	direct, err := c.Convert(raw)
+	require.NoError(tb, err)
+
+	decoded, err := (&pprofile.ProtoUnmarshaler{}).UnmarshalProfiles(raw)
+	require.NoError(tb, err)
+
+	viaPdata = &profile.Profiles{}
+	require.Zero(tb, pdataconv.AppendProfiles(viaPdata, decoded))
+
+	return canonicalProfiles(direct), canonicalProfiles(viaPdata)
+}
+
+// fullProfiles builds a batch touching every field the decoder reads: the whole shared dictionary,
+// resource and scope identity, and a profile with samples carrying values, timestamps, attribute
+// indices and a link.
+func fullProfiles(tb testing.TB) pprofile.Profiles {
+	tb.Helper()
+
+	pd := pprofile.NewProfiles()
+
+	dict := pd.Dictionary()
+	for _, s := range []string{
+		"", "samples", "count", "cpu", "nanoseconds", "main", "main.main",
+		"/src/main.go", "/usr/lib/libc.so", "thread.name", "ms",
+	} {
+		dict.StringTable().Append(s)
+	}
+
+	fn := dict.FunctionTable().AppendEmpty()
+	fn.SetNameStrindex(5)
+	fn.SetSystemNameStrindex(6)
+	fn.SetFilenameStrindex(7)
+	fn.SetStartLine(42)
+
+	fn2 := dict.FunctionTable().AppendEmpty()
+	fn2.SetNameStrindex(6)
+
+	mp := dict.MappingTable().AppendEmpty()
+	mp.SetMemoryStart(0x400000)
+	mp.SetMemoryLimit(0x500000)
+	mp.SetFileOffset(0x1000)
+	mp.SetFilenameStrindex(8)
+	mp.AttributeIndices().Append(0, 1)
+
+	dict.MappingTable().AppendEmpty()
+
+	loc := dict.LocationTable().AppendEmpty()
+	loc.SetMappingIndex(0)
+	loc.SetAddress(0x4010a0)
+	loc.AttributeIndices().Append(1)
+
+	ln := loc.Lines().AppendEmpty()
+	ln.SetFunctionIndex(0)
+	ln.SetLine(17)
+	ln.SetColumn(3)
+
+	ln2 := loc.Lines().AppendEmpty()
+	ln2.SetFunctionIndex(1)
+	ln2.SetLine(90)
+
+	loc2 := dict.LocationTable().AppendEmpty()
+	loc2.SetMappingIndex(1)
+	loc2.SetAddress(0x401200)
+
+	dict.StackTable().AppendEmpty().LocationIndices().Append(0, 1)
+	dict.StackTable().AppendEmpty().LocationIndices().Append(1)
+	dict.StackTable().AppendEmpty()
+
+	at := dict.AttributeTable().AppendEmpty()
+	at.SetKeyStrindex(9)
+	at.SetUnitStrindex(10)
+	at.Value().SetStr("worker-1")
+
+	at2 := dict.AttributeTable().AppendEmpty()
+	at2.SetKeyStrindex(1)
+	at2.Value().SetInt(7)
+
+	at3 := dict.AttributeTable().AppendEmpty()
+	at3.Value().SetDouble(1.5)
+
+	lk := dict.LinkTable().AppendEmpty()
+	lk.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	lk.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	dict.LinkTable().AppendEmpty()
+
+	rp := pd.ResourceProfiles().AppendEmpty()
+	rp.SetSchemaUrl("https://schema.example/resource")
+	rp.Resource().Attributes().PutStr("service.name", "api")
+	rp.Resource().Attributes().PutInt("process.pid", 1234)
+
+	nested := rp.Resource().Attributes().PutEmptyMap("host")
+	nested.PutStr("name", "node-a")
+	nested.PutEmptySlice("tags").AppendEmpty().SetStr("prod")
+
+	sp := rp.ScopeProfiles().AppendEmpty()
+	sp.SetSchemaUrl("https://schema.example/scope")
+	sp.Scope().SetName("go.opentelemetry.io/example")
+	sp.Scope().SetVersion("1.2.3")
+	sp.Scope().Attributes().PutBool("experimental", true)
+	sp.Scope().Attributes().PutStr("lang", "go")
+
+	pr := sp.Profiles().AppendEmpty()
+	pr.SampleType().SetTypeStrindex(1)
+	pr.SampleType().SetUnitStrindex(2)
+	pr.PeriodType().SetTypeStrindex(3)
+	pr.PeriodType().SetUnitStrindex(4)
+	pr.SetTime(1_700_000_000_000_000_000)
+	pr.SetDurationNano(30_000_000_000)
+	pr.SetPeriod(10_000_000)
+	pr.SetProfileID(pprofile.ProfileID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	pr.SetDroppedAttributesCount(3)
+	pr.AttributeIndices().Append(0, 2)
+
+	s := pr.Samples().AppendEmpty()
+	s.SetStackIndex(0)
+	s.SetLinkIndex(0)
+	s.AttributeIndices().Append(1)
+	s.Values().Append(10, 20, 30)
+	s.TimestampsUnixNano().Append(1_700_000_000_000_000_001, 1_700_000_000_000_000_002)
+
+	s2 := pr.Samples().AppendEmpty()
+	s2.SetStackIndex(1)
+	s2.Values().Append(5)
+
+	pr2 := sp.Profiles().AppendEmpty()
+	pr2.SampleType().SetTypeStrindex(3)
+	pr2.SetTime(1_700_000_001_000_000_000)
+	pr2.Samples().AppendEmpty().SetStackIndex(2)
+
+	return pd
+}
+
+func TestConvertProfilesMatchesPdata(t *testing.T) {
+	t.Parallel()
+
+	direct, viaPdata := convertBothProfiles(t, fullProfiles(t))
+	assert.Equal(t, viaPdata, direct)
+}
+
+// TestConvertProfilesMinimal covers the batch a profiler emits with nothing optional set.
+func TestConvertProfilesMinimal(t *testing.T) {
+	t.Parallel()
+
+	pd := pprofile.NewProfiles()
+	pd.Dictionary().StringTable().Append("")
+
+	pr := pd.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+	pr.SetTime(1)
+	pr.Samples().AppendEmpty()
+
+	direct, viaPdata := convertBothProfiles(t, pd)
+	require.Equal(t, viaPdata, direct)
+
+	got := direct.Resources[0].Scopes[0].Profiles[0]
+	assert.Empty(t, got.AttributeIndices)
+	assert.Empty(t, got.ProfileID)
+	assert.Len(t, got.Samples, 1)
+	assert.Empty(t, got.Samples[0].Values)
+}
+
+// TestConvertProfilesDictionary pins that every table lands index-preserving, so the indices the
+// samples, stacks and locations carry still resolve to the entry the producer meant.
+func TestConvertProfilesDictionary(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.ProfilesConverter
+
+	got, err := c.Convert(marshalProfiles(t, fullProfiles(t)))
+	require.NoError(t, err)
+
+	dict := got.Dictionary
+	require.GreaterOrEqual(t, len(dict.Strings), 11)
+	assert.Empty(t, string(dict.Strings[0]))
+	assert.Equal(t, "samples", string(dict.Strings[1]))
+	assert.Equal(t, "/usr/lib/libc.so", string(dict.Strings[8]))
+
+	require.Len(t, dict.Functions, 2)
+	assert.Equal(t, "main", string(dict.Strings[dict.Functions[0].NameStrindex]))
+	assert.Equal(t, "main.main", string(dict.Strings[dict.Functions[0].SystemNameStrindex]))
+	assert.Equal(t, "/src/main.go", string(dict.Strings[dict.Functions[0].FilenameStrindex]))
+	assert.Equal(t, int64(42), dict.Functions[0].StartLine)
+
+	require.Len(t, dict.Mappings, 2)
+	assert.Equal(t, uint64(0x400000), dict.Mappings[0].MemoryStart)
+	assert.Equal(t, uint64(0x500000), dict.Mappings[0].MemoryLimit)
+	assert.Equal(t, uint64(0x1000), dict.Mappings[0].FileOffset)
+	assert.Equal(t, []int32{0, 1}, dict.Mappings[0].AttributeIndices)
+	assert.Empty(t, dict.Mappings[1].AttributeIndices)
+
+	require.Len(t, dict.Locations, 2)
+	require.Len(t, dict.Locations[0].Lines, 2)
+	assert.Equal(t, int64(17), dict.Locations[0].Lines[0].Line)
+	assert.Equal(t, int64(3), dict.Locations[0].Lines[0].Column)
+	assert.Equal(t, int32(1), dict.Locations[0].Lines[1].FunctionIndex)
+	assert.Equal(t, uint64(0x4010a0), dict.Locations[0].Address)
+	assert.Empty(t, dict.Locations[1].Lines)
+
+	require.Len(t, dict.Stacks, 3)
+	assert.Equal(t, []int32{0, 1}, dict.Stacks[0].LocationIndices)
+	assert.Equal(t, []int32{1}, dict.Stacks[1].LocationIndices)
+	assert.Empty(t, dict.Stacks[2].LocationIndices)
+
+	require.Len(t, dict.Attributes, 3)
+	assert.Equal(t, "thread.name", string(dict.Strings[dict.Attributes[0].KeyStrindex]))
+	assert.Equal(t, "ms", string(dict.Strings[dict.Attributes[0].UnitStrindex]))
+	assert.Equal(t, "worker-1", string(dict.Attributes[0].Value.Str()))
+	assert.Equal(t, int64(7), dict.Attributes[1].Value.Int())
+	assert.InDelta(t, 1.5, dict.Attributes[2].Value.Double(), 0)
+
+	require.Len(t, dict.Links, 2)
+	assert.Len(t, dict.Links[0].TraceID, 16)
+	assert.Len(t, dict.Links[0].SpanID, 8)
+	assert.Empty(t, dict.Links[1].TraceID)
+
+	pr := got.Resources[0].Scopes[0].Profiles[0]
+	assert.Equal(t, "samples", string(dict.Strings[pr.SampleType.TypeStrindex]))
+	assert.Equal(t, "count", string(dict.Strings[pr.SampleType.UnitStrindex]))
+	assert.Equal(t, "cpu", string(dict.Strings[pr.PeriodType.TypeStrindex]))
+	assert.Equal(t, "nanoseconds", string(dict.Strings[pr.PeriodType.UnitStrindex]))
+	assert.Equal(t, []int64{10, 20, 30}, pr.Samples[0].Values)
+	assert.Len(t, pr.Samples[0].TimestampsUnixNano, 2)
+	assert.Equal(t, []int32{1}, pr.Samples[0].AttributeIndices)
+}
+
+// TestConvertProfilesResolvesAttributeReferences pins the profiles-only indirection: pdata rewrites
+// resource and scope attribute keys and string values into string-table indices before marshaling,
+// so a decoder that only reads the inline key sees empty attributes.
+func TestConvertProfilesResolvesAttributeReferences(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.ProfilesConverter
+
+	got, err := c.Convert(marshalProfiles(t, fullProfiles(t)))
+	require.NoError(t, err)
+
+	attrs := got.Resources[0].Resource.Attributes
+	require.NotEmpty(t, attrs)
+
+	found := map[string]string{}
+	for _, kv := range attrs {
+		found[string(kv.Key)] = string(kv.Value.Str())
+	}
+
+	assert.Equal(t, "api", found["service.name"])
+	assert.Contains(t, found, "process.pid")
+
+	scope := got.Resources[0].Scopes[0].Scope
+	require.Len(t, scope.Attributes, 2)
+	assert.Equal(t, "experimental", string(scope.Attributes[0].Key))
+	assert.Equal(t, "lang", string(scope.Attributes[1].Key))
+	assert.Equal(t, "go", string(scope.Attributes[1].Value.Str()))
+}
+
+// TestConvertProfilesManySamples pins that the scratch reused across samples does not bleed one
+// sample's values, timestamps or attribute indices into the next.
+func TestConvertProfilesManySamples(t *testing.T) {
+	t.Parallel()
+
+	pd := pprofile.NewProfiles()
+	pd.Dictionary().StringTable().Append("")
+
+	sp := pd.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty()
+
+	for p := range 3 {
+		pr := sp.Profiles().AppendEmpty()
+		pr.SetTime(1)
+		pr.SetPeriod(int64(p))
+
+		if p%2 == 0 {
+			pr.AttributeIndices().Append(int32(p))
+		}
+
+		for i := range 10 {
+			s := pr.Samples().AppendEmpty()
+			s.SetStackIndex(int32(i))
+			s.Values().Append(int64(i))
+
+			if i%3 == 0 {
+				s.TimestampsUnixNano().Append(uint64(i))
+			}
+
+			if i%4 == 0 {
+				s.AttributeIndices().Append(int32(i))
+			}
+		}
+	}
+
+	direct, viaPdata := convertBothProfiles(t, pd)
+	require.Equal(t, viaPdata, direct)
+
+	samples := direct.Resources[0].Scopes[0].Profiles[0].Samples
+	require.Len(t, samples, 10)
+	assert.Empty(t, samples[1].TimestampsUnixNano, "a sample without timestamps keeps none")
+	assert.Empty(t, samples[1].AttributeIndices, "a sample without attributes keeps none")
+	assert.Empty(t, direct.Resources[0].Scopes[0].Profiles[1].AttributeIndices)
+}
+
+func TestConvertProfilesIsFieldOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	var asc, desc otlpdirect.ProfilesConverter
+
+	up, err := asc.Convert(encodeProfiles(true))
+	require.NoError(t, err)
+
+	down, err := desc.Convert(encodeProfiles(false))
+	require.NoError(t, err)
+
+	require.Equal(t, canonicalProfiles(down), canonicalProfiles(up))
+
+	rp := up.Resources[0]
+	assert.Equal(t, "https://schema.example/resource", string(rp.Resource.SchemaURL))
+	assert.Equal(t, "https://schema.example/scope", string(rp.Scopes[0].Scope.SchemaURL))
+	assert.Equal(t, "scope-name", string(rp.Scopes[0].Scope.Name))
+
+	// The dictionary is written after the resources in ascending order, so a resolved key here
+	// proves it was decoded before the walk that needs it.
+	require.Len(t, rp.Resource.Attributes, 1)
+	assert.Equal(t, "service.name", string(rp.Resource.Attributes[0].Key))
+	assert.Equal(t, "api", string(rp.Resource.Attributes[0].Value.Str()))
+
+	pr := rp.Scopes[0].Profiles[0]
+	assert.Equal(t, int64(1_700_000_000_000_000_000), pr.TimeNanos)
+	assert.Equal(t, int64(30_000_000_000), pr.DurationNanos)
+	assert.Equal(t, int64(10_000_000), pr.Period)
+	assert.Equal(t, "profile-id-0000a", string(pr.ProfileID))
+	assert.Equal(t, []int32{0}, pr.AttributeIndices)
+	require.Len(t, pr.Samples, 1)
+	assert.Equal(t, []int64{10, 20}, pr.Samples[0].Values)
+
+	dict := up.Dictionary
+	require.Len(t, dict.Locations, 1)
+	assert.Len(t, dict.Locations[0].Lines, 1)
+	assert.Equal(t, int64(17), dict.Locations[0].Lines[0].Line)
+	assert.Equal(t, uint64(0x400000), dict.Mappings[0].MemoryStart)
+	assert.Equal(t, []int32{0}, dict.Stacks[0].LocationIndices)
+}
+
+func TestConvertProfilesEmpty(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.ProfilesConverter
+
+	got, err := c.Convert(nil)
+	require.NoError(t, err)
+	assert.Empty(t, got.Resources)
+	assert.Empty(t, got.Dictionary.Strings)
+
+	direct, viaPdata := convertBothProfiles(t, pprofile.NewProfiles())
+	assert.Equal(t, viaPdata, direct)
+}
+
+func TestConvertProfilesReuseIsIsolated(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.ProfilesConverter
+
+	second := pprofile.NewProfiles()
+	second.Dictionary().StringTable().Append("")
+	second.Dictionary().StringTable().Append("cpu")
+	second.Dictionary().StackTable().AppendEmpty().LocationIndices().Append(0)
+
+	pr := second.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty().Profiles().AppendEmpty()
+	pr.SetTime(2)
+	pr.SampleType().SetTypeStrindex(1)
+	pr.Samples().AppendEmpty().Values().Append(1)
+
+	rawSecond := marshalProfiles(t, second)
+
+	_, err := c.Convert(marshalProfiles(t, fullProfiles(t)))
+	require.NoError(t, err)
+
+	got, err := c.Convert(rawSecond)
+	require.NoError(t, err)
+
+	var fresh otlpdirect.ProfilesConverter
+
+	want, err := fresh.Convert(rawSecond)
+	require.NoError(t, err)
+
+	assert.Equal(t, canonicalProfiles(want), canonicalProfiles(got))
+}
+
+func BenchmarkConvertProfiles(b *testing.B) {
+	pd := pprofile.NewProfiles()
+
+	dict := pd.Dictionary()
+	for _, s := range []string{"", "samples", "count", "cpu", "nanoseconds", "main", "/src/main.go"} {
+		dict.StringTable().Append(s)
+	}
+
+	fn := dict.FunctionTable().AppendEmpty()
+	fn.SetNameStrindex(5)
+	fn.SetFilenameStrindex(6)
+
+	for i := range 100 {
+		loc := dict.LocationTable().AppendEmpty()
+		loc.SetAddress(uint64(0x400000 + i))
+		loc.Lines().AppendEmpty().SetLine(int64(i))
+
+		dict.StackTable().AppendEmpty().LocationIndices().Append(int32(i), int32((i+1)%100))
+	}
+
+	rp := pd.ResourceProfiles().AppendEmpty()
+	rp.Resource().Attributes().PutStr("service.name", "api")
+
+	sp := rp.ScopeProfiles().AppendEmpty()
+	sp.Scope().SetName("bench")
+
+	pr := sp.Profiles().AppendEmpty()
+	pr.SampleType().SetTypeStrindex(1)
+	pr.SampleType().SetUnitStrindex(2)
+	pr.SetTime(1_700_000_000_000_000_000)
+
+	for i := range 1_000 {
+		s := pr.Samples().AppendEmpty()
+		s.SetStackIndex(int32(i % 100))
+		s.Values().Append(int64(i))
+		s.TimestampsUnixNano().Append(uint64(1_700_000_000_000_000_000 + i))
+	}
+
+	raw := marshalProfiles(b, pd)
+
+	b.Run("Direct", func(b *testing.B) {
+		var c otlpdirect.ProfilesConverter
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(raw)))
+
+		for b.Loop() {
+			if _, err := c.Convert(raw); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Pdata", func(b *testing.B) {
+		var u pprofile.ProtoUnmarshaler
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(raw)))
+
+		for b.Loop() {
+			decoded, err := u.UnmarshalProfiles(raw)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			dst := &profile.Profiles{}
+			pdataconv.AppendProfiles(dst, decoded)
+		}
+	})
+}

--- a/internal/otlpdirect/response.go
+++ b/internal/otlpdirect/response.go
@@ -1,0 +1,45 @@
+package otlpdirect
+
+import (
+	"github.com/VictoriaMetrics/easyproto"
+
+	"github.com/oteldb/storage/signal"
+)
+
+// Every ExportXServiceResponse has the same shape: field 1 is an optional partial_success
+// submessage whose field 1 is the rejected count and whose field 2 is a human-readable message.
+// The count's name differs per signal (rejected_log_records, rejected_spans, rejected_data_points,
+// rejected_profiles) but the number does not, so one encoder serves all four.
+const (
+	fieldResponsePartialSuccess = 1
+	fieldPartialRejected        = 1
+	fieldPartialErrorMessage    = 2
+)
+
+// encodePartialSuccess builds the response for an export that stored some of what it was sent.
+//
+// OTLP requires 200 with a partial-success body here, not an error status: the rejected items are
+// ones no retry can fix, so a client that resends them would loop forever. The message says which
+// signal's unit was rejected, since the field name is all that distinguishes them.
+func encodePartialSuccess(sig signal.Signal, rejected int) []byte {
+	var m easyproto.Marshaler
+
+	ps := m.MessageMarshaler().AppendMessage(fieldResponsePartialSuccess)
+	ps.AppendInt64(fieldPartialRejected, int64(rejected))
+	ps.AppendString(fieldPartialErrorMessage, rejectionMessage(sig))
+
+	return m.Marshal(nil)
+}
+
+func rejectionMessage(sig signal.Signal) string {
+	switch sig {
+	case signal.Log:
+		return "some log records could not be represented and were dropped"
+	case signal.Trace:
+		return "some spans could not be represented and were dropped"
+	case signal.Profile:
+		return "some profiles could not be represented and were dropped"
+	default:
+		return "some data points carried no value and were dropped"
+	}
+}

--- a/internal/otlpdirect/traceorder_test.go
+++ b/internal/otlpdirect/traceorder_test.go
@@ -1,0 +1,185 @@
+package otlpdirect_test
+
+import (
+	"github.com/VictoriaMetrics/easyproto"
+
+	"github.com/oteldb/storage/signal/trace"
+)
+
+// encodeScopeSpans builds one ExportTraceServiceRequest carrying a single fully-populated span,
+// writing each message's fields ascending or descending. Traces has more nesting than logs — a
+// span's status, events and links are all submessages siblings of scalar fields — so the ordering
+// hazard has more places to hide here.
+func encodeScopeSpans(ascending bool) []byte {
+	var m easyproto.Marshaler
+
+	req := m.MessageMarshaler()
+	rs := req.AppendMessage(1) // resource_spans
+
+	writeResource := func() {
+		res := rs.AppendMessage(1)
+		kv := res.AppendMessage(1)
+		kv.AppendString(1, "service.name")
+		kv.AppendMessage(2).AppendString(1, "api")
+	}
+
+	writeScopes := func() {
+		ss := rs.AppendMessage(2) // scope_spans
+
+		writeScope := func() {
+			sc := ss.AppendMessage(1)
+			sc.AppendString(1, "scope-name")
+			sc.AppendString(2, "1.0.0")
+		}
+
+		writeSpans := func() {
+			sp := ss.AppendMessage(2) // spans
+
+			writeIDs := func() {
+				sp.AppendBytes(1, []byte("0123456789abcdef")) // trace_id
+				sp.AppendBytes(2, []byte("01234567"))         // span_id
+				sp.AppendString(3, "vendor=v")                // trace_state
+				sp.AppendBytes(4, []byte("76543210"))         // parent_span_id
+			}
+
+			writeCore := func() {
+				sp.AppendString(5, "op")                       // name
+				sp.AppendInt64(6, 2)                           // kind
+				sp.AppendFixed64(7, 1_700_000_000_000_000_000) // start
+				sp.AppendFixed64(8, 1_700_000_000_500_000_000) // end
+				kv := sp.AppendMessage(9)                      // attributes
+				kv.AppendString(1, "http.method")              //
+				kv.AppendMessage(2).AppendString(1, "GET")     //
+				sp.AppendInt64(10, 2)                          // dropped_attributes_count
+				sp.AppendFixed32(16, 1)                        // flags
+			}
+
+			writeEvent := func() {
+				ev := sp.AppendMessage(11)
+				ev.AppendFixed64(1, 1_700_000_000_100_000_000)
+				ev.AppendString(2, "exception")
+
+				kv := ev.AppendMessage(3)
+				kv.AppendString(1, "exception.type")
+				kv.AppendMessage(2).AppendString(1, "TimeoutError")
+			}
+
+			writeLink := func() {
+				ln := sp.AppendMessage(13)
+				ln.AppendBytes(1, []byte("fedcba9876543210"))
+				ln.AppendBytes(2, []byte("76543210"))
+				ln.AppendString(3, "link=state")
+
+				kv := ln.AppendMessage(4)
+				kv.AppendString(1, "rel")
+				kv.AppendMessage(2).AppendString(1, "follows_from")
+			}
+
+			writeStatus := func() {
+				st := sp.AppendMessage(15)
+				st.AppendString(2, "upstream timeout")
+				st.AppendInt64(3, 2)
+			}
+
+			if ascending {
+				writeIDs()
+				writeCore()
+				writeEvent()
+				writeLink()
+				writeStatus()
+			} else {
+				writeStatus()
+				writeLink()
+				writeEvent()
+				writeCore()
+				writeIDs()
+			}
+		}
+
+		writeSchema := func() { ss.AppendString(3, "https://schema.example/scope") }
+
+		if ascending {
+			writeScope()
+			writeSpans()
+			writeSchema()
+		} else {
+			writeSchema()
+			writeSpans()
+			writeScope()
+		}
+	}
+
+	writeSchema := func() { rs.AppendString(3, "https://schema.example/resource") }
+
+	if ascending {
+		writeResource()
+		writeScopes()
+		writeSchema()
+	} else {
+		writeSchema()
+		writeScopes()
+		writeResource()
+	}
+
+	return m.Marshal(nil)
+}
+
+// canonicalTraces is [canonical] for the traces model: it rewrites zero-length byte slices to nil
+// so the two paths' spellings of an absent field compare equal. See canonical_test.go.
+func canonicalTraces(t *trace.Traces) *trace.Traces {
+	for i := range t.Resources {
+		rs := &t.Resources[i]
+		rs.Resource.SchemaURL = canonBytes(rs.Resource.SchemaURL)
+		rs.Resource.Attributes = canonAttrs(rs.Resource.Attributes)
+
+		for j := range rs.Scopes {
+			ss := &rs.Scopes[j]
+			ss.Scope.Name = canonBytes(ss.Scope.Name)
+			ss.Scope.Version = canonBytes(ss.Scope.Version)
+			ss.Scope.SchemaURL = canonBytes(ss.Scope.SchemaURL)
+			ss.Scope.Attributes = canonAttrs(ss.Scope.Attributes)
+
+			for k := range ss.Spans {
+				canonicalSpan(&ss.Spans[k])
+			}
+
+			if len(ss.Spans) == 0 {
+				ss.Spans = nil
+			}
+		}
+	}
+
+	return t
+}
+
+func canonicalSpan(sp *trace.Span) {
+	sp.TraceID = canonBytes(sp.TraceID)
+	sp.SpanID = canonBytes(sp.SpanID)
+	sp.ParentSpanID = canonBytes(sp.ParentSpanID)
+	sp.Name = canonBytes(sp.Name)
+	sp.StatusMessage = canonBytes(sp.StatusMessage)
+	sp.TraceState = canonBytes(sp.TraceState)
+	sp.Attributes = canonAttrs(sp.Attributes)
+
+	for i := range sp.Events {
+		e := &sp.Events[i]
+		e.Name = canonBytes(e.Name)
+		e.Attributes = canonAttrs(e.Attributes)
+	}
+
+	for i := range sp.Links {
+		l := &sp.Links[i]
+		l.TraceID = canonBytes(l.TraceID)
+		l.SpanID = canonBytes(l.SpanID)
+		l.TraceState = canonBytes(l.TraceState)
+		l.Attributes = canonAttrs(l.Attributes)
+	}
+
+	if len(sp.Events) == 0 {
+		sp.Events = nil
+	}
+
+	if len(sp.Links) == 0 {
+		sp.Links = nil
+	}
+}

--- a/internal/otlpdirect/traces.go
+++ b/internal/otlpdirect/traces.go
@@ -1,0 +1,488 @@
+package otlpdirect
+
+import (
+	"github.com/VictoriaMetrics/easyproto"
+	"github.com/go-faster/errors"
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/signal/trace"
+)
+
+// Field numbers of trace.proto and collector/trace/v1/trace_service.proto.
+const (
+	// opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+	fieldExportResourceSpans = 1
+
+	// opentelemetry.proto.trace.v1.ResourceSpans
+	fieldResourceSpansResource  = 1
+	fieldResourceSpansScope     = 2
+	fieldResourceSpansSchemaURL = 3
+
+	// opentelemetry.proto.trace.v1.ScopeSpans
+	fieldScopeSpansScope     = 1
+	fieldScopeSpansSpans     = 2
+	fieldScopeSpansSchemaURL = 3
+
+	// opentelemetry.proto.trace.v1.Span
+	fieldSpanTraceID      = 1
+	fieldSpanSpanID       = 2
+	fieldSpanTraceState   = 3
+	fieldSpanParentSpanID = 4
+	fieldSpanName         = 5
+	fieldSpanKind         = 6
+	fieldSpanStart        = 7
+	fieldSpanEnd          = 8
+	fieldSpanAttributes   = 9
+	fieldSpanDropped      = 10
+	fieldSpanEvents       = 11
+	fieldSpanLinks        = 13
+	fieldSpanStatus       = 15
+	fieldSpanFlags        = 16
+
+	// opentelemetry.proto.trace.v1.Status
+	fieldStatusMessage = 2
+	fieldStatusCode    = 3
+
+	// opentelemetry.proto.trace.v1.Span.Event
+	fieldEventTime       = 1
+	fieldEventName       = 2
+	fieldEventAttributes = 3
+	fieldEventDropped    = 4
+
+	// opentelemetry.proto.trace.v1.Span.Link
+	fieldLinkTraceID    = 1
+	fieldLinkSpanID     = 2
+	fieldLinkTraceState = 3
+	fieldLinkAttributes = 4
+	fieldLinkDropped    = 5
+)
+
+// TracesConverter decodes an OTLP ExportTraceServiceRequest into [trace.Traces]. It retains the
+// batch and the scratch it is built from, so a converter reused across requests allocates nothing
+// in steady state. It is not safe for concurrent use; pool one per in-flight request.
+type TracesConverter struct {
+	batch trace.Traces
+	dec   decoder
+
+	// Submessage collectors, reused across the spans of a request. Each is consumed before the
+	// next span reaches it, so one buffer per kind serves the whole walk.
+	spanAttrs  [][]byte
+	spanEvents [][]byte
+	spanLinks  [][]byte
+	subAttrs   [][]byte
+}
+
+// Convert decodes a serialized ExportTraceServiceRequest.
+//
+// The returned batch aliases src: every key, name, id and string value is a sub-slice of it. It
+// stays valid until the next Convert on this converter, and src must not be recycled until the
+// write consuming the batch has returned.
+func (c *TracesConverter) Convert(src []byte) (*trace.Traces, error) {
+	c.batch.Reset()
+	c.dec.reset()
+
+	resources, err := collect(src, fieldExportResourceSpans, "resource spans")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, data := range resources {
+		if err := c.resourceSpans(data); err != nil {
+			return nil, err
+		}
+	}
+
+	return &c.batch, nil
+}
+
+func (c *TracesConverter) resourceSpans(src []byte) error {
+	var (
+		fc     easyproto.FieldContext
+		res    signal.Resource
+		scopes [][]byte
+		err    error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read resource spans field")
+		}
+
+		switch fc.FieldNum {
+		case fieldResourceSpansResource:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read resource")
+			}
+
+			if res.Attributes, err = c.dec.resource(data); err != nil {
+				return err
+			}
+		case fieldResourceSpansScope:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read scope spans")
+			}
+
+			scopes = append(scopes, data)
+		case fieldResourceSpansSchemaURL:
+			v, ok := fc.Bytes()
+			if !ok {
+				return errors.New("read resource schema url")
+			}
+
+			res.SchemaURL = v
+		}
+	}
+
+	rs := c.batch.AddResource()
+	rs.Resource = res
+
+	for _, data := range scopes {
+		if err := c.scopeSpans(rs, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *TracesConverter) scopeSpans(rs *trace.ResourceSpans, src []byte) error {
+	var (
+		fc        easyproto.FieldContext
+		scopeData []byte
+		schemaURL []byte
+		spans     [][]byte
+		err       error
+	)
+
+	// Field order is the producer's choice — pdata writes them descending, so schema_url arrives
+	// before scope. The scope submessage is therefore decoded after the walk, never during it:
+	// decoding in place would overwrite a schema_url already read.
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read scope spans field")
+		}
+
+		switch fc.FieldNum {
+		case fieldScopeSpansScope:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read scope")
+			}
+
+			scopeData = data
+		case fieldScopeSpansSpans:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read span")
+			}
+
+			spans = append(spans, data)
+		case fieldScopeSpansSchemaURL:
+			v, ok := fc.Bytes()
+			if !ok {
+				return errors.New("read scope schema url")
+			}
+
+			schemaURL = v
+		}
+	}
+
+	sc, err := c.dec.scope(scopeData)
+	if err != nil {
+		return err
+	}
+
+	sc.SchemaURL = schemaURL
+
+	ss := rs.AddScope()
+	ss.Scope = sc
+
+	for _, data := range spans {
+		if err := c.span(ss, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *TracesConverter) span(ss *trace.ScopeSpans, src []byte) error {
+	var (
+		fc         easyproto.FieldContext
+		statusData []byte
+		err        error
+	)
+
+	sp := ss.AddSpan()
+
+	attrs := c.spanAttrs[:0]
+	events := c.spanEvents[:0]
+	links := c.spanLinks[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read span field")
+		}
+
+		switch fc.FieldNum {
+		case fieldSpanTraceID:
+			if sp.TraceID, err = takeBytes(&fc, "span trace id"); err != nil {
+				return err
+			}
+		case fieldSpanSpanID:
+			if sp.SpanID, err = takeBytes(&fc, "span id"); err != nil {
+				return err
+			}
+		case fieldSpanParentSpanID:
+			if sp.ParentSpanID, err = takeBytes(&fc, "parent span id"); err != nil {
+				return err
+			}
+		case fieldSpanTraceState:
+			if sp.TraceState, err = takeBytes(&fc, "span trace state"); err != nil {
+				return err
+			}
+		case fieldSpanName:
+			if sp.Name, err = takeBytes(&fc, "span name"); err != nil {
+				return err
+			}
+		case fieldSpanKind:
+			v, ok := fc.Enum()
+			if !ok {
+				return errors.New("read span kind")
+			}
+
+			sp.Kind = v
+		case fieldSpanStart:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read span start")
+			}
+
+			sp.Start = int64(v)
+		case fieldSpanEnd:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read span end")
+			}
+
+			sp.End = int64(v)
+		case fieldSpanAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read span attribute")
+			}
+
+			attrs = append(attrs, data)
+		case fieldSpanDropped:
+			v, ok := fc.Uint32()
+			if !ok {
+				return errors.New("read span dropped count")
+			}
+
+			sp.Dropped = v
+		case fieldSpanEvents:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read span event")
+			}
+
+			events = append(events, data)
+		case fieldSpanLinks:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read span link")
+			}
+
+			links = append(links, data)
+		case fieldSpanStatus:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read span status")
+			}
+
+			statusData = data
+		case fieldSpanFlags:
+			v, ok := fc.Fixed32()
+			if !ok {
+				return errors.New("read span flags")
+			}
+
+			sp.Flags = v
+		}
+	}
+
+	c.spanAttrs, c.spanEvents, c.spanLinks = attrs, events, links
+
+	if sp.Attributes, err = c.dec.attributes(attrs); err != nil {
+		return err
+	}
+
+	if err := c.status(sp, statusData); err != nil {
+		return err
+	}
+
+	for _, data := range events {
+		if err := c.event(sp, data); err != nil {
+			return err
+		}
+	}
+
+	for _, data := range links {
+		if err := c.link(sp, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// status decodes a Span.Status. An absent status leaves the zero code and message, which is what
+// the pdata path produces for a span that never set one.
+func (c *TracesConverter) status(sp *trace.Span, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		err error
+	)
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read status field")
+		}
+
+		switch fc.FieldNum {
+		case fieldStatusMessage:
+			if sp.StatusMessage, err = takeBytes(&fc, "status message"); err != nil {
+				return err
+			}
+		case fieldStatusCode:
+			v, ok := fc.Enum()
+			if !ok {
+				return errors.New("read status code")
+			}
+
+			sp.StatusCode = v
+		}
+	}
+
+	return nil
+}
+
+func (c *TracesConverter) event(sp *trace.Span, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		ev  trace.Event
+		err error
+	)
+
+	kvs := c.subAttrs[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read event field")
+		}
+
+		switch fc.FieldNum {
+		case fieldEventTime:
+			v, ok := fc.Fixed64()
+			if !ok {
+				return errors.New("read event time")
+			}
+
+			ev.Time = int64(v)
+		case fieldEventName:
+			if ev.Name, err = takeBytes(&fc, "event name"); err != nil {
+				return err
+			}
+		case fieldEventAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read event attribute")
+			}
+
+			kvs = append(kvs, data)
+		case fieldEventDropped:
+			v, ok := fc.Uint32()
+			if !ok {
+				return errors.New("read event dropped count")
+			}
+
+			ev.Dropped = v
+		}
+	}
+
+	c.subAttrs = kvs
+
+	if ev.Attributes, err = c.dec.attributes(kvs); err != nil {
+		return err
+	}
+
+	*sp.AddEvent() = ev
+
+	return nil
+}
+
+func (c *TracesConverter) link(sp *trace.Span, src []byte) error {
+	var (
+		fc  easyproto.FieldContext
+		ln  trace.Link
+		err error
+	)
+
+	kvs := c.subAttrs[:0]
+
+	for len(src) > 0 {
+		if src, err = fc.NextField(src); err != nil {
+			return errors.Wrap(err, "read link field")
+		}
+
+		switch fc.FieldNum {
+		case fieldLinkTraceID:
+			if ln.TraceID, err = takeBytes(&fc, "link trace id"); err != nil {
+				return err
+			}
+		case fieldLinkSpanID:
+			if ln.SpanID, err = takeBytes(&fc, "link span id"); err != nil {
+				return err
+			}
+		case fieldLinkTraceState:
+			if ln.TraceState, err = takeBytes(&fc, "link trace state"); err != nil {
+				return err
+			}
+		case fieldLinkAttributes:
+			data, ok := fc.MessageData()
+			if !ok {
+				return errors.New("read link attribute")
+			}
+
+			kvs = append(kvs, data)
+		case fieldLinkDropped:
+			v, ok := fc.Uint32()
+			if !ok {
+				return errors.New("read link dropped count")
+			}
+
+			ln.Dropped = v
+		}
+	}
+
+	c.subAttrs = kvs
+
+	if ln.Attributes, err = c.dec.attributes(kvs); err != nil {
+		return err
+	}
+
+	*sp.AddLink() = ln
+
+	return nil
+}
+
+// takeBytes reads a length-delimited field, naming it in any error.
+func takeBytes(fc *easyproto.FieldContext, what string) ([]byte, error) {
+	v, ok := fc.Bytes()
+	if !ok {
+		return nil, errors.Errorf("read %s", what)
+	}
+
+	return v, nil
+}

--- a/internal/otlpdirect/traces_test.go
+++ b/internal/otlpdirect/traces_test.go
@@ -1,0 +1,300 @@
+package otlpdirect_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage/otlp/pdataconv"
+	"github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+func marshalTraces(tb testing.TB, td ptrace.Traces) []byte {
+	tb.Helper()
+
+	raw, err := (&ptrace.ProtoMarshaler{}).MarshalTraces(td)
+	require.NoError(tb, err)
+
+	return raw
+}
+
+// convertBothTraces decodes td directly and via the pdata path, canonicalized for comparison.
+func convertBothTraces(tb testing.TB, td ptrace.Traces) (direct, viaPdata *trace.Traces) {
+	tb.Helper()
+
+	var c otlpdirect.TracesConverter
+
+	direct, err := c.Convert(marshalTraces(tb, td))
+	require.NoError(tb, err)
+
+	viaPdata = &trace.Traces{}
+	require.Zero(tb, pdataconv.AppendTraces(viaPdata, td))
+
+	return canonicalTraces(direct), canonicalTraces(viaPdata)
+}
+
+// TestConvertTracesMatchesPdata exercises every field of a span, including the nested status,
+// events and links, against the pdata path.
+func TestConvertTracesMatchesPdata(t *testing.T) {
+	t.Parallel()
+
+	td := ptrace.NewTraces()
+
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.SetSchemaUrl("https://schema.example/resource")
+	rs.Resource().Attributes().PutStr("service.name", "api")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.SetSchemaUrl("https://schema.example/scope")
+	ss.Scope().SetName("go.opentelemetry.io/example")
+	ss.Scope().SetVersion("1.2.3")
+	ss.Scope().Attributes().PutBool("experimental", true)
+
+	sp := ss.Spans().AppendEmpty()
+	sp.SetTraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	sp.SetSpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	sp.SetParentSpanID([8]byte{8, 7, 6, 5, 4, 3, 2, 1})
+	sp.TraceState().FromRaw("vendor=value")
+	sp.SetName("GET /things")
+	sp.SetKind(ptrace.SpanKindServer)
+	sp.SetStartTimestamp(1_700_000_000_000_000_000)
+	sp.SetEndTimestamp(1_700_000_000_500_000_000)
+	sp.SetFlags(1)
+	sp.SetDroppedAttributesCount(2)
+	sp.Status().SetCode(ptrace.StatusCodeError)
+	sp.Status().SetMessage("upstream timeout")
+	sp.Attributes().PutStr("http.method", "GET")
+	sp.Attributes().PutInt("http.status_code", 504)
+
+	ev := sp.Events().AppendEmpty()
+	ev.SetTimestamp(1_700_000_000_100_000_000)
+	ev.SetName("exception")
+	ev.SetDroppedAttributesCount(1)
+	ev.Attributes().PutStr("exception.type", "TimeoutError")
+
+	ev2 := sp.Events().AppendEmpty()
+	ev2.SetTimestamp(1_700_000_000_200_000_000)
+	ev2.SetName("retry")
+
+	ln := sp.Links().AppendEmpty()
+	ln.SetTraceID([16]byte{9})
+	ln.SetSpanID([8]byte{9})
+	ln.TraceState().FromRaw("link=state")
+	ln.SetDroppedAttributesCount(3)
+	ln.Attributes().PutStr("rel", "follows_from")
+
+	direct, viaPdata := convertBothTraces(t, td)
+	assert.Equal(t, viaPdata, direct)
+}
+
+// TestConvertTracesMinimalSpan covers the span a real tracer emits with nothing optional set — no
+// status, no events, no links, no attributes.
+func TestConvertTracesMinimalSpan(t *testing.T) {
+	t.Parallel()
+
+	td := ptrace.NewTraces()
+
+	sp := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	sp.SetName("op")
+	sp.SetStartTimestamp(1)
+	sp.SetEndTimestamp(2)
+
+	direct, viaPdata := convertBothTraces(t, td)
+	require.Equal(t, viaPdata, direct)
+
+	got := direct.Resources[0].Scopes[0].Spans[0]
+	assert.Empty(t, got.Events)
+	assert.Empty(t, got.Links)
+	assert.Zero(t, got.StatusCode)
+}
+
+// TestConvertTracesSpanKindsAndStatuses walks the enums, where an Enum/Uint32 mix-up hides.
+func TestConvertTracesSpanKindsAndStatuses(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []ptrace.SpanKind{
+		ptrace.SpanKindUnspecified, ptrace.SpanKindInternal, ptrace.SpanKindServer,
+		ptrace.SpanKindClient, ptrace.SpanKindProducer, ptrace.SpanKindConsumer,
+	} {
+		for _, code := range []ptrace.StatusCode{
+			ptrace.StatusCodeUnset, ptrace.StatusCodeOk, ptrace.StatusCodeError,
+		} {
+			td := ptrace.NewTraces()
+
+			sp := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			sp.SetName("op")
+			sp.SetStartTimestamp(1)
+			sp.SetKind(kind)
+			sp.Status().SetCode(code)
+
+			direct, viaPdata := convertBothTraces(t, td)
+			require.Equal(t, viaPdata, direct, "kind=%v code=%v", kind, code)
+		}
+	}
+}
+
+// TestConvertTracesManySpans pins that the collectors reused across spans do not bleed one span's
+// attributes, events or links into the next.
+func TestConvertTracesManySpans(t *testing.T) {
+	t.Parallel()
+
+	td := ptrace.NewTraces()
+	ss := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty()
+
+	for i := range 20 {
+		sp := ss.Spans().AppendEmpty()
+		sp.SetName("op")
+		sp.SetStartTimestamp(pcommon.Timestamp(i + 1))
+		sp.Attributes().PutInt("i", int64(i))
+
+		// Only some spans carry events and links, so a leaked collector would show up as a span
+		// inheriting its predecessor's.
+		if i%3 == 0 {
+			e := sp.Events().AppendEmpty()
+			e.SetName("ev")
+			e.Attributes().PutInt("i", int64(i))
+		}
+
+		if i%4 == 0 {
+			l := sp.Links().AppendEmpty()
+			l.SetTraceID([16]byte{byte(i)})
+			l.Attributes().PutInt("i", int64(i))
+		}
+	}
+
+	direct, viaPdata := convertBothTraces(t, td)
+	require.Equal(t, viaPdata, direct)
+
+	spans := direct.Resources[0].Scopes[0].Spans
+	require.Len(t, spans, 20)
+	assert.Empty(t, spans[1].Events, "a span without events keeps none")
+	assert.Empty(t, spans[1].Links, "a span without links keeps none")
+}
+
+// TestConvertTracesIsFieldOrderIndependent is the traces twin of the logs ordering test: the same
+// message written ascending and descending must decode identically.
+func TestConvertTracesIsFieldOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	var asc, desc otlpdirect.TracesConverter
+
+	up, err := asc.Convert(encodeScopeSpans(true))
+	require.NoError(t, err)
+
+	down, err := desc.Convert(encodeScopeSpans(false))
+	require.NoError(t, err)
+
+	require.Equal(t, canonicalTraces(down), canonicalTraces(up))
+
+	ss := up.Resources[0].Scopes[0]
+	assert.Equal(t, "https://schema.example/scope", string(ss.Scope.SchemaURL))
+	assert.Equal(t, "scope-name", string(ss.Scope.Name))
+	assert.Equal(t, "https://schema.example/resource", string(up.Resources[0].Resource.SchemaURL))
+
+	sp := ss.Spans[0]
+	assert.Equal(t, "op", string(sp.Name))
+	assert.Equal(t, "upstream timeout", string(sp.StatusMessage))
+	assert.Len(t, sp.Events, 1)
+	assert.Len(t, sp.Links, 1)
+}
+
+func TestConvertTracesEmpty(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.TracesConverter
+
+	got, err := c.Convert(nil)
+	require.NoError(t, err)
+	assert.Empty(t, got.Resources)
+
+	direct, viaPdata := convertBothTraces(t, ptrace.NewTraces())
+	assert.Equal(t, viaPdata, direct)
+}
+
+func TestConvertTracesReuseIsIsolated(t *testing.T) {
+	t.Parallel()
+
+	var c otlpdirect.TracesConverter
+
+	first := ptrace.NewTraces()
+	fs := first.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	fs.SetName("first")
+	fs.SetStartTimestamp(1)
+	fs.Events().AppendEmpty().SetName("ev")
+	fs.Attributes().PutStr("a", "1")
+
+	second := ptrace.NewTraces()
+	sspan := second.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	sspan.SetName("second")
+	sspan.SetStartTimestamp(2)
+
+	_, err := c.Convert(marshalTraces(t, first))
+	require.NoError(t, err)
+
+	got, err := c.Convert(marshalTraces(t, second))
+	require.NoError(t, err)
+
+	want := &trace.Traces{}
+	require.Zero(t, pdataconv.AppendTraces(want, second))
+	assert.Equal(t, canonicalTraces(want), canonicalTraces(got))
+}
+
+func BenchmarkConvertTraces(b *testing.B) {
+	td := ptrace.NewTraces()
+
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "api")
+
+	ss := rs.ScopeSpans().AppendEmpty()
+	ss.Scope().SetName("bench")
+
+	for i := range 1_000 {
+		sp := ss.Spans().AppendEmpty()
+		sp.SetTraceID([16]byte{byte(i), byte(i >> 8)})
+		sp.SetSpanID([8]byte{byte(i)})
+		sp.SetName("GET /api/v1/things")
+		sp.SetKind(ptrace.SpanKindServer)
+		sp.SetStartTimestamp(pcommon.Timestamp(1_700_000_000_000_000_000 + i))
+		sp.SetEndTimestamp(pcommon.Timestamp(1_700_000_000_001_000_000 + i))
+		sp.Status().SetCode(ptrace.StatusCodeOk)
+		sp.Attributes().PutStr("http.method", "GET")
+		sp.Attributes().PutInt("http.status_code", 200)
+	}
+
+	raw := marshalTraces(b, td)
+
+	b.Run("Direct", func(b *testing.B) {
+		var c otlpdirect.TracesConverter
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(raw)))
+
+		for b.Loop() {
+			if _, err := c.Convert(raw); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Pdata", func(b *testing.B) {
+		var u ptrace.ProtoUnmarshaler
+
+		b.ReportAllocs()
+		b.SetBytes(int64(len(raw)))
+
+		for b.Loop() {
+			decoded, err := u.UnmarshalTraces(raw)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			dst := &trace.Traces{}
+			pdataconv.AppendTraces(dst, decoded)
+		}
+	})
+}

--- a/internal/promrw/histogram.go
+++ b/internal/promrw/histogram.go
@@ -190,7 +190,7 @@ func bound(index, schema int32) float64 {
 
 // formatBound formats a bucket bound as its `le` label value, carved from the name arena.
 func (c *Converter) formatBound(f float64) []byte {
-	return strconv.AppendFloat(c.names.alloc(32), f, 'g', -1, 64)
+	return strconv.AppendFloat(c.names.Alloc(32), f, 'g', -1, 64)
 }
 
 func histogramCount(h *prompb.Histogram) float64 {

--- a/internal/promrw/promrw.go
+++ b/internal/promrw/promrw.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oteldb/storage/signal/metric"
 
 	"github.com/oteldb/oteldb/internal/prompb"
+	"github.com/oteldb/oteldb/internal/xarena"
 )
 
 // nameLabel is the Prometheus metric name label. It is the metric's name, not one of its
@@ -52,8 +53,8 @@ func (o *Options) setDefaults() {
 // state. It is not safe for concurrent use; pool one per in-flight request.
 type Converter struct {
 	batch metric.Metrics
-	attrs arena[signal.KeyValue]
-	names arena[byte]
+	attrs xarena.Arena[signal.KeyValue]
+	names xarena.Arena[byte]
 }
 
 // Convert builds a metrics batch from the request's timeseries.
@@ -66,8 +67,8 @@ func (c *Converter) Convert(tss []prompb.TimeSeries, o Options) (_ *metric.Metri
 	cutoff := o.Now.Add(-o.TimeThreshold).UnixNano()
 
 	c.batch.Reset()
-	c.attrs.reset()
-	c.names.reset()
+	c.attrs.Reset()
+	c.names.Reset()
 
 	rm := c.batch.AddResource()
 	rm.Resource = o.Resource
@@ -147,7 +148,7 @@ func (c *Converter) addMetric(sm *metric.ScopeMetrics, name []byte) *metric.Metr
 // labelAttrs converts the series' labels (all but __name__) into one sorted attribute set shared
 // by every point of the series.
 func (c *Converter) labelAttrs(labels []prompb.Label) signal.Attributes {
-	kvs := c.attrs.alloc(len(labels))
+	kvs := c.attrs.Alloc(len(labels))
 	for _, l := range labels {
 		if bytes.Equal(l.Name, nameLabel) {
 			continue
@@ -159,7 +160,7 @@ func (c *Converter) labelAttrs(labels []prompb.Label) signal.Attributes {
 
 // withLabel returns attrs plus one string label, re-sorted.
 func (c *Converter) withLabel(attrs signal.Attributes, key, value []byte) signal.Attributes {
-	kvs := c.attrs.alloc(len(attrs) + 1)
+	kvs := c.attrs.Alloc(len(attrs) + 1)
 	kvs = append(kvs, attrs...)
 	kvs = append(kvs, signal.KeyValue{Key: key, Value: signal.StringValue(value)})
 	return signal.NewAttributes(kvs...)
@@ -167,7 +168,7 @@ func (c *Converter) withLabel(attrs signal.Attributes, key, value []byte) signal
 
 // suffixed returns name+suffix, carved from the converter's name arena.
 func (c *Converter) suffixed(name []byte, suffix string) []byte {
-	return c.names.concat(name, []byte(suffix))
+	return c.names.Concat(name, []byte(suffix))
 }
 
 func metricName(labels []prompb.Label) ([]byte, bool) {

--- a/internal/xarena/arena.go
+++ b/internal/xarena/arena.go
@@ -1,19 +1,20 @@
-package promrw
+// Package xarena provides a chunked, resettable allocator for the zero-copy ingest converters.
+package xarena
 
-// arenaChunk is the element count a fresh arena chunk is sized to.
-const arenaChunk = 512
+// Chunk is the element count a fresh arena chunk is sized to.
+const Chunk = 512
 
-// arena hands out slices carved from chunks it retains across [arena.reset], so a steady-state
+// Arena hands out slices carved from chunks it retains across [Arena.Reset], so a steady-state
 // converter allocates nothing. Chunks are never reallocated in place, so a slice handed out stays
 // valid until the reset that recycles it — unlike appending to one growing slice, which would
 // invalidate every slice handed out before a growth.
-type arena[T any] struct {
+type Arena[T any] struct {
 	chunks [][]T
 	cur    int
 }
 
-// alloc returns a zero-length slice with capacity n carved from the current chunk.
-func (a *arena[T]) alloc(n int) []T {
+// Alloc returns a zero-length slice with capacity n carved from the current chunk.
+func (a *Arena[T]) Alloc(n int) []T {
 	if n == 0 {
 		return nil
 	}
@@ -28,28 +29,28 @@ func (a *arena[T]) alloc(n int) []T {
 		a.cur++
 	}
 
-	c := make([]T, n, max(n, arenaChunk))
+	c := make([]T, n, max(n, Chunk))
 	a.chunks = append(a.chunks, c)
 	a.cur = len(a.chunks) - 1
 	return c[:0:n]
 }
 
-// reset makes every chunk available again. Slices handed out before it must not be used after.
-func (a *arena[T]) reset() {
+// Reset makes every chunk available again. Slices handed out before it must not be used after.
+func (a *Arena[T]) Reset() {
 	for i := range a.chunks {
 		a.chunks[i] = a.chunks[i][:0]
 	}
 	a.cur = 0
 }
 
-// concat returns the concatenation of parts, carved from the arena.
-func (a *arena[T]) concat(parts ...[]T) []T {
+// Concat returns the concatenation of parts, carved from the arena.
+func (a *Arena[T]) Concat(parts ...[]T) []T {
 	var n int
 	for _, p := range parts {
 		n += len(p)
 	}
 
-	out := a.alloc(n)
+	out := a.Alloc(n)
 	for _, p := range parts {
 		out = append(out, p...)
 	}


### PR DESCRIPTION
Part 2 of #1254. Stacked on #1255 — review that first; this PR's diff is only the OTLP work.

Decodes all four OTLP signals straight into the engine's ingest models, and serves them from odbingest over both OTLP transports. With this, odbingest can stand in for the collector gateway it exists to replace.

## Results

Per request, against the `receiver -> pdata -> pdataconv` path:

| Signal | Direct | Pdata | Batch |
|---|---|---|---|
| Logs | 197us, 12 allocs | 790us, 17039 allocs | 1000 records |
| Traces | 221us, 12 allocs | 943us, 16035 allocs | 1000 spans |
| Metrics | 614us, 52 allocs | 3787us, 47046 allocs | 500 gauges + 500 histograms |
| Profiles | 83us, 12 allocs | 242us, 7902 allocs | 1000 samples |

Every decoder's output is asserted byte-identical to the pdata path, which is what keeps two ingest paths for the same request from diverging. Fuzzed 38M-65M executions per signal.

## The bug this design is shaped around

**pdata's protobuf marshaler emits fields in descending field-number order.** Protobuf guarantees no ordering and producers genuinely differ — pdata descending, a hand-rolled encoder ascending.

The first logs decoder consumed the `scope` submessage as it walked, which wiped the `schema_url` it had already read, because `schema_url` (3) arrives *before* `scope` (1). Silent: one field missing from every scope, everything else correct.

For metrics it would have been worse. A metric's name and unit are siblings of the oneof arm holding its points, so a decoder that emitted series while walking would produce correctly-shaped, correctly-valued series under an **empty name** — data that looks healthy until someone queries for it.

So no submessage is decoded during a walk when a sibling field feeds the same struct; it is collected and decoded after. Each signal has an ordering test that encodes the identical message ascending and descending and requires both to decode the same.

## Transports

**OTLP/HTTP** at the spec's paths, with transparent gzip under a decoded-size cap set independently of the body limit (gzip's ratio is unbounded and the sender picks it — same class of bug as the snappy bomb in #1255).

**OTLP/gRPC** on 4317, which is what the SDKs and the collector's own exporter target by default. The services are registered by hand rather than from generated stubs: a generated server unmarshals into a pdata struct, which is the allocation this package exists to avoid. A raw codec hands the bytes to the same converters the HTTP endpoints use, so both transports share one decode path. gRPC frees its buffer when `Unmarshal` returns, so the bytes are copied into a pooled one — the same single copy the HTTP path already pays reading a body. Tested against the generated `plogotlp`/`ptraceotlp`/`pmetricotlp` clients over a real connection, so the hand-registered services are checked against the protocol rather than against our own encoder.

Rejections answer success-with-partial-success, not an error: the rejected items are ones no retry can fix, so an error status would make a client resend them forever. A routing failure still answers 5xx / `Unavailable`, because that write may not have landed.

## Two findings in pdata's profiles support

1. **Profiles carries a second indirection that is not in the OTLP proto you would look at.** `pprofile` marshals via the *slim* proto, whose `common.proto` adds `KeyValue.key_strindex` and `AnyValue.string_value_strindex`; on marshal it rewrites every resource/scope attribute into string-table indices. A decoder reading only `KeyValue.key` gets empty resource attributes from every real profiles request.

2. **A bug we deliberately do not reproduce.** `resolveKeyValueReferences` guards on `kv.KeyStrindex >= 0`, which is always true for the zero value — so a producer sending an inline `key` with no `key_strindex` has that key silently overwritten with `StringTable[0]` (the empty sentinel). Our decoder resolves only when the field is actually on the wire. Parity is unaffected because pdata always emits the strindex form, but a non-pdata producer would get correct keys from oteldb and empty ones from pdata. Worth filing upstream.

## Depends on

oteldb/storage#346 and its stacked follow-up (record framing + `Router.WriteLogs`/`WriteTraces`/`WriteProfiles`). `go.mod` pins a pseudo-version until those merge and tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)