### PR TITLE
feat(storagebackend): expose erasure coding as a policy tier

### DIFF
--- a/docs/storage-integration.md
+++ b/docs/storage-integration.md
@@ -90,9 +90,10 @@ So the pushdown path is: `PushableMatchers` → `AggregateMetricsNamed` → `Mat
 
 - **Lossy precision:** expose `tenant.Precision{Tiers: []{After, Bits}}` (age-tiered lossy float
   compression) through oteldb's per-tenant resolver, alongside Downsample/Recompress.
-  **Implemented** in `cmd/oteldb/storage_policy.go` (`tenancyOption` → `storage.WithTenancy`):
+  **Implemented** in `internal/storagebackend/policy.go` (`tenancyOption` → `storage.WithTenancy`):
   the `storage.policy` config block exposes `precision[]{after,bits}`,
-  `downsample[]{after,interval,agg}`, `recompress{after,level}`, `retention{max_age,max_bytes}`
+  `downsample[]{after,interval,agg}`, `recompress{after,level}`, `ec{data,parity,after}`,
+  `retention{max_age,max_bytes}`
   and `limits{ingest_bytes_per_second,max_in_flight_bytes,max_series,max_series_soft,max_part_size,
   max_merge_part_size}`. `max_part_size` bounds a *flushed* part's uncompressed estimate;
   `max_merge_part_size` bounds a *merged* part's compressed size on disk, and left at zero is
@@ -100,6 +101,11 @@ So the pushdown path is: `PushableMatchers` → `AggregateMetricsNamed` → `Mat
   oteldb runs the embedded engine single-tenant, so a static `tenant.ResolverFunc` returns one
   policy for every tenant — retention is therefore one global window, not per-tenant.
   Both `retention.max_age` and `retention.max_bytes` are enforced by the library.
+  `ec` is an age tier like `recompress`, but for durability: cold parts are stored as `data`+`parity`
+  Reed-Solomon shards, one per cluster node, instead of RF full copies. It applies only under
+  `storage.cluster` with `private_backend` — on a shared object store the store owns durability and
+  the policy is inert (logged as a warning at startup). Owner count is exactly `data+parity`; the
+  replication factor is ignored under EC.
 - **Sampling weights:** honour `fetch.Batch.ScaleFactors` in PromQL `sum`/`rate`/`count` for
   sampled tenants. The aggregate sidecar is skipped for sampled parts, so those fall back to a
   weighted raw fold. **Not implemented.** oteldb does not yet expose a `tenant.Sampling` policy,

--- a/internal/storagebackend/open.go
+++ b/internal/storagebackend/open.go
@@ -95,9 +95,11 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 			zap.Int("precision_tiers", len(cfg.Policy.Precision)),
 			zap.Int("downsample_tiers", len(cfg.Policy.Downsample)),
 			zap.Bool("recompress", cfg.Policy.Recompress != nil),
+			zap.Bool("ec", cfg.Policy.EC != nil),
 			zap.Duration("retention_max_age", retentionMaxAge(cfg.Policy.Retention)),
 			zap.Bool("limits", cfg.Policy.Limits != nil),
 		)
+		warnECInert(cfg.Cluster, cfg.Policy, lg)
 	}
 
 	caches := resolveCacheSettings(cfg)

--- a/internal/storagebackend/open_internal_test.go
+++ b/internal/storagebackend/open_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/oteldb/storage"
 	"github.com/oteldb/storage/signal"
@@ -110,6 +111,7 @@ func TestTenancyOption(t *testing.T) {
 				{After: 7 * 24 * time.Hour, Interval: time.Hour}, // Agg defaults to last.
 			},
 			Recompress: &RecompressConfig{After: 14 * 24 * time.Hour, Level: 9},
+			EC:         &ECConfig{Data: 4, Parity: 2, After: 30 * 24 * time.Hour},
 			Retention:  &RetentionConfig{MaxAge: 90 * 24 * time.Hour, MaxBytes: 1 << 30},
 			Limits: &LimitsConfig{
 				IngestBytesPerSecond: 10 << 20,
@@ -139,6 +141,13 @@ func TestTenancyOption(t *testing.T) {
 
 		require.Equal(t, 14*24*time.Hour, p.Recompress.After)
 		require.Equal(t, 9, p.Recompress.Level)
+
+		require.NotNil(t, p.Durability.EC)
+		require.Equal(t, 4, p.Durability.EC.Data)
+		require.Equal(t, 2, p.Durability.EC.Parity)
+		require.Equal(t, 30*24*time.Hour, p.Durability.EC.After)
+		// EC fixes the owner count at Data+Parity, so the tenant RF is left alone.
+		require.Zero(t, p.Durability.RF)
 
 		require.Equal(t, 90*24*time.Hour, p.Retention.MaxAge)
 		require.Equal(t, int64(1<<30), p.Retention.MaxBytes)
@@ -173,6 +182,36 @@ func TestTenancyOption(t *testing.T) {
 		require.Equal(t, int64(1000), o.Tenancy.Resolve("default").Limits.MaxSeries)
 	})
 
+	t.Run("ECOnlyInstallsResolver", func(t *testing.T) {
+		opt, err := tenancyOption(&PolicyConfig{
+			EC: &ECConfig{Data: 6, Parity: 3},
+		})
+		require.NoError(t, err)
+		o := applyOption(t, opt)
+		require.NotNil(t, o.Tenancy, "an EC-only policy must still install a resolver")
+
+		p := o.Tenancy.Resolve("default")
+		require.NotNil(t, p.Durability.EC)
+		require.Equal(t, 6, p.Durability.EC.Data)
+		require.Equal(t, 3, p.Durability.EC.Parity)
+		require.Zero(t, p.Durability.EC.After, "zero After erasure-codes every part")
+	})
+
+	t.Run("InvalidECSchemeIsAnError", func(t *testing.T) {
+		for name, cfg := range map[string]*ECConfig{
+			"NoParity":      {Data: 4, Parity: 0},
+			"NoData":        {Data: 0, Parity: 2},
+			"Negative":      {Data: -1, Parity: 2},
+			"TooManyShards": {Data: 200, Parity: 100},
+			"NegativeAfter": {Data: 4, Parity: 2, After: -time.Hour},
+		} {
+			t.Run(name, func(t *testing.T) {
+				_, err := tenancyOption(&PolicyConfig{EC: cfg})
+				require.Error(t, err)
+			})
+		}
+	})
+
 	t.Run("UnknownAggIsAnError", func(t *testing.T) {
 		_, err := tenancyOption(&PolicyConfig{
 			Downsample: []DownsampleTierConfig{{Interval: time.Minute, Agg: "median"}},
@@ -193,6 +232,36 @@ func TestTenancyOption(t *testing.T) {
 		})
 		require.Error(t, err)
 	})
+}
+
+func TestWarnECInert(t *testing.T) {
+	sharedNothing := &ClusterConfig{Etcd: []string{"http://etcd:2379"}, PrivateBackend: true}
+	sharedStore := &ClusterConfig{Etcd: []string{"http://etcd:2379"}}
+	ecPolicy := &PolicyConfig{EC: &ECConfig{Data: 4, Parity: 2}}
+
+	for name, tt := range map[string]struct {
+		cluster *ClusterConfig
+		policy  *PolicyConfig
+		warns   bool
+	}{
+		"SharedNothing":      {sharedNothing, ecPolicy, false},
+		"SharedStore":        {sharedStore, ecPolicy, true},
+		"SingleNode":         {nil, ecPolicy, true},
+		"ClusterWithoutEtcd": {&ClusterConfig{ID: "n1"}, ecPolicy, true},
+		"NoECPolicy":         {sharedStore, &PolicyConfig{Retention: &RetentionConfig{}}, false},
+		"NoPolicy":           {sharedStore, nil, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			core, logs := observer.New(zap.WarnLevel)
+			warnECInert(tt.cluster, tt.policy, zap.New(core))
+			if !tt.warns {
+				require.Zero(t, logs.Len())
+				return
+			}
+			require.Equal(t, 1, logs.Len())
+			require.Contains(t, logs.All()[0].Message, "erasure coding")
+		})
+	}
 }
 
 func TestS3Backend(t *testing.T) {

--- a/internal/storagebackend/policy.go
+++ b/internal/storagebackend/policy.go
@@ -4,8 +4,10 @@ import (
 	"time"
 
 	"github.com/go-faster/errors"
+	"go.uber.org/zap"
 
 	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/cluster/ec"
 	"github.com/oteldb/storage/signal"
 	"github.com/oteldb/storage/tenant"
 
@@ -13,7 +15,8 @@ import (
 )
 
 // PolicyConfig configures the per-tenant storage policy applied to the embedded engine's
-// background merges: age-tiered lossy float precision, downsampling, and cold-data recompression.
+// background merges: age-tiered lossy float precision, downsampling, cold-data recompression, and
+// cold-data erasure coding.
 // The storage library resolves these per-tenant via a [tenant.Resolver] callback; oteldb runs the
 // embedded engine single-tenant (every signal routes to the "default" tenant), so this one policy
 // is resolved for every tenant. Empty ⇒ no tenancy resolver is installed (the library default:
@@ -31,6 +34,10 @@ type PolicyConfig struct {
 	// tier, which does not mean uncompressed: a merge always compresses at a level its part's size
 	// earns.
 	Recompress *RecompressConfig `json:"recompress" yaml:"recompress"`
+	// EC erasure-codes fully-cold parts (older than After) across Data+Parity cluster nodes instead
+	// of storing RF full copies. Like Recompress it is an age tier, so recent data stays full-copy
+	// for fast local reads. Nil ⇒ full-copy replication.
+	EC *ECConfig `json:"ec" yaml:"ec"`
 	// Retention bounds how long data is kept: parts older than MaxAge are dropped whole at merge.
 	// Nil ⇒ retain forever.
 	Retention *RetentionConfig `json:"retention" yaml:"retention"`
@@ -68,6 +75,33 @@ type RecompressConfig struct {
 	// [tenant.DefaultRecompressLevel]. Levels past ~9 buy single-digit percent for roughly an order
 	// of magnitude more CPU, which competes with merge and retention.
 	Level int `json:"level" yaml:"level"`
+}
+
+// ECConfig configures the cold-data erasure-coding tier: a flushed part older than After is
+// re-encoded, at merge, into Data + Parity Reed-Solomon shards spread one per cluster node, in
+// place of RF full copies. It stores (Data+Parity)/Data of the logical bytes and survives Parity
+// node losses — {4,2} is 1.5x for two tolerated losses, against 3x for RF=3 — paying a
+// reconstruct-on-read cost only for parts that have converted.
+//
+// It applies to shared-nothing deployments only (cluster mode with private_backend): on a shared
+// object store the store owns durability, and an EC policy there does nothing. Objects below
+// [ec.FullCopyFloor] stay full-copy on every owner, since k+m shards of a tiny object cost more
+// than they save.
+type ECConfig struct {
+	// Data is the number of data shards (k); any Data shards reconstruct the object. Must be ≥ 1.
+	Data int `json:"data" yaml:"data"`
+	// Parity is the number of parity shards (m); the scheme tolerates Parity node losses. Must be
+	// ≥ 1, and Data+Parity at most 256.
+	//
+	// Data+Parity is also the tenant's owner count under EC — the replication factor, cluster-wide
+	// or per-tenant, is ignored. Placement spreads the shards over the rack/server/disk hierarchy,
+	// and is rack-safe (one rack failure costs at most Parity shards) only with at least
+	// ceil((Data+Parity)/Parity) racks; below that the engine converts anyway and warns.
+	Parity int `json:"parity" yaml:"parity"`
+	// After is the age past which a fully-cold part is erasure-coded, mirroring
+	// [RecompressConfig.After] and riding the same background-merge engine. Zero ⇒ erasure-code
+	// every part, accepting the reconstruct-on-read cost everywhere for the cheapest storage.
+	After time.Duration `json:"after" yaml:"after"`
 }
 
 // RetentionConfig configures age-based retention. Enforcement drops whole partitions at merge, so
@@ -117,11 +151,40 @@ func retentionMaxAge(cfg *RetentionConfig) time.Duration {
 	return cfg.MaxAge
 }
 
+// warnECInert warns when an EC policy is configured but cannot take effect, because the engine
+// gates erasure coding on shared-nothing cluster mode as well: without it every part stays
+// full-copy and nothing reports why.
+//
+// It warns rather than refuses, matching the shared-nothing diagnostic in storage#373: EC on a
+// shared store is a redundant setting, not a broken one — the store owns durability there, so the
+// deployment is still correct, only paying for a policy it does not get. Refusing would also turn
+// a config that is valid on its own into a startup failure decided by an unrelated section.
+func warnECInert(cluster *ClusterConfig, policy *PolicyConfig, lg *zap.Logger) {
+	if policy == nil || policy.EC == nil {
+		return
+	}
+
+	clustered := cluster != nil && len(cluster.Etcd) > 0
+	if clustered && cluster.PrivateBackend {
+		return
+	}
+
+	lg.Warn("storage policy sets erasure coding, but it cannot apply",
+		zap.Bool("clustered", clustered),
+		zap.Bool("private_backend", clustered && cluster.PrivateBackend),
+		zap.String("effect", "every part stays full-copy; the policy costs and saves nothing"),
+		zap.String("action", "erasure coding needs cluster mode with private_backend set, i.e. a "+
+			"shared-nothing deployment; on a shared object store the store owns durability and the "+
+			"policy should be dropped"),
+	)
+}
+
 // empty reports whether the policy configures nothing, in which case no resolver is installed.
 func (cfg *PolicyConfig) empty() bool {
 	return cfg == nil || (len(cfg.Precision) == 0 &&
 		len(cfg.Downsample) == 0 &&
 		cfg.Recompress == nil &&
+		cfg.EC == nil &&
 		cfg.Retention == nil &&
 		cfg.Limits == nil)
 }
@@ -174,6 +237,22 @@ func (cfg *PolicyConfig) policy() (tenant.Policy, error) {
 
 	if r := cfg.Recompress; r != nil {
 		p.Recompress = tenant.Recompress{After: r.After, Level: r.Level}
+	}
+
+	if e := cfg.EC; e != nil {
+		// An invalid scheme is silently swallowed downstream (Storage.ecSchemeFor drops to
+		// full-copy when Validate fails), so validate here to make it a startup error instead.
+		if err := (ec.Scheme{Data: e.Data, Parity: e.Parity}).Validate(); err != nil {
+			return tenant.Policy{}, errors.Wrap(err, "ec")
+		}
+		if e.After < 0 {
+			return tenant.Policy{}, errors.New("ec: after must not be negative")
+		}
+		p.Durability.EC = &tenant.ECScheme{
+			Data:   e.Data,
+			Parity: e.Parity,
+			After:  e.After,
+		}
 	}
 
 	if r := cfg.Retention; r != nil {


### PR DESCRIPTION
Fixes #1278.

`Storage.ecSchemeFor` gates erasure coding on three things: cluster mode, `cluster.private`, and a
non-nil `tenant.Durability.EC`. `PolicyConfig` mapped five policy tiers but not the third, so the
`cluster/ec` package was unreachable from oteldb no matter how the cluster was configured.

Companion to #1264 (already on `main`), which added the second condition, `private_backend`. This
branch is based on `main` and does not depend on it beyond that.

## Config surface

`tenant.ECScheme` has exactly three fields, so `ECConfig` does too — no invented knobs:

```yaml
storage:
  policy:
    ec:
      data: 4
      parity: 2
      after: 720h
```

Modelled on `RecompressConfig`, since `cluster/ARCH.md` describes EC as "an age tier like
recompression" and it rides the same background-merge engine. The full-copy size floor is the
`ec.FullCopyFloor` constant upstream, not a policy field, so it is documented rather than exposed.

Doc comments carry the three facts an operator cannot infer from the field names: owner count is
exactly `data+parity` and the tenant's RF is **ignored** under EC; placement is `LookupBalanced` over
the rack/server/disk hierarchy and is rack-safe only with at least `ceil(shards/parity)` racks;
sub-floor objects stay full-copy on every owner.

`EC` is included in `PolicyConfig.empty()` — without it an EC-only policy would install no resolver
and be silently inert.

## Validation

Upstream `ec.Scheme.Validate` already covers `Data >= 1`, `Parity >= 1`, and `Data+Parity <= 256`, so
this calls it rather than restating the bounds. The reason to call it at all is that `ecSchemeFor`
**swallows** the failure — `if scheme.Validate() != nil { return ec.Scheme{}, false }` — which turns
a typoed scheme into "EC quietly off", a durability loss with no signal. Startup is the right layer
for it, and the error surfaces once.

The only bound added on top is `after >= 0`: upstream does not check it, and a negative age puts the
cutoff in the future, i.e. erasure-codes everything, which is not what the operator wrote.

Ring size is deliberately not validated: membership is not known at config time, and upstream
already degrades sensibly (owner prune is skipped when the ring is smaller than `data+parity`, and a
rack-unsafe placement warns per part and converts anyway).

## EC without `private_backend`: warn, not error

`warnECInert` logs one warning when an EC policy is set but cannot apply — single-node, or clustered
on a shared store. Reasons for warn over refuse:

- **Consistency with storage#373**, which took exactly this position for the neighbouring
  misconfiguration (a node-private backend not declared private) and settled on warn + `effect` +
  `action` fields. Two adjacent shared-nothing diagnostics should not disagree on severity.
- **It is redundant, not broken.** On a shared object store the store owns durability; the
  deployment is correct, it just pays for a policy it does not get. #373's case was worse — silent
  data unavailability — and still only warranted a warning.
- **Sections shouldn't fail each other.** `storage.policy` is valid on its own; making it a startup
  error decided by `storage.cluster` means adding an object-store backend to a working config
  crashes the process on an unrelated block.

Documentation alone was not enough here, because the failure is invisible: EC-off and
EC-on-but-nothing-cold look identical from the outside.

## Tests

`TestTenancyOption` gains the EC mapping (including `Durability.RF` staying zero), an
`ECOnlyInstallsResolver` case for the `empty()` path, and a table over invalid schemes (no parity, no
data, negative, >256 shards, negative after). `TestWarnECInert` tables the warning both ways:
shared-nothing and no-EC-policy stay quiet; shared store, single node, and cluster-without-etcd warn.

`golangci-lint fmt ./...` is a no-op and `golangci-lint run ./internal/storagebackend/...` is clean
(the repo-wide run has pre-existing findings elsewhere);
`go test ./internal/storagebackend/... ./cmd/oteldb/...` passes.
`go.mod` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
