### PR TITLE
build(deps): bump github.com/oteldb/storage to v0.39.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.158.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.38.0
+	github.com/oteldb/storage v0.39.0
 	github.com/pierrec/lz4/v4 v4.1.28
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.158.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.158.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.37.3-0.20260816211206-b7b99536087b
+	github.com/oteldb/storage v0.38.0
 	github.com/pierrec/lz4/v4 v4.1.28
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1
@@ -95,7 +95,7 @@ require (
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	github.com/stretchr/testify v1.11.1
+	github.com/stretchr/testify v1.12.0
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/zeebo/xxh3 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1030,8 +1030,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.38.0 h1:MlkfHSv6V3K+2fk+tx2ev+a7hYh+7+XKs3q87XhETn4=
-github.com/oteldb/storage v0.38.0/go.mod h1:6CM7jbZpdhlpJCB3HHyZw3FhPll5d5X11HDgWd9Qnj4=
+github.com/oteldb/storage v0.39.0 h1:g/KDpaJ9nzYsElA0JczFm0QOrbmk/LoMS3t2XLq+LBg=
+github.com/oteldb/storage v0.39.0/go.mod h1:6CM7jbZpdhlpJCB3HHyZw3FhPll5d5X11HDgWd9Qnj4=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/go.sum
+++ b/go.sum
@@ -1030,8 +1030,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.37.3-0.20260816211206-b7b99536087b h1:VSmAPF+QNd/4++S3RVwb/aVA6RshC81VCYXqW1Y25w8=
-github.com/oteldb/storage v0.37.3-0.20260816211206-b7b99536087b/go.mod h1:5jH3Xz5R+arp//qqdtD6v01d86UhjKhWRli1Shb0Frc=
+github.com/oteldb/storage v0.38.0 h1:MlkfHSv6V3K+2fk+tx2ev+a7hYh+7+XKs3q87XhETn4=
+github.com/oteldb/storage v0.38.0/go.mod h1:6CM7jbZpdhlpJCB3HHyZw3FhPll5d5X11HDgWd9Qnj4=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=
@@ -1210,8 +1210,9 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
+github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 github.com/testcontainers/testcontainers-go v0.44.0 h1:/Fwh6HY1mIikhnm9e7HwoxGycx0lzRAE0f5VQpjFxzI=
 github.com/testcontainers/testcontainers-go v0.44.0/go.mod h1:IcnwQrYTO86xHXu5bvMaBH7ATlbS3Qn1M1QWW3c66rE=
 github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=


### PR DESCRIPTION
`go.mod` pinned `v0.37.3-0.20260816211206-b7b99536087b`, a pseudo-version of oteldb/storage#351's branch. That work merged and `v0.38.0` is tagged at `2edbbc0`, so this repoints to the release.

`testify` moves 1.11.1 → 1.12.0 as a transitive requirement of the new storage release (storage bumped it in its own #362).

This is the last open item on #1254, which states its own closing condition: *"Until that merges and tags, `go.mod` here pins a pseudo-version of its branch."* Its three deliverables — `internal/promrw` (#1260), `internal/otlpdirect` (#1256) and `cmd/odbingest` (#1255) — are all merged.

Closes #1254.

Verified: `go build ./...`, `go test ./internal/storagebackend/... ./cmd/odbingest/...` pass.

Note for sequencing: three more storage PRs are open (oteldb/storage#371 router read API, #372 partsync coverage, #373 private-backend warning). Once those merge and tag as v0.39.0, a follow-up bump lets #1266 delete `internal/clusterquery`'s workarounds — its own `*http.Client`, a copy of storage's unexported `matchesAllSeries`/`lookupSeriesLabel`, and sequential-instead-of-hedged failover.