### PR TITLE
fix(k8s): let automemlimit derive GOMEMLIMIT from the cgroup

### DIFF
--- a/.k8s/values.yml
+++ b/.k8s/values.yml
@@ -1,6 +1,6 @@
 env:
-  - name: GOMEMLIMIT
-    value: "4GiB"
+  # GOMEMLIMIT is intentionally unset: automemlimit (via go-faster/sdk/app) derives it from the
+  # cgroup limit below (0.9 * 2Gi = 1.8GiB) and skips when the env var is set.
   - name: GOMAXPROCS
     value: "6"
   - name: OTEL_METRICS_EXPORTER


### PR DESCRIPTION
Fixes #1269.

`.k8s/values.yml` pinned `GOMEMLIMIT=4GiB` against a 2Gi pod memory limit. A soft limit above the
cgroup hard limit can never do its job: the pacer grows the heap toward 4 GiB and the OOM killer
fires at 2 GiB first.

It also mis-sizes the embedded storage backend. `internal/storagebackend/open.go` derives all three
memory knobs from `detectMemoryBytes()`, which returns the Go memory limit when one is set:

| knob | formula | at 4GiB | at 1.8GiB |
|---|---|---|---|
| read cache | limit/16, floor 128 MiB | 256 MiB | 128 MiB |
| decode cache | limit/32, clamped [64, 512] MiB | 128 MiB | 64 MiB |
| decode admission | limit/2 - caches, floor 64 MiB | 1664 MiB | 730 MiB |
| total planned residency | | **2048 MiB (= the whole pod)** | **922 MiB (~45%)** |

The decode-admission budget is the load-bearing one: at 4GiB it admits query concurrency worth the
pod's entire hard limit before any resident baseline (head, WAL, ingest) or per-query eval
transients, so the pod OOMs instead of applying backpressure — the failure #1124 added it to
prevent.

### The corrected number

**1.8 GiB, and the right way to get it is to not set the variable.** `automemlimit` is already
wired into this binary: `cmd/oteldb/main.go` runs under `go-faster/sdk/app.Run`, which calls
`memlimit.SetGoMemLimitWithOpts` at startup and takes 0.9 x the cgroup limit (0.9 x 2Gi = 1.8 GiB;
the 10% is headroom for allocations the Go runtime does not account). It explicitly skips when
`GOMEMLIMIT` is present in the environment, so the hardcoded value was the only reason the pod did
not already get the right one. Removing it also keeps the limit correct if `resources.limits.memory`
is ever changed, instead of silently re-introducing the same skew.

~45% of the pod limit for caches plus admission is the right shape here because
`defaultDecodeMemoryBytes` deliberately meters only half the budget and subtracts the caches from
that half — the other half is headroom for everything the budget does not meter.

### Scope

`helm/oteldb/` is untouched on purpose; #1265 is in flight there. Note `GOMAXPROCS=6` against a
`cpu: "2"` limit in the same file has the same shape of problem (sdk wires `automaxprocs` too), but
it is not a correctness/OOM issue so it is left alone here.

### Verification

`go build ./cmd/oteldb` and `go test ./internal/storagebackend/...` pass; the change is
deployment-manifest only.
