### PR TITLE
feat(odbingest): resolve tenant from header or resource attribute

### DIFF
--- a/cmd/odbingest/app.go
+++ b/cmd/odbingest/app.go
@@ -12,6 +12,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/oteldb/storage/cluster"
 	"github.com/oteldb/storage/cluster/router"
 
 	"github.com/oteldb/oteldb/internal/otlpdirect"
@@ -42,7 +43,28 @@ func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (
 		return nil, errors.Wrap(err, "open cluster router")
 	}
 
-	sink, err := newClusterSink(rt, nil, m.MeterProvider())
+	tenants, err := newTenantResolver(cfg.Tenant)
+	if err != nil {
+		_ = rt.Close(ctx)
+
+		return nil, errors.Wrap(err, "configure tenancy")
+	}
+
+	// Which tenant a write lands in decides which shard, hence which node, holds it. An operator
+	// reading a startup log must be able to tell whether this process resolves tenants at all.
+	if tenants == nil {
+		lg.Info("Tenancy disabled, routing every write to the default tenant",
+			zap.String("tenant", string(cluster.DefaultTenant)))
+	} else {
+		lg.Info("Tenancy enabled",
+			zap.String("header", tenants.header),
+			zap.Strings("resource_attributes", cfg.Tenant.ResourceAttributes),
+			zap.String("default", string(tenants.defaultTenant())),
+			zap.Bool("require", tenants.required),
+		)
+	}
+
+	sink, err := newClusterSink(rt, tenants.tenantFunc, m.MeterProvider())
 	if err != nil {
 		_ = rt.Close(ctx)
 
@@ -74,15 +96,21 @@ func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (
 		Observer:        obs.observe,
 	})
 
+	// Only the ingest routes are wrapped: a health probe carries no tenant, and requiring one of it
+	// would fail readiness on a correctly configured deployment.
+	ingestMux := http.NewServeMux()
+	otlp.Register(ingestMux)
+	ingestMux.Handle(rw.Path, handler)
+
 	mux := http.NewServeMux()
-	otlp.Register(mux)
-	mux.Handle(rw.Path, handler)
+	mux.Handle("/", tenants.Middleware(ingestMux))
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
 	mux.Handle("GET /readyz", readyHandler(rt))
 
 	var grpcSrv *grpc.Server
 	if cfg.OTLP.GRPCBind != "-" {
-		grpcSrv = grpc.NewServer(otlp.GRPCServerOptions()...)
+		opts := append(otlp.GRPCServerOptions(), grpc.ChainUnaryInterceptor(tenants.UnaryInterceptor()))
+		grpcSrv = grpc.NewServer(opts...)
 		otlp.RegisterGRPC(grpcSrv)
 	}
 

--- a/cmd/odbingest/app_test.go
+++ b/cmd/odbingest/app_test.go
@@ -216,6 +216,12 @@ func series(name string, at time.Time, v float64) prompb.TimeSeries {
 func newTestSink(t *testing.T, endpoint, root string, shards int) *clusterSink {
 	t.Helper()
 
+	return newTestSinkWith(t, endpoint, root, shards, nil)
+}
+
+func newTestSinkWith(t *testing.T, endpoint, root string, shards int, tenantOf tenantFuncOf) *clusterSink {
+	t.Helper()
+
 	rt, err := router.Open(t.Context(), router.Config{
 		Etcd: []string{endpoint}, Root: root, RF: 1, ShardsPerTenant: shards,
 	})
@@ -225,10 +231,50 @@ func newTestSink(t *testing.T, endpoint, root string, shards int) *clusterSink {
 	require.Eventually(t, func() bool { return len(rt.Members()) > 0 },
 		10*time.Second, 10*time.Millisecond, "router sees the cluster")
 
-	sink, err := newClusterSink(rt, nil, noop.NewMeterProvider())
+	sink, err := newClusterSink(rt, tenantOf, noop.NewMeterProvider())
 	require.NoError(t, err)
 
 	return sink
+}
+
+// TestIngestRoutesHeaderTenant is the end-to-end check that a tenant named per request reaches
+// framing: the write must land under that tenant's shard key at the primary, and a request that
+// names none must still land under the default tenant.
+func TestIngestRoutesHeaderTenant(t *testing.T) {
+	t.Parallel()
+
+	const root = "/tenants"
+
+	endpoint := startEtcd(t)
+	node := startNode(t, endpoint, root, "node-tenant")
+
+	tenants, err := newTenantResolver(TenantConfig{Header: HeaderScopeOrgID})
+	require.NoError(t, err)
+
+	h := tenants.Middleware(promrw.NewHandler(
+		newTestSinkWith(t, endpoint, root, 1, tenants.tenantFunc),
+		promrw.HandlerConfig{Options: promrw.Options{TimeThreshold: time.Hour}},
+	))
+
+	at := time.Now().Truncate(time.Second)
+
+	for _, tenant := range []string{"acme", ""} {
+		body := writeRequest(t, series("http_requests_total", at, 1))
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/write", bytes.NewReader(body))
+		if tenant != "" {
+			req.Header.Set(HeaderScopeOrgID, tenant)
+		}
+
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusNoContent, rec.Code, rec.Body)
+	}
+
+	node.mu.Lock()
+	defer node.mu.Unlock()
+
+	assert.Equal(t, map[string]int{"acme": 1, string(cluster.DefaultTenant): 1}, node.shards)
 }
 
 // TestIngestRoutesToPrimary is the end-to-end check that odbingest is a routing tier: a remote

--- a/cmd/odbingest/config.go
+++ b/cmd/odbingest/config.go
@@ -19,6 +19,33 @@ type Config struct {
 	RemoteWrite RemoteWriteConfig `json:"prometheus_remote_write" yaml:"prometheus_remote_write"`
 	// OTLP configures the OTLP/HTTP endpoints, which share the remote write listener.
 	OTLP OTLPConfig `json:"otlp" yaml:"otlp"`
+	// Tenant configures which tenant a write routes to. Empty ⇒ everything routes to the
+	// "default" tenant, as it does with no tenancy configured at all.
+	Tenant TenantConfig `json:"tenant" yaml:"tenant"`
+}
+
+// TenantConfig configures tenant resolution on the ingest path.
+//
+// The zero value routes every write to [cluster.DefaultTenant]. That is deliberate and must stay
+// that way: a tenant picks the shard key, which picks the ring owner, so a deployment that starts
+// resolving tenants differently writes where its existing reads do not look. Enabling a source
+// here is a migration, not a config tweak.
+//
+// Sources compose narrowest-first — Header (a whole request) beats ResourceAttributes (one
+// resource within it), which beats Default.
+type TenantConfig struct {
+	// Default is the tenant a write routes to when no source names one. Empty ⇒ "default".
+	Default string `json:"default" yaml:"default"`
+	// Header is the request header (and OTLP/gRPC metadata key) carrying the tenant. Empty ⇒ the
+	// header is not read. "X-Scope-OrgID" is what Grafana-stack senders put it in.
+	Header string `json:"header" yaml:"header"`
+	// ResourceAttributes are the OTLP resource attribute keys read, in order, until one holds a
+	// usable tenant. Empty ⇒ resource attributes are not read. "service.namespace" is the
+	// OTel-native candidate.
+	ResourceAttributes []string `json:"resource_attributes" yaml:"resource_attributes"`
+	// Require refuses a request that does not carry Header, instead of routing it to Default.
+	// Requires Header.
+	Require bool `json:"require" yaml:"require"`
 }
 
 // OTLPConfig configures the OTLP/HTTP ingest endpoints. They are always served, at the paths the

--- a/cmd/odbingest/sink.go
+++ b/cmd/odbingest/sink.go
@@ -18,13 +18,18 @@ import (
 // holds no data of its own: it frames, routes, and reports what the primaries said.
 type clusterSink struct {
 	router   *router.Router
-	tenantOf cluster.TenantFunc
+	tenantOf tenantFuncOf
 
 	accepted metric.Int64Counter
 	rejected metric.Int64Counter
 }
 
-func newClusterSink(r *router.Router, tenantOf cluster.TenantFunc, mp metric.MeterProvider) (*clusterSink, error) {
+// tenantFuncOf derives the routing callback for one write from its request context, so a tenant
+// named per request (a header) and one named per resource (an attribute) reach framing the same
+// way. A nil tenantFuncOf, or one returning nil, routes to [cluster.DefaultTenant].
+type tenantFuncOf func(context.Context) cluster.TenantFunc
+
+func newClusterSink(r *router.Router, tenantOf tenantFuncOf, mp metric.MeterProvider) (*clusterSink, error) {
 	meter := mp.Meter("github.com/oteldb/oteldb/cmd/odbingest")
 
 	accepted, err := meter.Int64Counter("odbingest.cluster.accepted_points",
@@ -50,27 +55,35 @@ func newClusterSink(r *router.Router, tenantOf cluster.TenantFunc, mp metric.Met
 // the rest, which is a success with the counters moving. Only a routing or transport failure fails
 // the request, so the sender retries a write that may not have landed and leaves one that did.
 func (s *clusterSink) WriteMetrics(ctx context.Context, batch sigmetric.Metrics) error {
-	res, err := s.router.WriteMetrics(ctx, batch, s.tenantOf)
+	res, err := s.router.WriteMetrics(ctx, batch, s.routing(ctx))
 
 	return s.record(ctx, "metrics", res, err)
 }
 
 func (s *clusterSink) WriteLogs(ctx context.Context, batch log.Logs) error {
-	res, err := s.router.WriteLogs(ctx, batch, s.tenantOf)
+	res, err := s.router.WriteLogs(ctx, batch, s.routing(ctx))
 
 	return s.record(ctx, "logs", res, err)
 }
 
 func (s *clusterSink) WriteTraces(ctx context.Context, batch trace.Traces) error {
-	res, err := s.router.WriteTraces(ctx, batch, s.tenantOf)
+	res, err := s.router.WriteTraces(ctx, batch, s.routing(ctx))
 
 	return s.record(ctx, "traces", res, err)
 }
 
 func (s *clusterSink) WriteProfiles(ctx context.Context, batch *profile.Profiles) error {
-	res, err := s.router.WriteProfiles(ctx, batch, s.tenantOf)
+	res, err := s.router.WriteProfiles(ctx, batch, s.routing(ctx))
 
 	return s.record(ctx, "profiles", res, err)
+}
+
+func (s *clusterSink) routing(ctx context.Context) cluster.TenantFunc {
+	if s.tenantOf == nil {
+		return nil
+	}
+
+	return s.tenantOf(ctx)
 }
 
 // record meters what the primaries said and turns a routing failure into the caller's error.

--- a/cmd/odbingest/tenant.go
+++ b/cmd/odbingest/tenant.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/go-faster/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/oteldb/storage/cluster"
+	"github.com/oteldb/storage/signal"
+)
+
+// HeaderScopeOrgID is the header Grafana-stack senders (Loki, Mimir, their Grafana datasources)
+// put the tenant in, and the value to configure [TenantConfig.Header] with to accept them.
+const HeaderScopeOrgID = "X-Scope-OrgID"
+
+// maxTenantLen bounds a tenant id. A tenant id becomes a shard key, which becomes a backend path
+// segment and an etcd key component, so an unbounded one from a request header is a way to make
+// keys nobody can address.
+const maxTenantLen = 150
+
+// tenantCtxKey carries the tenant a request's headers named. Header tenancy is per request while
+// [cluster.TenantFunc] is per resource, so the request-scoped value rides the context the handler
+// already passes to the sink, and the sink turns it into a constant TenantFunc for that write.
+type tenantCtxKey struct{}
+
+func withRequestTenant(ctx context.Context, tid signal.TenantID) context.Context {
+	return context.WithValue(ctx, tenantCtxKey{}, tid)
+}
+
+func requestTenant(ctx context.Context) signal.TenantID {
+	tid, _ := ctx.Value(tenantCtxKey{}).(signal.TenantID)
+
+	return tid
+}
+
+// tenantResolver decides which tenant a write routes to.
+//
+// The sources compose by scope, narrowest first: a header names the tenant of a whole request, a
+// resource attribute names the tenant of one resource within it, and the configured default backs
+// both. A header therefore wins — it is set by the gateway that authenticated the sender, whereas
+// an attribute is whatever the sender put in its payload.
+type tenantResolver struct {
+	def      signal.TenantID
+	header   string
+	attrs    [][]byte
+	required bool
+}
+
+// newTenantResolver builds the resolver cfg describes, or nil if cfg configures nothing — a nil
+// resolver routes exactly like the unconfigured ingest path, to [cluster.DefaultTenant].
+func newTenantResolver(cfg TenantConfig) (*tenantResolver, error) {
+	r := &tenantResolver{
+		header:   strings.TrimSpace(cfg.Header),
+		required: cfg.Require,
+	}
+
+	if cfg.Default != "" {
+		tid, err := parseTenantID(cfg.Default)
+		if err != nil {
+			return nil, errors.Wrap(err, "tenant.default")
+		}
+
+		r.def = tid
+	}
+
+	for _, key := range cfg.ResourceAttributes {
+		if key == "" {
+			return nil, errors.New("tenant.resource_attributes: empty attribute key")
+		}
+
+		r.attrs = append(r.attrs, []byte(key))
+	}
+
+	if r.required && r.header == "" {
+		return nil, errors.New("tenant.require needs tenant.header")
+	}
+
+	if r.def == "" && r.header == "" && len(r.attrs) == 0 {
+		return nil, nil
+	}
+
+	return r, nil
+}
+
+// defaultTenant is where an unresolved write lands.
+func (r *tenantResolver) defaultTenant() signal.TenantID {
+	if r == nil || r.def == "" {
+		return cluster.DefaultTenant
+	}
+
+	return r.def
+}
+
+// tenantFunc returns the routing callback for one write, given the request context the header
+// middleware annotated. A nil result routes to [cluster.DefaultTenant].
+func (r *tenantResolver) tenantFunc(ctx context.Context) cluster.TenantFunc {
+	if r == nil {
+		return nil
+	}
+
+	if tid := requestTenant(ctx); tid != "" {
+		return func(signal.Resource, signal.Scope) signal.TenantID { return tid }
+	}
+
+	if len(r.attrs) == 0 {
+		if r.def == "" {
+			return nil
+		}
+
+		def := r.def
+
+		return func(signal.Resource, signal.Scope) signal.TenantID { return def }
+	}
+
+	return r.fromResource
+}
+
+// fromResource reads the tenant off the resource, first configured key wins. A missing, non-string
+// or malformed value falls back to the default rather than failing the batch: framing is past the
+// point where a request can be answered with an error, and shedding a resource silently would be
+// worse than putting it where an unconfigured deployment puts it.
+func (r *tenantResolver) fromResource(res signal.Resource, _ signal.Scope) signal.TenantID {
+	for _, key := range r.attrs {
+		v, ok := res.Attributes.Get(key)
+		if !ok {
+			continue
+		}
+
+		s := v.Str()
+		if len(s) == 0 {
+			continue
+		}
+
+		tid, err := parseTenantID(string(s))
+		if err != nil {
+			continue
+		}
+
+		return tid
+	}
+
+	return r.def
+}
+
+// Middleware resolves the header tenant onto the request context, refusing a request that names an
+// unusable tenant instead of quietly routing it to the default.
+func (r *tenantResolver) Middleware(next http.Handler) http.Handler {
+	if r == nil || (r.header == "" && !r.required) {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var raw string
+		if r.header != "" {
+			raw = req.Header.Get(r.header)
+		}
+
+		tid, err := r.resolveHeader(raw)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
+		if tid != "" {
+			req = req.WithContext(withRequestTenant(req.Context(), tid))
+		}
+
+		next.ServeHTTP(w, req)
+	})
+}
+
+// UnaryInterceptor is [tenantResolver.Middleware] for OTLP/gRPC, reading the same header out of
+// the request metadata.
+func (r *tenantResolver) UnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+	) (any, error) {
+		if r == nil || (r.header == "" && !r.required) {
+			return handler(ctx, req)
+		}
+
+		var raw string
+		if r.header != "" {
+			if md, ok := metadata.FromIncomingContext(ctx); ok {
+				if vs := md.Get(r.header); len(vs) > 0 {
+					raw = vs[0]
+				}
+			}
+		}
+
+		tid, err := r.resolveHeader(raw)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
+		if tid != "" {
+			ctx = withRequestTenant(ctx, tid)
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// resolveHeader validates a header value. An absent one is not an error unless the deployment
+// requires the sender to name its tenant, in which case routing it to a shared default would mix
+// two senders' data under one tenant.
+func (r *tenantResolver) resolveHeader(raw string) (signal.TenantID, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		if r.required {
+			return "", errors.Errorf("missing %s header", r.header)
+		}
+
+		return "", nil
+	}
+
+	tid, err := parseTenantID(raw)
+	if err != nil {
+		return "", errors.Wrapf(err, "%s header", r.header)
+	}
+
+	return tid, nil
+}
+
+// parseTenantID validates a tenant id. The character set is what stays safe as a backend path
+// segment and an etcd key, and excludes [cluster.ShardSep] so a tenant id can never be mistaken
+// for the shard key derived from it.
+func parseTenantID(s string) (signal.TenantID, error) {
+	s = strings.TrimSpace(s)
+
+	switch {
+	case s == "":
+		return "", errors.New("empty tenant id")
+	case len(s) > maxTenantLen:
+		return "", errors.Errorf("tenant id longer than %d bytes", maxTenantLen)
+	case s == "." || s == "..":
+		return "", errors.Errorf("invalid tenant id %q", s)
+	}
+
+	for _, c := range []byte(s) {
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.':
+		default:
+			return "", errors.Errorf("invalid character %q in tenant id", string(c))
+		}
+	}
+
+	return signal.TenantID(s), nil
+}

--- a/cmd/odbingest/tenant_test.go
+++ b/cmd/odbingest/tenant_test.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/oteldb/storage/signal"
+)
+
+type passthrough struct{}
+
+func (passthrough) ServeHTTP(http.ResponseWriter, *http.Request) {}
+
+func resourceWith(kvs ...[2]string) signal.Resource {
+	attrs := make([]signal.KeyValue, 0, len(kvs))
+	for _, kv := range kvs {
+		attrs = append(attrs, signal.KeyValue{Key: []byte(kv[0]), Value: signal.StringValue([]byte(kv[1]))})
+	}
+
+	return signal.Resource{Attributes: signal.NewAttributes(attrs...)}
+}
+
+func TestParseTenantID(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		in    string
+		want  signal.TenantID
+		error bool
+	}{
+		{name: "Simple", in: "acme", want: "acme"},
+		{name: "Trimmed", in: "  acme  ", want: "acme"},
+		{name: "Punctuation", in: "acme-prod_1.eu", want: "acme-prod_1.eu"},
+		{name: "Empty", in: "", error: true},
+		{name: "Blank", in: "   ", error: true},
+		{name: "Dot", in: ".", error: true},
+		{name: "DotDot", in: "..", error: true},
+		{name: "Slash", in: "acme/prod", error: true},
+		{name: "ShardMarker", in: "acme/_s1", error: true},
+		{name: "Pipe", in: "acme|other", error: true},
+		{name: "Space", in: "acme prod", error: true},
+		{name: "TooLong", in: strings.Repeat("a", maxTenantLen+1), error: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseTenantID(tt.in)
+			if tt.error {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewTenantResolver(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ZeroConfigIsNil", func(t *testing.T) {
+		t.Parallel()
+
+		r, err := newTenantResolver(TenantConfig{})
+		require.NoError(t, err)
+		require.Nil(t, r, "zero config must route exactly like no tenancy at all")
+		require.Nil(t, r.tenantFunc(context.Background()))
+	})
+
+	t.Run("RejectsBadDefault", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newTenantResolver(TenantConfig{Default: "bad/tenant"})
+		require.Error(t, err)
+	})
+
+	t.Run("RejectsEmptyAttributeKey", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newTenantResolver(TenantConfig{ResourceAttributes: []string{""}})
+		require.Error(t, err)
+	})
+
+	t.Run("RejectsRequireWithoutHeader", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := newTenantResolver(TenantConfig{Require: true})
+		require.Error(t, err)
+	})
+}
+
+func TestTenantResolverTenantFunc(t *testing.T) {
+	t.Parallel()
+
+	const attrKey = "service.namespace"
+
+	for _, tt := range []struct {
+		name   string
+		cfg    TenantConfig
+		header signal.TenantID
+		res    signal.Resource
+		want   signal.TenantID
+	}{
+		{
+			name: "DefaultOnly",
+			cfg:  TenantConfig{Default: "shared"},
+			res:  resourceWith([2]string{attrKey, "acme"}),
+			want: "shared",
+		},
+		{
+			name: "Attribute",
+			cfg:  TenantConfig{ResourceAttributes: []string{attrKey}},
+			res:  resourceWith([2]string{attrKey, "acme"}),
+			want: "acme",
+		},
+		{
+			name: "AttributeFallsBackToDefault",
+			cfg:  TenantConfig{Default: "shared", ResourceAttributes: []string{attrKey}},
+			res:  resourceWith([2]string{"service.name", "api"}),
+			want: "shared",
+		},
+		{
+			name: "MalformedAttributeFallsBackToDefault",
+			cfg:  TenantConfig{Default: "shared", ResourceAttributes: []string{attrKey}},
+			res:  resourceWith([2]string{attrKey, "acme/prod"}),
+			want: "shared",
+		},
+		{
+			name: "FirstConfiguredAttributeWins",
+			cfg:  TenantConfig{ResourceAttributes: []string{"tenant", attrKey}},
+			res:  resourceWith([2]string{"tenant", "one"}, [2]string{attrKey, "two"}),
+			want: "one",
+		},
+		{
+			name:   "HeaderBeatsAttribute",
+			cfg:    TenantConfig{Header: HeaderScopeOrgID, ResourceAttributes: []string{attrKey}},
+			header: "acme",
+			res:    resourceWith([2]string{attrKey, "other"}),
+			want:   "acme",
+		},
+		{
+			name:   "HeaderBeatsDefault",
+			cfg:    TenantConfig{Header: HeaderScopeOrgID, Default: "shared"},
+			header: "acme",
+			want:   "acme",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, err := newTenantResolver(tt.cfg)
+			require.NoError(t, err)
+			require.NotNil(t, r)
+
+			ctx := context.Background()
+			if tt.header != "" {
+				ctx = withRequestTenant(ctx, tt.header)
+			}
+
+			fn := r.tenantFunc(ctx)
+			require.NotNil(t, fn)
+			require.Equal(t, tt.want, fn(tt.res, signal.Scope{}))
+		})
+	}
+}
+
+// TestTenantResolverUnresolvedRoutesToDefault pins the compatibility guarantee: with tenancy
+// configured but nothing naming a tenant, framing must see a nil callback and put the write where
+// an unconfigured deployment puts it.
+func TestTenantResolverUnresolvedRoutesToDefault(t *testing.T) {
+	t.Parallel()
+
+	r, err := newTenantResolver(TenantConfig{Header: HeaderScopeOrgID})
+	require.NoError(t, err)
+	require.Nil(t, r.tenantFunc(context.Background()))
+}
+
+func TestTenantResolverMiddleware(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		cfg    TenantConfig
+		header string
+		code   int
+		want   signal.TenantID
+	}{
+		{
+			name:   "Resolves",
+			cfg:    TenantConfig{Header: HeaderScopeOrgID},
+			header: "acme",
+			code:   http.StatusOK,
+			want:   "acme",
+		},
+		{
+			name: "MissingIsAllowed",
+			cfg:  TenantConfig{Header: HeaderScopeOrgID},
+			code: http.StatusOK,
+		},
+		{
+			name: "MissingIsRefusedWhenRequired",
+			cfg:  TenantConfig{Header: HeaderScopeOrgID, Require: true},
+			code: http.StatusBadRequest,
+		},
+		{
+			name:   "MalformedIsRefused",
+			cfg:    TenantConfig{Header: HeaderScopeOrgID},
+			header: "acme/prod",
+			code:   http.StatusBadRequest,
+		},
+		{
+			name:   "HeaderIgnoredWhenNotConfigured",
+			cfg:    TenantConfig{Default: "shared"},
+			header: "acme",
+			code:   http.StatusOK,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, err := newTenantResolver(tt.cfg)
+			require.NoError(t, err)
+
+			var seen signal.TenantID
+
+			h := r.Middleware(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				seen = requestTenant(req.Context())
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/metrics", http.NoBody)
+			if tt.header != "" {
+				req.Header.Set(HeaderScopeOrgID, tt.header)
+			}
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.code, rec.Code, rec.Body)
+			assert.Equal(t, tt.want, seen)
+		})
+	}
+}
+
+// TestTenantMiddlewareNilResolver pins that unconfigured tenancy adds nothing to the chain.
+func TestTenantMiddlewareNilResolver(t *testing.T) {
+	t.Parallel()
+
+	var r *tenantResolver
+
+	next := passthrough{}
+	require.Equal(t, http.Handler(next), r.Middleware(next))
+}
+
+func TestTenantResolverUnaryInterceptor(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		cfg  TenantConfig
+		md   metadata.MD
+		code codes.Code
+		want signal.TenantID
+	}{
+		{
+			name: "Resolves",
+			cfg:  TenantConfig{Header: HeaderScopeOrgID},
+			md:   metadata.Pairs(HeaderScopeOrgID, "acme"),
+			want: "acme",
+		},
+		{
+			name: "MissingIsAllowed",
+			cfg:  TenantConfig{Header: HeaderScopeOrgID},
+			md:   metadata.MD{},
+		},
+		{
+			name: "MissingIsRefusedWhenRequired",
+			cfg:  TenantConfig{Header: HeaderScopeOrgID, Require: true},
+			md:   metadata.MD{},
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "MalformedIsRefused",
+			cfg:  TenantConfig{Header: HeaderScopeOrgID},
+			md:   metadata.Pairs(HeaderScopeOrgID, "acme/prod"),
+			code: codes.InvalidArgument,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, err := newTenantResolver(tt.cfg)
+			require.NoError(t, err)
+
+			var seen signal.TenantID
+
+			ctx := metadata.NewIncomingContext(t.Context(), tt.md)
+			_, err = r.UnaryInterceptor()(ctx, nil, &grpc.UnaryServerInfo{},
+				func(ctx context.Context, _ any) (any, error) {
+					seen = requestTenant(ctx)
+
+					return nil, nil
+				})
+
+			require.Equal(t, tt.code, status.Code(err))
+			assert.Equal(t, tt.want, seen)
+		})
+	}
+}


### PR DESCRIPTION
Closes #1277 (ingest half). Groundwork for #820, #823.

## What was wrong

`cmd/odbingest/app.go` passed `nil` for `cluster.TenantFunc`, so every signal routed to
`cluster.DefaultTenant`. Tenant is the key sharding, per-tenant policy and quotas hang off, so all
of that was inert on the write path.

## Ground truth found while investigating

- `cluster.TenantFunc` is `func(signal.Resource, signal.Scope) signal.TenantID`, called per
  projected batch inside `FrameMetrics`/`FrameRecords`; nil or `""` ⇒ `cluster.DefaultTenant`.
- **The embedded path is unwired too, and worse.** `internal/storagebackend/open.go` never passes
  `storage.WithTenant`, and the read side has no per-request tenant at all: `Backend.tenant` is a
  fixed field (`""` ⇒ `"default"`) that every fetcher and queryable is scoped to, and `WithTenancy`
  resolves the same policy for every tenant id. Nothing in the repo reads `X-Scope-OrgID`.

So oteldb's query path cannot serve more than one tenant today. That is why this PR does not touch
it: resolving tenants on ingest without a tenant-aware reader would write where reads do not look.
Making the read path tenant-aware is the larger half of #820 and lands separately.

## This PR

Opt-in tenant resolution in `cmd/odbingest` only. New `tenant` config block:

```yaml
tenant:
  header: X-Scope-OrgID          # request header + OTLP/gRPC metadata key; "" ⇒ not read
  resource_attributes:           # OTLP resource attribute keys, first usable wins; [] ⇒ not read
    - service.namespace
  default: shared                # "" ⇒ "default"
  require: false                 # refuse a request without `header` instead of using `default`
```

How the two sources compose, since a header covers a whole batch and an attribute covers one
resource in it: the header is resolved once per request by middleware (HTTP) or a unary interceptor
(gRPC) onto the request context, and the sink turns a context tenant into a constant `TenantFunc`
for that write. Absent a header, the callback reads the configured resource attributes per
resource. So **header (whole request) > resource attribute (per resource) > default** — the header
wins because a gateway sets it after authenticating the sender, whereas an attribute is whatever
the sender put in its payload.

Tenant ids are validated (`[A-Za-z0-9_.-]`, ≤150 bytes, not `.`/`..`) so a tenant can never contain
`cluster.ShardSep` or escape a backend path segment. A malformed header is a 400 /
`InvalidArgument`; a malformed *attribute* falls back to the default, because framing is past the
point where a request can be answered. Health probes are outside the middleware, so `require: true`
does not fail readiness.

## What changes for an existing deployment

**Nothing.** With no `tenant:` block the resolver is nil, the sink passes a nil `TenantFunc`, and
every write routes to `cluster.DefaultTenant` exactly as before — same shard keys, same ring owners.
`TestTenantResolverUnresolvedRoutesToDefault` and the existing routing tests pin this.

To migrate, an operator opts in per source, and must understand that a series that starts resolving
to a new tenant lands on a different shard, hence a different owner, and existing data stays under
`default`. Until the read path is tenant-aware, a multi-tenant `tenant:` config is only useful for
placement/policy experiments, not for serving separate tenants' queries.

## Tests

Table tests for id validation, resolver construction, precedence, HTTP middleware and the gRPC
interceptor, plus an end-to-end test over embedded etcd and a fake primary asserting a
header-tenanted remote write lands under shard key `acme` while an unheadered one lands under
`default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
