### PR TITLE
refactor(helm): assorted chart gaps (resources sizing, non-root, s3, self-metrics)

### DIFF
--- a/helm/oteldb/Chart.yaml
+++ b/helm/oteldb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.0
+version: 0.23.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/oteldb/templates/NOTES.txt
+++ b/helm/oteldb/templates/NOTES.txt
@@ -1,3 +1,20 @@
+{{- $memLimit := dig "limits" "memory" "" (.Values.resources | default dict) }}
+{{- range .Values.env }}
+{{- if eq .name "GOMEMLIMIT" }}
+{{- $memLimit = .value }}
+{{- end }}
+{{- end }}
+{{- if not $memLimit }}
+
+WARNING: no resources.limits.memory is set.
+
+  The embedded storage engine sizes its read cache, decode cache and decode-admission
+  budget from the Go memory limit, which is derived from the cgroup memory limit at
+  startup. Without one the caches collapse to their floors and the admission budget is
+  sized against whole-host memory this pod may not get. Set resources.limits.memory (or
+  an explicit GOMEMLIMIT in `env`).
+{{- end }}
+
 Set up datasources:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}

--- a/helm/oteldb/templates/_helpers.tpl
+++ b/helm/oteldb/templates/_helpers.tpl
@@ -51,6 +51,73 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Local state directory backed by the persistent volume: the data directory for the "file"
+backend (parts + WAL), the write-ahead log directory for the stateless "s3" backend.
+Empty when the backend keeps nothing locally, in which case no volume is mounted.
+*/}}
+{{- define "oteldb.dataDir" -}}
+{{- $storage := .Values.config.storage | default dict }}
+{{- if eq (default "memory" $storage.backend) "s3" }}
+{{- $storage.wal_dir | default "" }}
+{{- else }}
+{{- $storage.dir | default "" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Whether a local volume is mounted at all: only when persistence is meaningful for the
+selected backend (see oteldb.dataDir).
+*/}}
+{{- define "oteldb.persistent" -}}
+{{- if include "oteldb.dataDir" . }}true{{- end }}
+{{- end }}
+
+{{/*
+Whether oteldb serves its own metrics in Prometheus format, i.e. the effective
+OTEL_METRICS_EXPORTER (which .Values.env may override) includes the prometheus exporter.
+*/}}
+{{- define "oteldb.metricsEnabled" -}}
+{{- if .Values.telemetry.metrics.enabled }}
+{{- $exporters := .Values.telemetry.metrics.exporters | toString }}
+{{- range .Values.env }}
+{{- if eq .name "OTEL_METRICS_EXPORTER" }}
+{{- $exporters = .value | toString }}
+{{- end }}
+{{- end }}
+{{- if has "prometheus" (splitList "," ($exporters | nospace)) }}true{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container environment: self-telemetry defaults first, then .Values.env. Defaults whose
+name is already set in .Values.env are dropped, so user values always win.
+*/}}
+{{- define "oteldb.env" -}}
+{{- $defaults := list }}
+{{- if .Values.telemetry.metrics.enabled }}
+{{- $port := .Values.telemetry.metrics.port | int }}
+{{- $defaults = list
+  (dict "name" "OTEL_METRICS_EXPORTER" "value" (.Values.telemetry.metrics.exporters | toString))
+  (dict "name" "OTEL_EXPORTER_PROMETHEUS_HOST" "value" "0.0.0.0")
+  (dict "name" "OTEL_EXPORTER_PROMETHEUS_PORT" "value" (printf "%d" $port)) }}
+{{- end }}
+{{- $taken := dict }}
+{{- range .Values.env }}
+{{- $_ := set $taken .name true }}
+{{- end }}
+{{- $env := list }}
+{{- range $defaults }}
+{{- if not (hasKey $taken .name) }}
+{{- $env = append $env . }}
+{{- end }}
+{{- end }}
+{{- range .Values.env }}
+{{- $env = append $env . }}
+{{- end }}
+{{- toYaml $env }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "oteldb.serviceAccountName" -}}

--- a/helm/oteldb/templates/configmap.yaml
+++ b/helm/oteldb/templates/configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "oteldb.labels" . | nindent 4 }}
 data:
   config.yml: |-
-    {{ .Values.config | toYaml | nindent 4 }}
+    {{- .Values.config | toYaml | nindent 4 }}

--- a/helm/oteldb/templates/service.yaml
+++ b/helm/oteldb/templates/service.yaml
@@ -14,7 +14,13 @@ spec:
     - port: 8090
       protocol: TCP
       targetPort: 8090
+      name: admin
+    {{- if include "oteldb.metricsEnabled" . }}
+    - port: {{ .Values.telemetry.metrics.port }}
+      protocol: TCP
+      targetPort: metrics
       name: metrics
+    {{- end }}
     - port: 3200
       protocol: TCP
       targetPort: 3200

--- a/helm/oteldb/templates/servicemonitor.yaml
+++ b/helm/oteldb/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.telemetry.serviceMonitor.enabled }}
+{{- if not (include "oteldb.metricsEnabled" .) }}
+{{- fail "telemetry.serviceMonitor.enabled requires the prometheus exporter (telemetry.metrics)" }}
+{{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "oteldb.fullname" . }}
+  labels:
+    {{- include "oteldb.labels" . | nindent 4 }}
+    {{- with .Values.telemetry.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.telemetry.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "oteldb.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: {{ .Values.telemetry.serviceMonitor.path }}
+      honorLabels: {{ .Values.telemetry.serviceMonitor.honorLabels }}
+      {{- with .Values.telemetry.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.telemetry.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.telemetry.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.telemetry.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/oteldb/templates/statefulset.yaml
+++ b/helm/oteldb/templates/statefulset.yaml
@@ -1,3 +1,8 @@
+{{- $dataDir := include "oteldb.dataDir" . }}
+{{- if and (eq (default "memory" .Values.config.storage.backend) "file") (not $dataDir) }}
+{{- fail "config.storage.dir is required for the file backend" }}
+{{- end }}
+{{- $persistent := and .Values.persistence.enabled $dataDir }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -5,7 +10,8 @@ metadata:
   labels:
     {{- include "oteldb.labels" . | nindent 4 }}
 spec:
-  # Single node only: the embedded storage engine here is not clustered.
+  # Single node only: the embedded storage engine here is not clustered. Clustered,
+  # multi-replica oteldb is deployed by the operator (github.com/oteldb/operator).
   replicas: 1
   serviceName: {{ include "oteldb.fullname" . }}
   selector:
@@ -26,15 +32,19 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "oteldb.serviceAccountName" . }}
+      # Flushing the head and the WAL on shutdown scales with the data directory.
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
         - name: config
           configMap:
             name: {{ include "oteldb.fullname" . }}-cfg
-        {{- if not .Values.persistence.enabled }}
+        {{- if not $persistent }}
+        {{- if $dataDir }}
         - name: data
           emptyDir: {}
+        {{- end }}
         {{- else if .Values.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:
@@ -50,28 +60,33 @@ spec:
             httpGet:
               path: /liveness
               port: health-check
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /readiness
               port: health-check
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          # Replaying the WAL of a large data directory can take minutes; give startup its
+          # own budget instead of the (much tighter) liveness one.
           startupProbe:
             httpGet:
               path: /startup
               port: health-check
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           volumeMounts:
             - mountPath: /etc/otel/
               name: config
-            - mountPath: {{ .Values.config.storage.dir }}
+            {{- if $dataDir }}
+            - mountPath: {{ $dataDir }}
               name: data
+            {{- end }}
           args:
             - --config=/etc/otel/config.yml
           {{- with .Values.envFrom }}
           envFrom: {{ toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- if .Values.env }}
-            {{- toYaml .Values.env | nindent 12 }}
-            {{- end }}
+            {{- include "oteldb.env" . | nindent 12 }}
           ports:
             - containerPort: 19291
               protocol: TCP
@@ -94,6 +109,14 @@ spec:
             - containerPort: 4318
               protocol: TCP
               name: otlp-http
+            - containerPort: 8090
+              protocol: TCP
+              name: admin
+            {{- if include "oteldb.metricsEnabled" . }}
+            - containerPort: {{ .Values.telemetry.metrics.port }}
+              protocol: TCP
+              name: metrics
+            {{- end }}
             - containerPort: 13133
               protocol: TCP
               name: health-check
@@ -111,7 +134,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  {{- if and $persistent (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/helm/oteldb/values.yaml
+++ b/helm/oteldb/values.yaml
@@ -1,11 +1,10 @@
 # Default values for oteldb.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-# oteldb runs as a single node backed by the embedded github.com/oteldb/storage
-# engine with on-disk persistence. Scaling beyond a single replica requires the
-# clustered storage backend and is intentionally not supported by this chart yet.
-replicaCount: 1
+#
+# oteldb runs here as a single node backed by the embedded github.com/oteldb/storage
+# engine with on-disk persistence. Clustered, multi-replica deployments are handled by
+# the oteldb operator (https://github.com/oteldb/operator), not by this chart.
 
 image:
   repository: ghcr.io/oteldb/oteldb
@@ -28,22 +27,32 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+# Runs as the distroless "nonroot" user (65532). fsGroup makes the data volume
+# group-writable for it, which a non-root process needs to write parts and the WAL.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  # Only relabel the volume when its root does not already match fsGroup, so a large
+  # data directory does not stall pod startup on every restart.
+  fsGroupChangePolicy: OnRootMismatch
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP
 
-# Persistence for the embedded storage engine's data directory (config.storage.dir).
-# A PersistentVolumeClaim is created from a volumeClaimTemplate on the StatefulSet.
+# Persistence for the embedded storage engine's local state. For the "file" backend this
+# is the data directory (config.storage.dir: parts and WAL). For the "s3" backend the
+# durable tier lives in the object store and only the write-ahead log is local, so the
+# volume is mounted at config.storage.wal_dir instead; with no wal_dir set, the s3 backend
+# is stateless and no volume is mounted at all.
 persistence:
   enabled: true
   # Use an existing PersistentVolumeClaim instead of creating one. When set, size,
@@ -73,18 +82,62 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+# A memory limit is not optional here: the embedded storage engine sizes its read cache,
+# decode cache and decode-admission budget from the Go memory limit, which automemlimit
+# derives from the cgroup limit at startup. Without limits.memory the caches collapse to
+# their floors while the admission budget is sized against whole-host RAM the pod may not
+# get. Raise these together with the expected ingest/query volume.
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+  limits:
+    # No CPU limit on purpose: throttling a query engine costs more than it saves.
+    memory: 4Gi
 
+# Flushing the head and the WAL on shutdown, and replaying the WAL on startup, both scale
+# with the data directory, so both budgets are generous by default.
+terminationGracePeriodSeconds: 120
+
+# Startup gets failureThreshold * periodSeconds (5m by default) to replay the WAL before
+# the pod is restarted.
+startupProbe:
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 30
+livenessProbe:
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+readinessProbe:
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# Self-observability: oteldb's own telemetry (engine part counts, merge duration, cache
+# hit rates, decode-admission waits, HTTP/gRPC metrics).
+telemetry:
+  metrics:
+    # Serve oteldb's own metrics in Prometheus format on `port`.
+    enabled: true
+    port: 9464
+    # OTEL_METRICS_EXPORTER value. Comma-separated; e.g. "prometheus,otlp" to also push
+    # to a collector (configure the endpoint through `env`).
+    exporters: prometheus
+  # Prometheus Operator ServiceMonitor scraping the port above.
+  serviceMonitor:
+    enabled: false
+    # Extra labels, e.g. the `release` label your Prometheus selects on.
+    labels: {}
+    annotations: {}
+    interval: ""
+    scrapeTimeout: ""
+    path: /metrics
+    honorLabels: false
+    relabelings: []
+    metricRelabelings: []
+
+# Extra environment variables. Anything set here wins over the telemetry defaults above.
 env:
   - name: OTEL_LOG_LEVEL
     value: "DEBUG"
@@ -99,6 +152,20 @@ config:
   profiles_backend: storage
   # Embedded storage engine configuration. The "file" backend persists parts and the
   # write-ahead log under dir, which is backed by the persistent volume above.
+  #
+  # For the "s3" backend, set backend: s3, an s3 block, and a wal_dir (the local WAL is
+  # the only thing keeping unflushed head data across a restart):
+  #
+  #   storage:
+  #     backend: s3
+  #     wal_dir: /var/lib/oteldb/wal
+  #     s3:
+  #       bucket: oteldb
+  #       endpoint: http://minio:9000
+  #       force_path_style: true
+  #
+  # Credentials are better left out of the config: the AWS default chain is used when
+  # access_key_id/secret_access_key are empty, so pass them through `envFrom` a Secret.
   storage:
     backend: file
     dir: /var/lib/oteldb
@@ -115,6 +182,9 @@ config:
     bind: 0.0.0.0:4040
   health_check:
     bind: 0.0.0.0:13133
+  # Admin API and UI.
+  admin:
+    bind: 0.0.0.0:8090
 
 nodeSelector: {}
 


### PR DESCRIPTION
Fixes #1196.

## Scope: what this chart still owns

`helm/oteldb` is the **single-node** deployment. Clustered oteldb (etcd membership, HRW
ring, peer replication, one PVC per pod) belongs to
[`oteldb/operator`](https://github.com/oteldb/operator), which already models it as a
StatefulSet + headless peer Service + client Service. [`oteldb/charts`](https://github.com/oteldb/charts)
is only a publishing repo — `index.yaml` plus packaged `.tgz` snapshots of this directory
per release — so it is not a place to author chart changes. Nothing here grows toward
clustering; `replicaCount` is removed rather than honoured, and the hardcoded `replicas: 1`
now points at the operator in a comment.

## Changes

- **Memory sizing.** `internal/storagebackend/open.go` sizes the read cache
  (`defaultCacheBytes`, 1/16, floor 128 MiB), the decode cache (`budgetedCacheBytes`, 1/32,
  64–512 MiB) and the decode-admission budget (`defaultDecodeMemoryBytes`,
  `detected/2 − caches`) off `detectMemoryBytes()`, which prefers the Go memory limit that
  `go-faster/sdk/app` sets from the cgroup via automemlimit. With no `limits.memory` the
  read cache collapses to its 128 MiB floor and the admission budget is sized against
  whole-host RAM the pod may not get. **Chosen fix: ship default `resources`**
  (`requests: 500m / 2Gi`, `limits: memory 4Gi`, no CPU limit) — this is the only option
  that also gives the scheduler something to work with, whereas a bare `GOMEMLIMIT` env
  fixes the sizing but still lets the kernel OOM-kill an unbounded pod, and a NOTES-only
  warning fixes nothing by default. The NOTES warning is kept as a backstop for anyone who
  nulls the block (note that `resources: {}` in a values file *merges* with the defaults;
  clearing requires an explicit `null`), and it is suppressed when `env` carries an
  explicit `GOMEMLIMIT`.
- **`replicaCount`** removed — it was declared in values and never read.
- **Shutdown/startup budgets.** `terminationGracePeriodSeconds: 120` for the head+WAL
  flush, and a tunable `startupProbe` with `failureThreshold: 30` (~5m for WAL replay),
  matching the operator. Liveness/readiness periods are now values too.
- **Non-root by default.** `runAsNonRoot`, uid/gid 65532 (the distroless nonroot user),
  `fsGroup: 65532` with `fsGroupChangePolicy: OnRootMismatch` so a large data dir is not
  relabelled on every restart, plus `allowPrivilegeEscalation: false` and dropped
  capabilities.
- **s3 backend reachable.** The data volume now mounts at `storage.wal_dir` when
  `storage.backend: s3` (the local WAL is what keeps unflushed head data across a restart),
  and no volume/PVC is created at all when an s3 install sets no `wal_dir`. The file
  backend fails rendering when `storage.dir` is empty instead of producing a broken mount.
- **Port 8090 renamed `metrics` → `admin`** (it is `admin.bind`, not a metrics endpoint),
  and `config.admin.bind` is now explicit in values.
- **Self-telemetry.** New `telemetry.metrics` block wires `OTEL_METRICS_EXPORTER`,
  `OTEL_EXPORTER_PROMETHEUS_HOST/PORT` (9464 by default) and exposes a `metrics` port, plus
  an optional `telemetry.serviceMonitor`. Env defaults are dropped whenever `env` sets the
  same name, so existing values keep winning; the port and ServiceMonitor only appear when
  the effective exporter list actually includes `prometheus`.
- **configmap `nindent`** stray-whitespace fix.

Chart version bumped to 0.23.0.

## Upgrade notes

Existing releases move to a non-root pod: the data volume is relabelled to gid 65532 on
first start. Defaults also now cap memory at 4Gi — installs that were running larger should
raise `resources` explicitly.

## Verification

`helm lint helm/oteldb` clean, and `helm template` renders for: defaults, `.k8s/values.yml`
(the repo's own prod values), s3 + wal_dir + ServiceMonitor + custom resources, s3 without
`wal_dir` (no volume), `persistence.enabled=false`, and `existingClaim` + ingress. NOTES
warning verified with `resources.limits=null` and its suppression with a `GOMEMLIMIT` env.

## Not done here

- Multi-replica / clustered support — operator's job.
- Structured ClickHouse DSN values — #827.
- Out of scope but worth a separate look: the operator hardcodes `portSelfMetric = 8090`
  and sets `OTEL_EXPORTER_PROMETHEUS_PORT=8090`, which collides with oteldb's admin API on
  the same port; and `.k8s/values.yml` sets `GOMEMLIMIT=4GiB` under a 2Gi memory limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)