### PR TITLE
feat(storagebackend): expose cluster private_backend

### DIFF
--- a/cmd/oteldb/storage_config_test.go
+++ b/cmd/oteldb/storage_config_test.go
@@ -26,6 +26,7 @@ storage:
     rf: 3
     shards_per_tenant: 8
     root: /oteldb
+    private_backend: true
 `
 	f, err := os.CreateTemp("", "oteldb.yml")
 	require.NoError(t, err)
@@ -46,6 +47,7 @@ storage:
 	require.Equal(t, 3, cfg.Storage.Cluster.RF)
 	require.Equal(t, 8, cfg.Storage.Cluster.ShardsPerTenant)
 	require.Equal(t, "/oteldb", cfg.Storage.Cluster.Root)
+	require.True(t, cfg.Storage.Cluster.PrivateBackend)
 }
 
 // TestStoragePolicyConfigYAML checks the policy block parses from the documented YAML shape. What

--- a/dev/local/storage-cluster/README.md
+++ b/dev/local/storage-cluster/README.md
@@ -64,7 +64,17 @@ storage:
     port: 7946   # replication server port; address is <hostname>:<port>
     rf: 2        # replicas per write
     root: /oteldb
+    private_backend: true   # each node's disk is its own; parts replicate node-to-node
 ```
+
+`private_backend` picks the storage model, and it is not inferable from the backend type — an S3
+bucket shared by every node and a per-node local disk are both legal backends. Here each node has
+its own `/data` volume that peers cannot read, so it must be `true`: flushed parts are mirrored over
+the cluster's parts endpoints (`partsync`) instead of being exchanged through a shared store. Left
+at the default `false` writes still reach the replicas, but anything that reads another node's
+flushed parts breaks — rebalance handoffs, a newly-promoted owner, and backfill before compaction
+would all have no source. A deployment where every node points at the same object store wants
+`false`.
 
 To scale out, add another `oteldb-N` service (with its own `hostname` and data volume) pointing at
 the same etcd — it joins the ring and takes ownership of a share of the data automatically.

--- a/dev/local/storage-cluster/oteldb.yml
+++ b/dev/local/storage-cluster/oteldb.yml
@@ -12,3 +12,6 @@ storage:
     # Replication factor: each write is stored on 2 of the 3 nodes (tolerates one node down).
     rf: 2
     root: /oteldb
+    # Each node's file backend is its own volume, not a store the peers can read, so flushed parts
+    # must be replicated node-to-node (partsync) instead of exchanged through the backend.
+    private_backend: true

--- a/internal/storagebackend/config.go
+++ b/internal/storagebackend/config.go
@@ -86,6 +86,13 @@ type ClusterConfig struct {
 	ShardsPerTenant int `json:"shards_per_tenant" yaml:"shards_per_tenant"`
 	// Root is the etcd key prefix for this cluster's state. Empty ⇒ "/oteldb".
 	Root string `json:"root" yaml:"root"`
+	// PrivateBackend declares this node's backend private to it (a local disk, not a shared object
+	// store), so peers cannot read the parts it flushes. The cluster then replicates flushed parts
+	// node-to-node: replicas mirror their owner's objects over the parts endpoints instead of
+	// loading them from a shared store, and an owner backfills from its peers before compacting.
+	// False (the default) keeps the shared-store model. Not inferable from the backend type — an
+	// S3 bucket shared by every node and a per-node local disk are both legal backends.
+	PrivateBackend bool `json:"private_backend" yaml:"private_backend"`
 }
 
 // S3Config configures the embedded storage engine's "s3" backend: an S3-compatible object

--- a/internal/storagebackend/open.go
+++ b/internal/storagebackend/open.go
@@ -156,6 +156,7 @@ func clusterOption(cfg *ClusterConfig, lg *zap.Logger) (storage.Option, error) {
 		zap.String("addr", addr),
 		zap.Int("rf", cfg.RF),
 		zap.Int("shards_per_tenant", cfg.ShardsPerTenant),
+		zap.Bool("private_backend", cfg.PrivateBackend),
 	)
 	return storage.WithCluster(&cluster.Config{
 		Etcd:            cfg.Etcd,
@@ -163,6 +164,7 @@ func clusterOption(cfg *ClusterConfig, lg *zap.Logger) (storage.Option, error) {
 		RF:              cfg.RF,
 		ShardsPerTenant: cfg.ShardsPerTenant,
 		Root:            cfg.Root,
+		PrivateBackend:  cfg.PrivateBackend,
 	}), nil
 }
 

--- a/internal/storagebackend/open_internal_test.go
+++ b/internal/storagebackend/open_internal_test.go
@@ -43,7 +43,7 @@ func TestClusterOption(t *testing.T) {
 	t.Run("Explicit", func(t *testing.T) {
 		opt, err := clusterOption(&ClusterConfig{
 			Etcd: []string{"http://etcd:2379"}, ID: "node-1", Zone: "z1",
-			Addr: "node-1:9000", RF: 2, ShardsPerTenant: 4, Root: "/x",
+			Addr: "node-1:9000", RF: 2, ShardsPerTenant: 4, Root: "/x", PrivateBackend: true,
 		}, lg)
 		require.NoError(t, err)
 		o := applyOption(t, opt)
@@ -55,6 +55,14 @@ func TestClusterOption(t *testing.T) {
 		require.Equal(t, 2, o.Cluster.RF)
 		require.Equal(t, 4, o.Cluster.ShardsPerTenant)
 		require.Equal(t, "/x", o.Cluster.Root)
+		require.True(t, o.Cluster.PrivateBackend)
+	})
+
+	t.Run("PrivateBackendDefaultsToShared", func(t *testing.T) {
+		opt, err := clusterOption(&ClusterConfig{Etcd: []string{"e"}, ID: "n1"}, lg)
+		require.NoError(t, err)
+		o := applyOption(t, opt)
+		require.False(t, o.Cluster.PrivateBackend, "unset keeps the shared-store model")
 	})
 
 	t.Run("AddrDerivedFromID", func(t *testing.T) {


### PR DESCRIPTION
Fixes #1262.

`ClusterConfig` mapped six of `cluster.Config`'s seven fields — `PrivateBackend` was missing and
`clusterOption` never set it, so a shared-nothing deployment ran under the shared-store assumption
and `cluster/partsync` never replicated flushed parts node-to-node. Writes still reached every
replica through the primary-authoritative path, which is why the demo and the Cluster E2E job pass;
what did not work was anything reading another node's flushed parts (rebalance handoff, a
newly-promoted owner, backfill before compaction).

- `private_backend` added to `ClusterConfig` (json+yaml) and passed through `clusterOption`, plus
  logged in the "Joining storage cluster" line.
- Set to `true` in `dev/local/storage-cluster/oteldb.yml` — three nodes, `backend: file`, per-node
  `/data` volume, no shared store — with a README note on the choice, since the flag is not
  inferable from the backend type.
- Unit coverage in `open_internal_test.go` (mapping + the shared-store default) and in the
  `cmd/oteldb` YAML shape test.

No dependency change: `go.mod` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)