### PR TITLE
build(release): ship odbingest in release artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,6 +84,21 @@ builds:
     flags:
       - -trimpath
 
+  - id: odbingest
+    binary: "odbingest{{ .Ext }}"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - riscv64
+    main: ./cmd/odbingest
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    flags:
+      - -trimpath
+
   - id: odbagent
     binary: "odbagent{{ .Ext }}"
     env:
@@ -352,6 +367,7 @@ nfpms:
       - odbbackup
       - odbrestore
       - odbmigrate
+      - odbingest
       - odbagent
     homepage: https://github.com/oteldb/oteldb
     maintainer: Aleksandr Razumov <ernado@go-faster.org>

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
     cmds:
       - |
         set -e
-        for target in oteldb odbbackup odbrestore odbmigrate otelproxy chotel odbagent; do
+        for target in oteldb odbbackup odbrestore odbmigrate odbingest otelproxy chotel odbagent; do
           go build -trimpath -buildvcs=false -v -o ./$target ./cmd/$target
         done
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=alpine:latest
 
 FROM golang:${GO_VERSION} AS builder
 ARG GOPROXY=https://proxy.golang.org,direct
-ARG TARGETS="oteldb odbbackup odbrestore odbmigrate"
+ARG TARGETS="oteldb odbbackup odbrestore odbmigrate odbingest"
 
 WORKDIR /app
 

--- a/dev/deploy/deploy.Dockerfile
+++ b/dev/deploy/deploy.Dockerfile
@@ -5,5 +5,6 @@ ADD oteldb     /usr/local/bin/oteldb
 ADD odbbackup  /usr/local/bin/odbbackup
 ADD odbrestore /usr/local/bin/odbrestore
 ADD odbmigrate /usr/local/bin/odbmigrate
+ADD odbingest  /usr/local/bin/odbingest
 
 ENTRYPOINT ["oteldb"]

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -6,5 +6,6 @@ COPY $TARGETPLATFORM/oteldb     /usr/local/bin/oteldb
 COPY $TARGETPLATFORM/odbbackup  /usr/local/bin/odbbackup
 COPY $TARGETPLATFORM/odbrestore /usr/local/bin/odbrestore
 COPY $TARGETPLATFORM/odbmigrate /usr/local/bin/odbmigrate
+COPY $TARGETPLATFORM/odbingest  /usr/local/bin/odbingest
 
 ENTRYPOINT ["/usr/local/bin/oteldb"]


### PR DESCRIPTION
Fixes #1273. Unblocks oteldb/operator#14, whose `spec.ingest` role runs
`/usr/local/bin/odbingest` in a Deployment and currently cannot start on any published image.

## What changed

- `.goreleaser.yaml`: new `odbingest` build, identical to the neighbours — `CGO_ENABLED=0`,
  `-trimpath`, `mod_timestamp`, linux amd64/arm64/riscv64. No separate ldflags exist in this
  config, so there were none to copy.
- `.goreleaser.yaml`: added `odbingest` to the `oteldb` nfpm `ids:`, which enumerates binaries
  separately from `builds:`. Without this it would be absent from the apk/deb/rpm/archlinux
  packages. The single `archives:` entry has no `ids:` filter, so it picks up the new build
  automatically.
- `release.Dockerfile`: copy `odbingest` into `/usr/local/bin` next to the others. Same image,
  same layer convention — no new image and no new publishing path.
- `dev/deploy/deploy.Dockerfile` + `Taskfile.yml` `build-deploy`: same addition for the local
  `registry.localhost` deploy image, so an operator dev loop sees the same binary set.
- `dev/Dockerfile`: added to the default `TARGETS` so the compose-based dev images carry it too.

## Audit of `cmd/`

Already shipped: `oteldb`, `chotel`, `odbbackup`, `odbrestore`, `odbmigrate`, `odbagent`
(own image), `docker-logql` (own nfpm, installed as a Docker CLI plugin).

Was missing, now added: `odbingest` — a production server role, deployed by the operator.

Deliberately excluded, left excluded:

- `otelbench` — benchmarking suite, has its own `dev/otelbench.Dockerfile`.
- `oteldemo` — demo telemetry generator, dev/demo only.
- `otelproxy` — Grafana datasource proxy for testing; used from `dev/otelproxy/`.
- `ch2storagebackend` — one-shot chstorage-to-storagebackend migration tool.
- `logql-compliance-tester`, `promql-compliance-tester` — compliance harnesses run from
  `dev/local/ch-*-compliance`.

None of these is a server anyone deploys, so none belongs in the release image.

One inconsistency noted but not changed: `Taskfile.yml`'s `build-deploy` also compiles
`otelproxy`, which has no image target and no goreleaser build. Harmless, out of scope here.

## When #1266 lands

`cmd/odbselect` (stateless query node, draft PR #1266) does not exist on `main` and is not
touched here. It needs the identical treatment when it merges: an `odbselect` entry in
`builds:`, in the `oteldb` nfpm `ids:`, and a `COPY` line in `release.Dockerfile`.

## Verification

`go build ./cmd/...` — clean.

`goreleaser check` — config valid.

`goreleaser build --snapshot --clean --single-target --id odbingest --skip=before`:

```
  • building binaries
    • partial build       match=target=linux_amd64_v1
    • building            paths=cmd/odbingest binaries=odbingest{{ .Ext }} target=linux_amd64_v1
  • build succeeded after 9s
```

Then a real `docker build -f release.Dockerfile` over a goreleaser-shaped context
(`linux/amd64/<binary>`), and the binary is present and runs in the resulting image:

```
$ docker run --rm --entrypoint /bin/sh <image> -c 'ls -l /usr/local/bin && odbingest --help'
-rwxr-xr-x 1 root root  24924674 odbbackup
-rwxr-xr-x 1 root root  34132906 odbingest
-rwxr-xr-x 1 root root  24602090 odbmigrate
-rwxr-xr-x 1 root root  24984033 odbrestore
-rwxr-xr-x 1 root root 116473434 oteldb

Usage of /usr/local/bin/odbingest:
  -config string
        Path to config (defaults to odbingest.yml)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
