### PR TITLE
feat(multitenancy): resolve the query tenant from the caller's credential

### DIFF
--- a/cmd/odbselect/api.go
+++ b/cmd/odbselect/api.go
@@ -71,8 +71,9 @@ func (a *App) setupAPIs(b *storagebackend.Backend) error {
 	return nil
 }
 
-// serve registers an ogen server under name. odbselect has no auth and no <NAME>_ADDR override:
-// binds come from the config alone.
+// serve registers an ogen server under name. odbselect has no separate auth block and no
+// <NAME>_ADDR override: binds come from the config alone, and the only credential check is the
+// tenancy resolver's, when tenancy is configured.
 func serve[
 	R httpmiddleware.OgenRoute,
 	S interface {
@@ -80,10 +81,15 @@ func serve[
 		http.Handler
 	},
 ](a *App, name, bind string, server S, extra ...httpmiddleware.Middleware) {
+	middlewares := extra
+	if a.tenancy != nil {
+		middlewares = append([]httpmiddleware.Middleware{a.tenancy}, extra...)
+	}
+
 	a.servers[name] = queryapi.HTTPServer(queryapi.ServerOptions{
 		Name:    name,
 		Addr:    bind,
 		Logger:  a.lg.Named(name),
 		Metrics: a.tel,
-	}, server, extra...)
+	}, server, middlewares...)
 }

--- a/cmd/odbselect/app.go
+++ b/cmd/odbselect/app.go
@@ -13,6 +13,8 @@ import (
 	"github.com/oteldb/storage/cluster/router"
 
 	"github.com/oteldb/oteldb/internal/clusterquery"
+	"github.com/oteldb/oteldb/internal/config"
+	"github.com/oteldb/oteldb/internal/httpmiddleware"
 	"github.com/oteldb/oteldb/internal/storagebackend"
 )
 
@@ -24,6 +26,10 @@ type App struct {
 	lg     *zap.Logger
 	tel    *sdkapp.Telemetry
 	router *router.Router
+
+	// tenancy resolves each request's tenant from its credential. Nil when read-path tenancy is not
+	// configured, in which case every read serves the default tenant.
+	tenancy httpmiddleware.Middleware
 
 	servers map[string]*http.Server
 }
@@ -42,7 +48,20 @@ func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *sdkapp.Telemetry
 		servers: map[string]*http.Server{},
 	}
 
-	backend := storagebackend.NewQuery(clusterquery.New(rt))
+	tenancy, err := config.TenancyMiddleware(cfg.Tenancy)
+	if err != nil {
+		_ = rt.Close(ctx)
+
+		return nil, errors.Wrap(err, "setup tenancy")
+	}
+	app.tenancy = tenancy
+
+	var backendOpts []storagebackend.Option
+	if cfg.Tenancy.Enabled {
+		backendOpts = append(backendOpts, storagebackend.WithTenancy())
+	}
+
+	backend := storagebackend.NewQuery(clusterquery.New(rt), backendOpts...)
 
 	if err := app.setupAPIs(backend); err != nil {
 		_ = rt.Close(ctx)

--- a/cmd/odbselect/config.go
+++ b/cmd/odbselect/config.go
@@ -23,6 +23,9 @@ type Config struct {
 	Pyroscope config.Pyroscope `json:"pyroscope" yaml:"pyroscope"`
 	// Health configures the health/readiness listener.
 	Health config.HealthCheck `json:"health" yaml:"health"`
+	// Tenancy configures read-path multi-tenancy. Disabled by default, in which case every read is
+	// served from the single default tenant, exactly as before.
+	Tenancy config.Tenancy `json:"tenancy" yaml:"tenancy"`
 	// ShutdownTimeout bounds how long in-flight queries are given to finish. Zero ⇒ 30s.
 	ShutdownTimeout time.Duration `json:"shutdown_timeout" yaml:"shutdown_timeout"`
 }

--- a/cmd/oteldb/app.go
+++ b/cmd/oteldb/app.go
@@ -53,6 +53,10 @@ type App struct {
 	// the admin panel's first-class storage view. Nil when every signal is on ClickHouse.
 	storageBackend *storagebackend.Backend
 
+	// tenancy resolves each query request's tenant from its credential. Nil when read-path tenancy
+	// is not configured, in which case every read serves the default tenant.
+	tenancy httpmiddleware.Middleware
+
 	lg        *zap.Logger
 	telemetry *sdkapp.Telemetry
 	startTime time.Time
@@ -68,6 +72,16 @@ func newApp(ctx context.Context, cfg Config, m *sdkapp.Telemetry) (_ *App, err e
 		telemetry: m,
 		startTime: time.Now(),
 	}
+
+	if err := cfg.validateTenancy(); err != nil {
+		return nil, err
+	}
+
+	tenancy, err := config.TenancyMiddleware(cfg.Tenancy)
+	if err != nil {
+		return nil, errors.Wrap(err, "setup tenancy")
+	}
+	app.tenancy = tenancy
 
 	// ClickHouse is started only when a queryable signal is still served by it. Under --embedded
 	// (every signal on the embedded storage engine) ClickHouse is skipped entirely, including the
@@ -112,7 +126,14 @@ func newApp(ctx context.Context, cfg Config, m *sdkapp.Telemetry) (_ *App, err e
 	// ClickHouse. For each swapped signal both the query side (the API handler's querier) and
 	// the ingestion side (the collector exporter's sink) are replaced.
 	if cfg.usesStorageBackend() {
-		b, closeStore, err := storagebackend.Open(ctx, cfg.Storage, app.lg.Named("storage"), app.telemetry)
+		var storageOpts []storagebackend.Option
+		if cfg.Tenancy.Enabled {
+			storageOpts = append(storageOpts, storagebackend.WithTenancy())
+		}
+
+		b, closeStore, err := storagebackend.Open(
+			ctx, cfg.Storage, app.lg.Named("storage"), app.telemetry, storageOpts...,
+		)
 		if err != nil {
 			return nil, errors.Wrap(err, "setup storage backend")
 		}
@@ -198,15 +219,21 @@ func addOgen[
 		lg := lg.With(zap.String("addr", addr))
 		lg.Info("Starting HTTP server")
 
-		middlewares := additionalMiddlewares
+		var middlewares []httpmiddleware.Middleware
 		auth, err := config.AuthMiddleware(authCfg)
 		if err != nil {
 			return errors.Wrap(err, "create auth middlewares")
 		}
 		if auth != nil {
 			lg.Info("Enabling authentication middleware", zap.Int("configs", len(authCfg)))
-			middlewares = append([]httpmiddleware.Middleware{auth}, middlewares...)
+			middlewares = append(middlewares, auth)
 		}
+		// Tenancy sits inside authentication: it resolves which tenants a credential reads, while an
+		// outer authenticator only decides whether the request gets that far.
+		if app.tenancy != nil {
+			middlewares = append(middlewares, app.tenancy)
+		}
+		middlewares = append(middlewares, additionalMiddlewares...)
 
 		httpServer := queryapi.HTTPServer(queryapi.ServerOptions{
 			Name:    name,

--- a/cmd/oteldb/config.go
+++ b/cmd/oteldb/config.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-faster/errors"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/oteldb/oteldb/internal/config"
@@ -103,6 +104,10 @@ type Config struct {
 
 	// Auth is global auth config.
 	Auth []AuthConfig `json:"auth" yaml:"auth"`
+
+	// Tenancy configures read-path multi-tenancy. Disabled by default, in which case every read is
+	// served from the single default tenant, exactly as before.
+	Tenancy config.Tenancy `json:"tenancy" yaml:"tenancy"`
 
 	// Whether if enable certain collector/inserter signals.
 	CollectorSignals map[string]bool `json:"collector_signals" yaml:"collector_signals"`
@@ -232,3 +237,34 @@ const (
 	AuthTypeBasic       = config.AuthTypeBasic
 	AuthTypeBearerToken = config.AuthTypeBearerToken
 )
+
+// validateTenancy refuses a config where enabling read-path tenancy would not actually isolate
+// tenants.
+//
+// Tenancy is implemented by the embedded storage engine, where a tenant is the shard-key namespace
+// data is stored under. A signal still served by ClickHouse has no such namespace here (see #1038),
+// so it would answer every credential from the same tables — the exact cross-tenant read tenancy is
+// turned on to prevent. Refusing at startup keeps that from being a silent hole.
+func (cfg *Config) validateTenancy() error {
+	if !cfg.Tenancy.Enabled {
+		return nil
+	}
+
+	for _, s := range []struct {
+		name    string
+		backend string
+	}{
+		{"metrics", cfg.MetricsBackend},
+		{"traces", cfg.TracesBackend},
+		{"logs", cfg.LogsBackend},
+	} {
+		if s.backend != MetricsBackendStorage {
+			return errors.Errorf(
+				"tenancy.enabled requires %s_backend to be %q, got %q: ClickHouse-backed signals are not tenant-scoped",
+				s.name, MetricsBackendStorage, s.backend,
+			)
+		}
+	}
+
+	return nil
+}

--- a/cmd/oteldb/tenancy_test.go
+++ b/cmd/oteldb/tenancy_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/config"
+	"github.com/oteldb/oteldb/internal/httpmiddleware"
+)
+
+// TestValidateTenancy pins that tenancy can only be enabled where it is actually enforced: every
+// queryable signal must be served by the embedded storage engine, since a ClickHouse-backed signal
+// has no tenant scoping and would answer every credential from the same tables.
+func TestValidateTenancy(t *testing.T) {
+	enabled := config.Tenancy{
+		Enabled: true,
+		Tokens: []config.TenancyToken{{
+			Token:   httpmiddleware.Token{Token: "tok"},
+			Tenants: []string{"acme"},
+		}},
+	}
+
+	t.Run("DisabledIsAlwaysValid", func(t *testing.T) {
+		cfg := Config{}
+		cfg.setDefaults()
+		require.NoError(t, cfg.validateTenancy())
+	})
+
+	t.Run("ClickHouseSignalRefused", func(t *testing.T) {
+		cfg := Config{Tenancy: enabled}
+		cfg.setDefaults()
+		require.Error(t, cfg.validateTenancy())
+	})
+
+	t.Run("PartialStorageRefused", func(t *testing.T) {
+		cfg := Config{Tenancy: enabled}
+		cfg.useEmbeddedStorage()
+		cfg.LogsBackend = MetricsBackendClickHouse
+		cfg.setDefaults()
+		require.Error(t, cfg.validateTenancy())
+	})
+
+	t.Run("FullyEmbeddedAccepted", func(t *testing.T) {
+		cfg := Config{Tenancy: enabled}
+		cfg.useEmbeddedStorage()
+		cfg.setDefaults()
+		require.NoError(t, cfg.validateTenancy())
+	})
+}
+
+// TestTenancyConfigYAML checks the tenancy block parses from the documented YAML shape via the real
+// config loader.
+func TestTenancyConfigYAML(t *testing.T) {
+	const data = `
+tenancy:
+  enabled: true
+  selector_header: X-Scope-OrgID
+  tokens:
+    - token: acme-secret
+      tenants: [acme, acme-staging]
+      username: alice
+`
+
+	f, err := os.CreateTemp(t.TempDir(), "oteldb.yml")
+	require.NoError(t, err)
+	_, err = f.WriteString(data)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	cfg, err := loadConfig(f.Name())
+	require.NoError(t, err)
+
+	require.True(t, cfg.Tenancy.Enabled)
+	require.Equal(t, "X-Scope-OrgID", cfg.Tenancy.SelectorHeader)
+	require.Len(t, cfg.Tenancy.Tokens, 1)
+	require.Equal(t, "acme-secret", cfg.Tenancy.Tokens[0].Token.Token)
+	require.Equal(t, []string{"acme", "acme-staging"}, cfg.Tenancy.Tokens[0].Tenants)
+	require.Equal(t, "alice", cfg.Tenancy.Tokens[0].Username)
+
+	m, err := config.TenancyMiddleware(cfg.Tenancy)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+}

--- a/docs/storage-integration.md
+++ b/docs/storage-integration.md
@@ -88,6 +88,28 @@ So the pushdown path is: `PushableMatchers` → `AggregateMetricsNamed` → `Mat
 
 ## Other touch points
 
+- **Read-path tenancy:** every storage call is tenant-parameterised, and `internal/storagebackend`
+  resolves that tenant per request instead of pinning one for the backend's lifetime. It is opt-in
+  (`tenancy.enabled`, default off): without it a backend never reads the request context and serves
+  the single default tenant, exactly as before.
+
+  A tenant is granted by the *credential*, not by a header. `tenancy.tokens[]{token, tenants[],
+  username}` maps a credential to the tenants it may read (`internal/multitenancy`'s `Resolver` →
+  `Decision`); `X-Scope-OrgID` is only a selector *within* that grant, required when a credential
+  permits more than one tenant and refused (403) when it names one the credential does not permit.
+  This is deliberately not the ingest side's precedence: ingest routes trusted senders, queries
+  authorize untrusted callers, so a header that is a routing hint there would be a grant here.
+
+  It is fail-closed at both ends. With tenancy on, a read whose context carries no tenant is refused
+  with `ErrNoTenant` rather than served the default, so a route that bypassed the middleware reads
+  nothing; and `cmd/oteldb` refuses to start with tenancy enabled while any signal is still served
+  by ClickHouse, which has no tenant scoping on this path (see #1038).
+
+  The `LabelCache` shared across tenants is safe: it is keyed by the content-addressed
+  `signal.SeriesID` and its value is a pure projection of that same identity, so two tenants with an
+  identical series share one entry holding the label set both would have computed, and an entry is
+  only looked up for a series the caller's own tenant-scoped fetch returned. The library's query
+  results cache keys on the tenant set (`Storage.tenantScope`) and is not enabled by oteldb anyway.
 - **Lossy precision:** expose `tenant.Precision{Tiers: []{After, Bits}}` (age-tiered lossy float
   compression) through oteldb's per-tenant resolver, alongside Downsample/Recompress.
   **Implemented** in `internal/storagebackend/policy.go` (`tenancyOption` → `storage.WithTenancy`):
@@ -98,8 +120,9 @@ So the pushdown path is: `PushableMatchers` → `AggregateMetricsNamed` → `Mat
   max_merge_part_size}`. `max_part_size` bounds a *flushed* part's uncompressed estimate;
   `max_merge_part_size` bounds a *merged* part's compressed size on disk, and left at zero is
   derived from the backend's free space.
-  oteldb runs the embedded engine single-tenant, so a static `tenant.ResolverFunc` returns one
-  policy for every tenant — retention is therefore one global window, not per-tenant.
+  The rules written directly under `storage.policy` are the default, resolved for every tenant not
+  named under `storage.policy.tenants.<id>`; a named tenant's block replaces the default wholesale
+  rather than merging into it, so retention, limits and durability can differ per tenant.
   Both `retention.max_age` and `retention.max_bytes` are enforced by the library.
   `ec` is an age tier like `recompress`, but for durability: cold parts are stored as `data`+`parity`
   Reed-Solomon shards, one per cluster node, instead of RF full copies. It applies only under

--- a/internal/config/tenancy.go
+++ b/internal/config/tenancy.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/oteldb/internal/httpmiddleware"
+	"github.com/oteldb/oteldb/internal/multitenancy"
+	"github.com/oteldb/oteldb/internal/multitenancy/static"
+)
+
+// Tenancy configures read-path multi-tenancy: which tenants a query credential may read.
+//
+// It is off by default, and a deployment that leaves it off behaves exactly as one with no notion
+// of tenants — every read is served from the single default tenant. It is deliberately not a switch
+// that can be turned on without also naming credentials: a tenant is granted by the credential, so
+// enabling tenancy without a credential table is a config error rather than a permissive default.
+type Tenancy struct {
+	// Enabled turns read-path tenancy on. Off ⇒ no middleware is installed at all.
+	Enabled bool `json:"enabled" yaml:"enabled"`
+	// CredentialHeader is the header the credential is read from. Empty ⇒ "Authorization", whose
+	// "Bearer " prefix is stripped.
+	CredentialHeader string `json:"credential_header" yaml:"credential_header"`
+	// SelectorHeader is the header a caller picks one of its permitted tenants with, which it must
+	// do when its credential permits more than one. Empty ⇒ [multitenancy.HeaderScopeOrgID], the
+	// header a Grafana datasource sends. It only ever narrows: a tenant the credential does not
+	// permit is refused.
+	SelectorHeader string `json:"selector_header" yaml:"selector_header"`
+	// Tokens is the credential table. A credential absent from it reads nothing.
+	Tokens []TenancyToken `json:"tokens" yaml:"tokens"`
+}
+
+// TenancyToken grants one credential read access to a set of tenants.
+type TenancyToken struct {
+	httpmiddleware.Token `json:",inline" yaml:",inline"`
+	// Tenants are the tenant ids this credential may read. At least one is required — a token that
+	// grants nothing is a config mistake, not a way to spell "no access".
+	Tenants []string `json:"tenants" yaml:"tenants"`
+	// Username is informational, and the fallback quota key.
+	Username string `json:"username" yaml:"username"`
+}
+
+// TenancyMiddleware builds the read-path tenancy middleware, returning nil when tenancy is
+// disabled.
+//
+// It must be installed inside any authentication middleware: it authenticates the credential itself
+// (an unknown one is refused), so an outer authenticator only narrows who reaches it.
+func TenancyMiddleware(cfg Tenancy) (httpmiddleware.Middleware, error) {
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
+	if len(cfg.Tokens) == 0 {
+		return nil, errors.New("tenancy.tokens is required when tenancy is enabled")
+	}
+
+	decisions := make(map[string]multitenancy.Decision, len(cfg.Tokens))
+	for i, t := range cfg.Tokens {
+		value, err := t.Token.Get()
+		if err != nil {
+			return nil, errors.Wrapf(err, "tenancy.tokens[%d]", i)
+		}
+
+		if len(t.Tenants) == 0 {
+			return nil, errors.Errorf("tenancy.tokens[%d]: at least one tenant is required", i)
+		}
+
+		if _, ok := decisions[value]; ok {
+			return nil, errors.Errorf("tenancy.tokens[%d]: duplicate token", i)
+		}
+
+		decisions[value] = multitenancy.Decision{
+			Enabled:   true,
+			Username:  t.Username,
+			TenantIDs: t.Tenants,
+			QuotaKey:  t.Username,
+		}
+	}
+
+	resolver, err := static.NewResolver(static.Config{
+		Read:             decisions,
+		CredentialHeader: cfg.CredentialHeader,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "tenancy")
+	}
+
+	return multitenancy.NewMiddleware(multitenancy.MiddlewareConfig{
+		Resolver:       resolver,
+		SelectorHeader: cfg.SelectorHeader,
+	}), nil
+}

--- a/internal/config/tenancy_test.go
+++ b/internal/config/tenancy_test.go
@@ -1,0 +1,132 @@
+package config_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/config"
+	"github.com/oteldb/oteldb/internal/httpmiddleware"
+	"github.com/oteldb/oteldb/internal/multitenancy"
+)
+
+// TestTenancyMiddlewareDisabled pins that a deployment which has not opted in installs no
+// middleware at all.
+func TestTenancyMiddlewareDisabled(t *testing.T) {
+	m, err := config.TenancyMiddleware(config.Tenancy{})
+	require.NoError(t, err)
+	require.Nil(t, m)
+
+	m, err = config.TenancyMiddleware(config.Tenancy{
+		Tokens: []config.TenancyToken{{
+			Token:   httpmiddleware.Token{Token: "tok"},
+			Tenants: []string{"acme"},
+		}},
+	})
+	require.NoError(t, err)
+	require.Nil(t, m, "tokens alone must not enable tenancy")
+}
+
+// TestTenancyMiddlewareRejectsUnusableConfig pins that enabling tenancy without a usable credential
+// table is a startup error, so the easy misconfiguration fails loudly rather than permissively.
+func TestTenancyMiddlewareRejectsUnusableConfig(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cfg  config.Tenancy
+	}{
+		{
+			name: "NoTokens",
+			cfg:  config.Tenancy{Enabled: true},
+		},
+		{
+			name: "TokenWithoutTenants",
+			cfg: config.Tenancy{Enabled: true, Tokens: []config.TenancyToken{{
+				Token: httpmiddleware.Token{Token: "tok"},
+			}}},
+		},
+		{
+			name: "EmptyToken",
+			cfg: config.Tenancy{Enabled: true, Tokens: []config.TenancyToken{{
+				Tenants: []string{"acme"},
+			}}},
+		},
+		{
+			name: "DuplicateToken",
+			cfg: config.Tenancy{Enabled: true, Tokens: []config.TenancyToken{
+				{Token: httpmiddleware.Token{Token: "tok"}, Tenants: []string{"acme"}},
+				{Token: httpmiddleware.Token{Token: "tok"}, Tenants: []string{"globex"}},
+			}},
+		},
+		{
+			name: "InvalidTenantID",
+			cfg: config.Tenancy{Enabled: true, Tokens: []config.TenancyToken{{
+				Token:   httpmiddleware.Token{Token: "tok"},
+				Tenants: []string{"acme/_s0"},
+			}}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := config.TenancyMiddleware(tt.cfg)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestTenancyMiddlewareEndToEnd drives a configured middleware, covering the whole path from a
+// credential to the tenant a handler reads.
+func TestTenancyMiddlewareEndToEnd(t *testing.T) {
+	m, err := config.TenancyMiddleware(config.Tenancy{
+		Enabled: true,
+		Tokens: []config.TenancyToken{
+			{Token: httpmiddleware.Token{Token: "acme-tok"}, Tenants: []string{"acme"}, Username: "alice"},
+			{Token: httpmiddleware.Token{Token: "both-tok"}, Tenants: []string{"acme", "globex"}},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	var seen string
+	h := m(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen, _ = multitenancy.TenantFromContext(r.Context())
+	}))
+
+	do := func(token, selector string) (int, string) {
+		seen = ""
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/query", http.NoBody)
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		if selector != "" {
+			req.Header.Set(multitenancy.HeaderScopeOrgID, selector)
+		}
+
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		return rec.Code, seen
+	}
+
+	for _, tt := range []struct {
+		name     string
+		token    string
+		selector string
+		status   int
+		tenant   string
+	}{
+		{"NoCredential", "", "", http.StatusUnauthorized, ""},
+		{"UnknownCredential", "nope", "", http.StatusUnauthorized, ""},
+		{"SingleTenant", "acme-tok", "", http.StatusOK, "acme"},
+		{"HeaderCannotWidenGrant", "acme-tok", "globex", http.StatusForbidden, ""},
+		{"AmbiguousGrantNeedsSelector", "both-tok", "", http.StatusBadRequest, ""},
+		{"SelectorPicksPermittedTenant", "both-tok", "globex", http.StatusOK, "globex"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			status, tenant := do(tt.token, tt.selector)
+			require.Equal(t, tt.status, status)
+			require.Equal(t, tt.tenant, tenant)
+		})
+	}
+}

--- a/internal/multitenancy/middleware.go
+++ b/internal/multitenancy/middleware.go
@@ -1,0 +1,103 @@
+package multitenancy
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+)
+
+// Middleware is a net/http middleware.
+type Middleware = func(http.Handler) http.Handler
+
+// HeaderScopeOrgID is the header Grafana-stack clients put a tenant in, and the default
+// [MiddlewareConfig.SelectorHeader].
+//
+// On the read path it is a *selector*, never a grant: it may only narrow the tenant set the
+// credential already resolved to. A request that names a tenant its credential does not permit is
+// refused.
+const HeaderScopeOrgID = "X-Scope-OrgID"
+
+// MiddlewareConfig configures [NewMiddleware].
+type MiddlewareConfig struct {
+	// Resolver maps the request's credential to a [Decision]. Required.
+	Resolver Resolver
+	// SelectorHeader is the header a caller uses to pick one of the tenants its credential permits,
+	// which it must do when the credential permits more than one. Empty ⇒ [HeaderScopeOrgID].
+	SelectorHeader string
+}
+
+// NewMiddleware resolves each request's authorization and attaches both the [Decision] and the
+// single tenant the request reads to the context.
+//
+// Narrowing a permitted set to one tenant happens here rather than in a backend, for two reasons.
+// It is the only layer that can answer a caller — an ambiguous or refused selection is an HTTP
+// status, not a query result. And it leaves every backend with the simple contract of one tenant
+// per request, so a backend cannot accidentally read wider than it was authorized to.
+func NewMiddleware(cfg MiddlewareConfig) Middleware {
+	selector := cfg.SelectorHeader
+	if selector == "" {
+		selector = HeaderScopeOrgID
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			d, err := cfg.Resolver.Resolve(r.Context(), r, OperationRead)
+			if err != nil {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+				return
+			}
+
+			ctx := WithDecision(r.Context(), d)
+
+			tenant, code, msg := selectTenant(d, r.Header.Get(selector), selector)
+			if code != 0 {
+				http.Error(w, msg, code)
+
+				return
+			}
+
+			if tenant != "" {
+				ctx = WithTenant(ctx, tenant)
+			}
+
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// selectTenant narrows a decision to the one tenant a request reads, returning ("", 0, "") when
+// tenancy does not apply and the backend should serve its default tenant. A non-zero status is the
+// refusal to answer the caller with.
+func selectTenant(d Decision, raw, header string) (tenant string, status int, msg string) {
+	if !d.Enabled {
+		return "", 0, ""
+	}
+
+	if len(d.TenantIDs) == 0 {
+		return "", http.StatusForbidden, "credential permits no tenant"
+	}
+
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		if len(d.TenantIDs) > 1 {
+			return "", http.StatusBadRequest, "credential permits tenants " +
+				strings.Join(d.TenantIDs, ", ") + "; select one with the " + header + " header"
+		}
+		raw = d.TenantIDs[0]
+	}
+
+	// The selector is checked against the permitted set before it is validated as an id, so a
+	// malformed value cannot be distinguished from an unpermitted one — a caller probing for which
+	// tenants exist learns nothing either way.
+	if !slices.Contains(d.TenantIDs, raw) {
+		return "", http.StatusForbidden, "tenant not permitted"
+	}
+
+	id, err := ParseTenantID(raw)
+	if err != nil {
+		return "", http.StatusForbidden, "tenant not permitted"
+	}
+
+	return id, 0, ""
+}

--- a/internal/multitenancy/middleware_test.go
+++ b/internal/multitenancy/middleware_test.go
@@ -1,0 +1,199 @@
+package multitenancy_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/multitenancy"
+)
+
+// resolverFunc adapts a function to [multitenancy.Resolver].
+type resolverFunc func(*http.Request, multitenancy.Operation) (multitenancy.Decision, error)
+
+func (f resolverFunc) Resolve(
+	_ context.Context, r *http.Request, op multitenancy.Operation,
+) (multitenancy.Decision, error) {
+	return f(r, op)
+}
+
+// run drives the middleware over a request carrying the given selector header, returning the
+// response and the tenant the handler observed ("" when none was attached).
+func run(
+	t *testing.T, d multitenancy.Decision, err error, selector string,
+) (res *http.Response, tenant string) {
+	t.Helper()
+
+	var (
+		seen   string
+		called bool
+	)
+
+	mw := multitenancy.NewMiddleware(multitenancy.MiddlewareConfig{
+		Resolver: resolverFunc(func(_ *http.Request, op multitenancy.Operation) (multitenancy.Decision, error) {
+			require.Equal(t, multitenancy.OperationRead, op)
+
+			return d, err
+		}),
+	})
+
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		called = true
+		seen, _ = multitenancy.TenantFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/query", http.NoBody)
+	if selector != "" {
+		req.Header.Set(multitenancy.HeaderScopeOrgID, selector)
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	res = rec.Result()
+	t.Cleanup(func() { _ = res.Body.Close() })
+
+	if res.StatusCode != http.StatusOK {
+		require.False(t, called, "handler must not run when the request is refused")
+	}
+
+	return res, seen
+}
+
+func TestMiddlewareSelectsTenant(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		decision multitenancy.Decision
+		selector string
+		status   int
+		tenant   string
+	}{
+		{
+			name:     "DisabledPassesThroughUnscoped",
+			decision: multitenancy.Decision{},
+			status:   http.StatusOK,
+			tenant:   "",
+		},
+		{
+			name:     "SingleTenantNeedsNoSelector",
+			decision: multitenancy.Decision{Enabled: true, TenantIDs: []string{"acme"}},
+			status:   http.StatusOK,
+			tenant:   "acme",
+		},
+		{
+			name:     "SelectorNarrowsPermittedSet",
+			decision: multitenancy.Decision{Enabled: true, TenantIDs: []string{"acme", "globex"}},
+			selector: "globex",
+			status:   http.StatusOK,
+			tenant:   "globex",
+		},
+		{
+			name:     "SelectorMatchingSoleTenant",
+			decision: multitenancy.Decision{Enabled: true, TenantIDs: []string{"acme"}},
+			selector: "acme",
+			status:   http.StatusOK,
+			tenant:   "acme",
+		},
+		{
+			name:     "AmbiguousWithoutSelector",
+			decision: multitenancy.Decision{Enabled: true, TenantIDs: []string{"acme", "globex"}},
+			status:   http.StatusBadRequest,
+		},
+		{
+			name:     "SelectorCannotWidenGrant",
+			decision: multitenancy.Decision{Enabled: true, TenantIDs: []string{"acme"}},
+			selector: "globex",
+			status:   http.StatusForbidden,
+		},
+		{
+			name:     "EmptyGrantPermitsNothing",
+			decision: multitenancy.Decision{Enabled: true},
+			status:   http.StatusForbidden,
+		},
+		{
+			name:     "MalformedSelectorRefused",
+			decision: multitenancy.Decision{Enabled: true, TenantIDs: []string{"acme"}},
+			selector: "../etc",
+			status:   http.StatusForbidden,
+		},
+		{
+			name:     "SelectorEscapingShardKeyRefused",
+			decision: multitenancy.Decision{Enabled: true, TenantIDs: []string{"acme"}},
+			selector: "acme/_s0",
+			status:   http.StatusForbidden,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			res, tenant := run(t, tt.decision, nil, tt.selector)
+			require.Equal(t, tt.status, res.StatusCode)
+			require.Equal(t, tt.tenant, tenant)
+		})
+	}
+}
+
+// TestMiddlewareResolverErrorIs401 pins that an unresolvable credential is refused rather than
+// falling through unscoped.
+func TestMiddlewareResolverErrorIs401(t *testing.T) {
+	res, tenant := run(t, multitenancy.Decision{}, errors.New("unauthorized"), "")
+	require.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	require.Empty(t, tenant)
+}
+
+// TestMiddlewareAttachesDecision pins that the full decision reaches the handler, not just the
+// narrowed tenant, so a backend can also enforce restrictions and quota keys.
+func TestMiddlewareAttachesDecision(t *testing.T) {
+	want := multitenancy.Decision{
+		Enabled:   true,
+		Username:  "alice",
+		TenantIDs: []string{"acme"},
+		QuotaKey:  "acme",
+	}
+
+	mw := multitenancy.NewMiddleware(multitenancy.MiddlewareConfig{
+		Resolver: resolverFunc(func(*http.Request, multitenancy.Operation) (multitenancy.Decision, error) {
+			return want, nil
+		}),
+	})
+
+	var got multitenancy.Decision
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var ok bool
+		got, ok = multitenancy.DecisionFromContext(r.Context())
+		require.True(t, ok)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", http.NoBody))
+
+	require.Equal(t, want, got)
+}
+
+// TestMiddlewareCustomSelectorHeader pins that the selector header is configurable, and that the
+// default one is then not honored.
+func TestMiddlewareCustomSelectorHeader(t *testing.T) {
+	mw := multitenancy.NewMiddleware(multitenancy.MiddlewareConfig{
+		Resolver: resolverFunc(func(*http.Request, multitenancy.Operation) (multitenancy.Decision, error) {
+			return multitenancy.Decision{Enabled: true, TenantIDs: []string{"acme", "globex"}}, nil
+		}),
+		SelectorHeader: "X-Tenant",
+	})
+
+	var seen string
+	h := mw(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		seen, _ = multitenancy.TenantFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req.Header.Set("X-Tenant", "globex")
+	req.Header.Set(multitenancy.HeaderScopeOrgID, "acme")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "globex", seen)
+}

--- a/internal/multitenancy/multitenancy.go
+++ b/internal/multitenancy/multitenancy.go
@@ -1,0 +1,128 @@
+// Package multitenancy resolves, per request, which tenants a caller is authorized to read.
+//
+// The read path and the write path decide tenancy by different mechanisms and deliberately do not
+// share one. Ingest resolves a tenant by *routing*: the sender is a trusted collector or gateway,
+// and the question is which shard namespace its telemetry belongs to (see cmd/odbingest). Query
+// resolves a tenant by *authorization*: the caller is untrusted, and the question is what it may
+// see. Only the credential answers that, so a [Resolver] maps a credential to a [Decision] and a
+// client-supplied header can never widen it.
+//
+// The types here are storage-agnostic: what a [Decision] means is applied by the backend serving
+// the query — a tenant-scoped read on the storage engine, a predicate on ClickHouse.
+package multitenancy
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Decision is the resolved authorization result for one request.
+//
+// The zero value grants nothing: with Enabled false it is the "tenancy is not configured" answer,
+// which every caller reads as the deployment's single default tenant.
+type Decision struct {
+	// Enabled reports whether tenancy applies to this request. False bypasses tenant scoping
+	// entirely, which is what an unconfigured deployment sees.
+	Enabled bool
+	// Username is informational, and the fallback quota key.
+	Username string
+	// TenantIDs are the tenants this credential may read. It is meaningful only when Enabled: an
+	// empty set then permits nothing, whereas with Enabled false it means the scoping does not
+	// apply at all.
+	TenantIDs []string
+	// ResourceSelectors are mandatory resource-attribute filters applied on top of tenant scoping.
+	// They are enforced by backends that can inject predicates; the storage engine ignores them
+	// (see [ErrUnsupportedSelectors]).
+	ResourceSelectors []ResourceSelector
+	// QuotaKey identifies the caller for backend-side quota accounting.
+	QuotaKey string
+	// Restrictions are per-query resource limits.
+	Restrictions QueryRestrictions
+}
+
+// ResourceSelector is a mandatory filter on a resource attribute imposed by the authorization
+// layer, applied in addition to tenant scoping and before any user-supplied matcher.
+type ResourceSelector struct {
+	// Key is the resource attribute name, e.g. "service.namespace".
+	Key string
+	// Op is the match operation.
+	Op MatchOp
+	// Value is the match value.
+	Value string
+}
+
+// MatchOp is a [ResourceSelector] match operation.
+type MatchOp uint8
+
+// Supported [MatchOp] values.
+const (
+	// OpEq tests exact equality.
+	OpEq MatchOp = iota
+	// OpNotEq tests inequality.
+	OpNotEq
+	// OpRe tests a regex match.
+	OpRe
+	// OpNotRe tests a negated regex match.
+	OpNotRe
+)
+
+// QueryRestrictions are per-query resource limits a backend may enforce.
+type QueryRestrictions struct {
+	// MaxMemoryUsageBytes bounds a query's memory.
+	MaxMemoryUsageBytes uint64
+	// MaxExecutionTime bounds a query's wall time.
+	MaxExecutionTime time.Duration
+	// MaxResultRows bounds a query's result size.
+	MaxResultRows uint64
+}
+
+// Operation distinguishes the read and write trust domains, which resolve independently: the same
+// credential may read one tenant set and write another.
+type Operation uint8
+
+// Supported [Operation] values.
+const (
+	// OperationRead is the query side: what may this caller see.
+	OperationRead Operation = iota
+	// OperationWrite is the ingest side: what may this sender claim.
+	OperationWrite
+)
+
+// Resolver maps a request's credential to a [Decision].
+//
+// A Resolver is the only grant: it must derive the tenant set from the credential and must never
+// read it from a caller-supplied tenant header.
+type Resolver interface {
+	Resolve(ctx context.Context, r *http.Request, op Operation) (Decision, error)
+}
+
+type (
+	decisionKey struct{}
+	tenantKey   struct{}
+)
+
+// WithDecision attaches d to ctx.
+func WithDecision(ctx context.Context, d Decision) context.Context {
+	return context.WithValue(ctx, decisionKey{}, d)
+}
+
+// DecisionFromContext returns the [Decision] attached to ctx, if any.
+func DecisionFromContext(ctx context.Context) (Decision, bool) {
+	d, ok := ctx.Value(decisionKey{}).(Decision)
+
+	return d, ok
+}
+
+// WithTenant attaches the single tenant a request resolved to. It is set by [Middleware] after
+// narrowing [Decision.TenantIDs], so a backend never has to re-derive it (and can never widen it).
+func WithTenant(ctx context.Context, tenant string) context.Context {
+	return context.WithValue(ctx, tenantKey{}, tenant)
+}
+
+// TenantFromContext returns the tenant a request resolved to, if any.
+func TenantFromContext(ctx context.Context) (string, bool) {
+	t, ok := ctx.Value(tenantKey{}).(string)
+
+	return t, ok && t != ""
+}

--- a/internal/multitenancy/static/resolver.go
+++ b/internal/multitenancy/static/resolver.go
@@ -1,0 +1,124 @@
+// Package static resolves tenancy from a token→[multitenancy.Decision] table held in the config,
+// for a deployment with no external authorization service.
+package static
+
+import (
+	"context"
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/oteldb/internal/multitenancy"
+)
+
+// Config configures a [Resolver].
+type Config struct {
+	// Read maps a credential to the decision it gets for a read. A credential absent here is
+	// refused, so an empty table grants nothing.
+	Read map[string]multitenancy.Decision
+	// Write is [Config.Read] for the ingest side, resolved independently so one credential can read
+	// and write different tenant sets.
+	Write map[string]multitenancy.Decision
+	// CredentialHeader is the header the credential is read from. Empty ⇒ "Authorization", whose
+	// "Bearer " prefix is stripped.
+	CredentialHeader string
+}
+
+// Resolver is a [multitenancy.Resolver] over a fixed credential table.
+type Resolver struct {
+	read   []entry
+	write  []entry
+	header string
+}
+
+type entry struct {
+	credential string
+	decision   multitenancy.Decision
+}
+
+// NewResolver builds a [Resolver] from cfg, validating every tenant id it grants so a typo is a
+// startup error rather than a query that reaches the storage layer with an unusable shard key.
+func NewResolver(cfg Config) (*Resolver, error) {
+	read, err := entries(cfg.Read)
+	if err != nil {
+		return nil, errors.Wrap(err, "read")
+	}
+
+	write, err := entries(cfg.Write)
+	if err != nil {
+		return nil, errors.Wrap(err, "write")
+	}
+
+	header := cfg.CredentialHeader
+	if header == "" {
+		header = "Authorization"
+	}
+
+	return &Resolver{read: read, write: write, header: header}, nil
+}
+
+func entries(m map[string]multitenancy.Decision) ([]entry, error) {
+	out := make([]entry, 0, len(m))
+	for cred, d := range m {
+		if cred == "" {
+			return nil, errors.New("empty credential")
+		}
+
+		for i, t := range d.TenantIDs {
+			id, err := multitenancy.ParseTenantID(t)
+			if err != nil {
+				return nil, errors.Wrap(err, "tenant")
+			}
+
+			d.TenantIDs[i] = id
+		}
+
+		out = append(out, entry{credential: cred, decision: d})
+	}
+
+	return out, nil
+}
+
+// Resolve implements [multitenancy.Resolver].
+func (r *Resolver) Resolve(
+	_ context.Context, req *http.Request, op multitenancy.Operation,
+) (multitenancy.Decision, error) {
+	cred := req.Header.Get(r.header)
+	if cred == "" {
+		return multitenancy.Decision{}, errors.New("missing credential")
+	}
+
+	if r.header == "Authorization" {
+		if v, ok := strings.CutPrefix(cred, "Bearer "); ok {
+			cred = strings.TrimSpace(v)
+		}
+	}
+
+	var table []entry
+	switch op {
+	case multitenancy.OperationRead:
+		table = r.read
+	case multitenancy.OperationWrite:
+		table = r.write
+	default:
+		return multitenancy.Decision{}, errors.Errorf("unknown operation %d", op)
+	}
+
+	// Scanned rather than looked up so a wrong credential costs the same time as a right one,
+	// matching how [httpmiddleware.BearerToken] compares its tokens.
+	found := false
+	var d multitenancy.Decision
+	for _, e := range table {
+		if subtle.ConstantTimeCompare([]byte(cred), []byte(e.credential)) == 1 {
+			d, found = e.decision, true
+		}
+	}
+
+	if !found {
+		return multitenancy.Decision{}, errors.New("unauthorized")
+	}
+
+	return d, nil
+}

--- a/internal/multitenancy/static/resolver_test.go
+++ b/internal/multitenancy/static/resolver_test.go
@@ -1,0 +1,91 @@
+package static_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/multitenancy"
+	"github.com/oteldb/oteldb/internal/multitenancy/static"
+)
+
+func TestResolver(t *testing.T) {
+	ctx := context.Background()
+
+	r, err := static.NewResolver(static.Config{
+		Read: map[string]multitenancy.Decision{
+			"acme-token": {Enabled: true, TenantIDs: []string{"acme"}, Username: "alice"},
+		},
+		Write: map[string]multitenancy.Decision{
+			"acme-token": {Enabled: true, TenantIDs: []string{"acme", "acme-staging"}},
+		},
+	})
+	require.NoError(t, err)
+
+	req := func(auth string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		if auth != "" {
+			r.Header.Set("Authorization", auth)
+		}
+
+		return r
+	}
+
+	t.Run("BearerPrefixStripped", func(t *testing.T) {
+		d, err := r.Resolve(ctx, req("Bearer acme-token"), multitenancy.OperationRead)
+		require.NoError(t, err)
+		require.Equal(t, []string{"acme"}, d.TenantIDs)
+		require.Equal(t, "alice", d.Username)
+	})
+
+	t.Run("BareToken", func(t *testing.T) {
+		d, err := r.Resolve(ctx, req("acme-token"), multitenancy.OperationRead)
+		require.NoError(t, err)
+		require.True(t, d.Enabled)
+	})
+
+	t.Run("ReadAndWriteResolveIndependently", func(t *testing.T) {
+		d, err := r.Resolve(ctx, req("acme-token"), multitenancy.OperationWrite)
+		require.NoError(t, err)
+		require.Equal(t, []string{"acme", "acme-staging"}, d.TenantIDs)
+	})
+
+	t.Run("UnknownCredential", func(t *testing.T) {
+		_, err := r.Resolve(ctx, req("nope"), multitenancy.OperationRead)
+		require.Error(t, err)
+	})
+
+	t.Run("MissingCredential", func(t *testing.T) {
+		_, err := r.Resolve(ctx, req(""), multitenancy.OperationRead)
+		require.Error(t, err)
+	})
+}
+
+// TestResolverValidatesTenants pins that a tenant id which is unusable as a shard key is a
+// construction error, so it can never reach the storage layer.
+func TestResolverValidatesTenants(t *testing.T) {
+	_, err := static.NewResolver(static.Config{
+		Read: map[string]multitenancy.Decision{
+			"tok": {Enabled: true, TenantIDs: []string{"acme/_s0"}},
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestResolverCustomHeader(t *testing.T) {
+	r, err := static.NewResolver(static.Config{
+		Read:             map[string]multitenancy.Decision{"tok": {Enabled: true, TenantIDs: []string{"acme"}}},
+		CredentialHeader: "X-API-Key",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req.Header.Set("X-API-Key", "tok")
+
+	d, err := r.Resolve(context.Background(), req, multitenancy.OperationRead)
+	require.NoError(t, err)
+	require.Equal(t, []string{"acme"}, d.TenantIDs)
+}

--- a/internal/multitenancy/tenantid.go
+++ b/internal/multitenancy/tenantid.go
@@ -1,0 +1,43 @@
+package multitenancy
+
+import (
+	"strings"
+
+	"github.com/go-faster/errors"
+)
+
+// MaxTenantLen bounds a tenant id. A tenant id becomes a shard key, which becomes a backend path
+// segment and an etcd key component, so an unbounded one is a way to make keys nobody can address.
+const MaxTenantLen = 150
+
+// ParseTenantID validates a tenant id, returning it trimmed.
+//
+// The character set is what stays safe as a backend path segment and an etcd key, and excludes
+// cluster.ShardSep so a tenant id can never be mistaken for the shard key derived from it. It is
+// the same rule the ingest side applies, because the constraint is about the storage layer rather
+// than about where the id came from: any id reaching it, from either direction, must satisfy it.
+func ParseTenantID(s string) (string, error) {
+	s = strings.TrimSpace(s)
+
+	switch {
+	case s == "":
+		return "", errors.New("empty tenant id")
+	case len(s) > MaxTenantLen:
+		return "", errors.Errorf("tenant id longer than %d bytes", MaxTenantLen)
+	case s == "." || s == "..":
+		return "", errors.Errorf("invalid tenant id %q", s)
+	}
+
+	for _, c := range []byte(s) {
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.':
+		default:
+			return "", errors.Errorf("invalid character %q in tenant id", string(c))
+		}
+	}
+
+	return s, nil
+}

--- a/internal/multitenancy/tenantid_test.go
+++ b/internal/multitenancy/tenantid_test.go
@@ -1,0 +1,52 @@
+package multitenancy_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/multitenancy"
+)
+
+func TestParseTenantID(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"Simple", "acme", "acme"},
+		{"Trimmed", "  acme  ", "acme"},
+		{"Punctuation", "acme-prod_1.eu", "acme-prod_1.eu"},
+		{"MaxLen", strings.Repeat("a", multitenancy.MaxTenantLen), strings.Repeat("a", multitenancy.MaxTenantLen)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := multitenancy.ParseTenantID(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+
+	for _, tt := range []struct {
+		name  string
+		input string
+	}{
+		{"Empty", ""},
+		{"Blank", "   "},
+		{"Dot", "."},
+		{"DotDot", ".."},
+		{"Slash", "acme/prod"},
+		{"Backslash", `acme\prod`},
+		{"ShardSep", "acme/_s0"},
+		{"Space", "acme prod"},
+		{"NUL", "acme\x00"},
+		{"Newline", "acme\nprod"},
+		{"Unicode", "acmé"},
+		{"TooLong", strings.Repeat("a", multitenancy.MaxTenantLen+1)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := multitenancy.ParseTenantID(tt.input)
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -123,11 +123,16 @@ type fetchOptions struct {
 // batches for [lo, hi]. Shared by the entry-materialization path (EvalPipeline) and the bucketed
 // sampling path (bucketSamplingNode.EvalBucketedSample).
 func (n *logStreamNode) fetchBatches(ctx context.Context, lo, hi int64, opts fetchOptions) (_ []*fetch.Batch, selectorPushed bool, _ error) {
+	tenant, err := n.q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
 	// Offload equality matchers: resource/scope labels prune streams via the postings index, clean
 	// record-attribute labels drop records via a per-record condition — both before materialization.
-	matchers, selConds, selectorPushed := n.streamFilters(ctx, lo, hi)
+	matchers, selConds, selectorPushed := n.streamFilters(ctx, tenant, lo, hi)
 	req := fetch.Request{
-		Tenant:     n.q.b.tenant,
+		Tenant:     tenant,
 		Signal:     signal.Log,
 		Start:      lo,
 		End:        hi,
@@ -150,7 +155,7 @@ func (n *logStreamNode) fetchBatches(ctx context.Context, lo, hi int64, opts fet
 		req.AllConditions = true
 	}
 
-	it, err := n.q.b.src.LogFetcher(n.q.b.tenant).Fetch(ctx, req)
+	it, err := n.q.b.src.LogFetcher(tenant).Fetch(ctx, req)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "fetch logs")
 	}
@@ -289,7 +294,9 @@ func (n *logStreamNode) materializeRange(batches []*fetch.Batch, offsets []int, 
 // selectorPushed reports whether every selector matcher is applied exactly by the returned filters,
 // so a fetched record needs no in-memory matchSelector re-check (used by the bucketed sampling fast
 // path). It shares the single LogKeys lookup.
-func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matchers []fetch.Matcher, conditions []fetch.Condition, selectorPushed bool) {
+func (n *logStreamNode) streamFilters(
+	ctx context.Context, tenant signal.TenantID, lo, hi int64,
+) (matchers []fetch.Matcher, conditions []fetch.Condition, selectorPushed bool) {
 	var (
 		// wanted holds the pushable matchers per label; a label may carry several, which AND.
 		wanted = map[string][]logql.LabelMatcher{}
@@ -314,7 +321,7 @@ func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matche
 		return nil, nil, len(n.selector) == 0
 	}
 
-	keys, err := n.q.b.src.LogKeys(ctx, n.q.b.tenant, lo, hi)
+	keys, err := n.q.b.src.LogKeys(ctx, tenant, lo, hi)
 	if err != nil {
 		return nil, nil, false // best effort: fall back to in-memory filtering.
 	}
@@ -537,8 +544,13 @@ func (q *LogQuerier) LabelNames(ctx context.Context, opts logstorage.LabelsOptio
 	// rather than stream-scoped, so only fold them in for an unfiltered listing — a stream selector
 	// can't soundly restrict them.
 	if len(opts.Query.Matchers) == 0 {
+		tenant, err := q.b.tenantFor(ctx)
+		if err != nil {
+			return nil, err
+		}
+
 		lo, hi := seriesWindow(opts.Start, opts.End)
-		keys, err := q.b.src.LogKeys(ctx, q.b.tenant, lo, hi)
+		keys, err := q.b.src.LogKeys(ctx, tenant, lo, hi)
 		if err != nil {
 			return nil, errors.Wrap(err, "log keys")
 		}
@@ -654,8 +666,13 @@ func (q *LogQuerier) DetectedFields(ctx context.Context, opts logstorage.LabelsO
 
 // logStreams returns the label sets of the streams matching the selector within [start, end].
 func (q *LogQuerier) logStreams(ctx context.Context, start, end time.Time, matchers []logql.LabelMatcher) ([]logqlabels.LabelSet, error) {
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	lo, hi := seriesWindow(start, end)
-	series, err := q.b.src.LogSeries(ctx, q.b.tenant, nil, lo, hi)
+	series, err := q.b.src.LogSeries(ctx, tenant, nil, lo, hi)
 	if err != nil {
 		return nil, errors.Wrap(err, "log series")
 	}

--- a/internal/storagebackend/open.go
+++ b/internal/storagebackend/open.go
@@ -33,7 +33,9 @@ import (
 // Open constructs the embedded storage engine and an adapter implementing
 // oteldb's metric query and ingestion interfaces. The returned close func stops and flushes
 // the engine. It is used when [Config.MetricsBackend] is [MetricsBackendStorage].
-func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*Backend, func(context.Context) error, error) {
+func Open(
+	ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry, backendOpts ...Option,
+) (*Backend, func(context.Context) error, error) {
 	// The engine logs, traces, and meters through the injected providers (no-op if absent).
 	opts := []storage.Option{
 		storage.WithLogger(lg),
@@ -96,6 +98,7 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 			zap.Int("downsample_tiers", len(cfg.Policy.Downsample)),
 			zap.Bool("recompress", cfg.Policy.Recompress != nil),
 			zap.Bool("ec", cfg.Policy.EC != nil),
+			zap.Int("tenant_policies", len(cfg.Policy.Tenants)),
 			zap.Duration("retention_max_age", retentionMaxAge(cfg.Policy.Retention)),
 			zap.Bool("limits", cfg.Policy.Limits != nil),
 		)
@@ -119,9 +122,7 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 		zap.Int64("merge_memory_bytes", caches.MergeMemory),
 		zap.Bool("aggregate_stats", caches.AggregateStats),
 	)
-	b := New(store,
-		WithLogParallelism(cfg.LogQueryParallelism),
-	)
+	b := New(store, append([]Option{WithLogParallelism(cfg.LogQueryParallelism)}, backendOpts...)...)
 	return b, store.Close, nil
 }
 

--- a/internal/storagebackend/open_internal_test.go
+++ b/internal/storagebackend/open_internal_test.go
@@ -101,7 +101,7 @@ func TestTenancyOption(t *testing.T) {
 	})
 
 	t.Run("ResolvesPolicyForEveryTenant", func(t *testing.T) {
-		opt, err := tenancyOption(&PolicyConfig{
+		opt, err := tenancyOption(&PolicyConfig{PolicyRules: PolicyRules{
 			Precision: []PrecisionTierConfig{
 				{After: 7 * 24 * time.Hour, Bits: 32},
 				{After: 30 * 24 * time.Hour, Bits: 16},
@@ -121,7 +121,7 @@ func TestTenancyOption(t *testing.T) {
 				MaxPartSize:          32 << 20,
 				MaxMergePartSize:     512 << 20,
 			},
-		})
+		}})
 		require.NoError(t, err)
 		o := applyOption(t, opt)
 		require.NotNil(t, o.Tenancy)
@@ -163,9 +163,9 @@ func TestTenancyOption(t *testing.T) {
 	})
 
 	t.Run("RetentionOnlyInstallsResolver", func(t *testing.T) {
-		opt, err := tenancyOption(&PolicyConfig{
+		opt, err := tenancyOption(&PolicyConfig{PolicyRules: PolicyRules{
 			Retention: &RetentionConfig{MaxAge: 14 * 24 * time.Hour},
-		})
+		}})
 		require.NoError(t, err)
 		o := applyOption(t, opt)
 		require.NotNil(t, o.Tenancy, "a retention-only policy must still install a resolver")
@@ -173,9 +173,9 @@ func TestTenancyOption(t *testing.T) {
 	})
 
 	t.Run("LimitsOnlyInstallsResolver", func(t *testing.T) {
-		opt, err := tenancyOption(&PolicyConfig{
+		opt, err := tenancyOption(&PolicyConfig{PolicyRules: PolicyRules{
 			Limits: &LimitsConfig{MaxSeries: 1000},
-		})
+		}})
 		require.NoError(t, err)
 		o := applyOption(t, opt)
 		require.NotNil(t, o.Tenancy)
@@ -183,9 +183,9 @@ func TestTenancyOption(t *testing.T) {
 	})
 
 	t.Run("ECOnlyInstallsResolver", func(t *testing.T) {
-		opt, err := tenancyOption(&PolicyConfig{
+		opt, err := tenancyOption(&PolicyConfig{PolicyRules: PolicyRules{
 			EC: &ECConfig{Data: 6, Parity: 3},
-		})
+		}})
 		require.NoError(t, err)
 		o := applyOption(t, opt)
 		require.NotNil(t, o.Tenancy, "an EC-only policy must still install a resolver")
@@ -206,30 +206,30 @@ func TestTenancyOption(t *testing.T) {
 			"NegativeAfter": {Data: 4, Parity: 2, After: -time.Hour},
 		} {
 			t.Run(name, func(t *testing.T) {
-				_, err := tenancyOption(&PolicyConfig{EC: cfg})
+				_, err := tenancyOption(&PolicyConfig{PolicyRules: PolicyRules{EC: cfg}})
 				require.Error(t, err)
 			})
 		}
 	})
 
 	t.Run("UnknownAggIsAnError", func(t *testing.T) {
-		_, err := tenancyOption(&PolicyConfig{
+		_, err := tenancyOption(&PolicyConfig{PolicyRules: PolicyRules{
 			Downsample: []DownsampleTierConfig{{Interval: time.Minute, Agg: "median"}},
-		})
+		}})
 		require.Error(t, err)
 	})
 
 	t.Run("NegativeRetentionIsAnError", func(t *testing.T) {
-		_, err := tenancyOption(&PolicyConfig{
+		_, err := tenancyOption(&PolicyConfig{PolicyRules: PolicyRules{
 			Retention: &RetentionConfig{MaxAge: -time.Hour},
-		})
+		}})
 		require.Error(t, err)
 	})
 
 	t.Run("SoftSeriesAboveHardIsAnError", func(t *testing.T) {
-		_, err := tenancyOption(&PolicyConfig{
+		_, err := tenancyOption(&PolicyConfig{PolicyRules: PolicyRules{
 			Limits: &LimitsConfig{MaxSeries: 100, MaxSeriesSoft: 200},
-		})
+		}})
 		require.Error(t, err)
 	})
 }
@@ -237,7 +237,7 @@ func TestTenancyOption(t *testing.T) {
 func TestWarnECInert(t *testing.T) {
 	sharedNothing := &ClusterConfig{Etcd: []string{"http://etcd:2379"}, PrivateBackend: true}
 	sharedStore := &ClusterConfig{Etcd: []string{"http://etcd:2379"}}
-	ecPolicy := &PolicyConfig{EC: &ECConfig{Data: 4, Parity: 2}}
+	ecPolicy := &PolicyConfig{PolicyRules: PolicyRules{EC: &ECConfig{Data: 4, Parity: 2}}}
 
 	for name, tt := range map[string]struct {
 		cluster *ClusterConfig
@@ -248,7 +248,7 @@ func TestWarnECInert(t *testing.T) {
 		"SharedStore":        {sharedStore, ecPolicy, true},
 		"SingleNode":         {nil, ecPolicy, true},
 		"ClusterWithoutEtcd": {&ClusterConfig{ID: "n1"}, ecPolicy, true},
-		"NoECPolicy":         {sharedStore, &PolicyConfig{Retention: &RetentionConfig{}}, false},
+		"NoECPolicy":         {sharedStore, &PolicyConfig{PolicyRules: PolicyRules{Retention: &RetentionConfig{}}}, false},
 		"NoPolicy":           {sharedStore, nil, false},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/storagebackend/policy.go
+++ b/internal/storagebackend/policy.go
@@ -11,17 +11,29 @@ import (
 	"github.com/oteldb/storage/signal"
 	"github.com/oteldb/storage/tenant"
 
+	"github.com/oteldb/oteldb/internal/multitenancy"
 	"github.com/oteldb/oteldb/internal/xbytes"
 )
 
-// PolicyConfig configures the per-tenant storage policy applied to the embedded engine's
-// background merges: age-tiered lossy float precision, downsampling, cold-data recompression, and
-// cold-data erasure coding.
-// The storage library resolves these per-tenant via a [tenant.Resolver] callback; oteldb runs the
-// embedded engine single-tenant (every signal routes to the "default" tenant), so this one policy
-// is resolved for every tenant. Empty ⇒ no tenancy resolver is installed (the library default:
-// lossless, no rollup, no recompression).
+// PolicyConfig configures the storage policy applied to the embedded engine's background merges:
+// age-tiered lossy float precision, downsampling, cold-data recompression, and cold-data erasure
+// coding.
+//
+// The rules declared inline are the default policy, resolved for every tenant that Tenants does not
+// name. Empty (no default rules and no per-tenant ones) ⇒ no tenancy resolver is installed (the
+// library default: lossless, no rollup, no recompression).
 type PolicyConfig struct {
+	// PolicyRules is the default policy, applied to every tenant Tenants does not name. It is
+	// inlined, so a single-tenant deployment spells its policy exactly as before.
+	PolicyRules `json:",inline" yaml:",inline"`
+	// Tenants overrides the default policy per tenant id. A named tenant's policy replaces the
+	// default wholesale rather than merging into it, so a tenant's retention and limits can be read
+	// off its own block without consulting the default.
+	Tenants map[string]PolicyRules `json:"tenants" yaml:"tenants"`
+}
+
+// PolicyRules is one tenant's merge-time storage policy.
+type PolicyRules struct {
 	// Precision is the age-tiered lossy float-compression policy: each tier re-encodes, at merge,
 	// the value column of parts older than After to retain only Bits significant mantissa bits, so
 	// recent data stays lossless and only old data trades accuracy for size. Empty ⇒ lossless.
@@ -160,7 +172,7 @@ func retentionMaxAge(cfg *RetentionConfig) time.Duration {
 // deployment is still correct, only paying for a policy it does not get. Refusing would also turn
 // a config that is valid on its own into a startup failure decided by an unrelated section.
 func warnECInert(cluster *ClusterConfig, policy *PolicyConfig, lg *zap.Logger) {
-	if policy == nil || policy.EC == nil {
+	if policy == nil || !policy.usesEC() {
 		return
 	}
 
@@ -179,8 +191,23 @@ func warnECInert(cluster *ClusterConfig, policy *PolicyConfig, lg *zap.Logger) {
 	)
 }
 
-// empty reports whether the policy configures nothing, in which case no resolver is installed.
-func (cfg *PolicyConfig) empty() bool {
+// usesEC reports whether any tenant's policy configures erasure coding.
+func (cfg *PolicyConfig) usesEC() bool {
+	if cfg.EC != nil {
+		return true
+	}
+
+	for _, rules := range cfg.Tenants {
+		if rules.EC != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+// empty reports whether the rules configure nothing, in which case no resolver is installed.
+func (cfg *PolicyRules) empty() bool {
 	return cfg == nil || (len(cfg.Precision) == 0 &&
 		len(cfg.Downsample) == 0 &&
 		cfg.Recompress == nil &&
@@ -190,26 +217,52 @@ func (cfg *PolicyConfig) empty() bool {
 }
 
 // tenancyOption builds the storage tenancy option from the policy config, or returns (nil, nil)
-// when no policy is configured. The resolved policy is applied to every tenant — oteldb runs the
-// embedded engine single-tenant, so a static resolver suffices.
+// when no policy is configured at all.
+//
+// The resolver is a lookup rather than a constant: the library asks per tenant, so a named tenant
+// gets its own policy and everything else the default. The table is built once at startup, so an
+// invalid tenant id or aggregation name is a startup error rather than a policy that silently never
+// resolves.
 func tenancyOption(cfg *PolicyConfig) (storage.Option, error) {
-	if cfg.empty() {
+	if cfg == nil || (cfg.PolicyRules.empty() && len(cfg.Tenants) == 0) {
 		return nil, nil
 	}
 
-	policy, err := cfg.policy()
+	def, err := cfg.PolicyRules.policy()
 	if err != nil {
 		return nil, err
 	}
 
-	return storage.WithTenancy(tenant.ResolverFunc(func(signal.TenantID) tenant.Policy {
-		return policy
+	var byTenant map[signal.TenantID]tenant.Policy
+	if len(cfg.Tenants) > 0 {
+		byTenant = make(map[signal.TenantID]tenant.Policy, len(cfg.Tenants))
+		for name, rules := range cfg.Tenants {
+			id, err := multitenancy.ParseTenantID(name)
+			if err != nil {
+				return nil, errors.Wrap(err, "policy.tenants")
+			}
+
+			p, err := rules.policy()
+			if err != nil {
+				return nil, errors.Wrapf(err, "policy.tenants[%q]", name)
+			}
+
+			byTenant[signal.TenantID(id)] = p
+		}
+	}
+
+	return storage.WithTenancy(tenant.ResolverFunc(func(id signal.TenantID) tenant.Policy {
+		if p, ok := byTenant[id]; ok {
+			return p
+		}
+
+		return def
 	})), nil
 }
 
 // policy translates the config into a [tenant.Policy]. It validates the downsample aggregation
 // names so a typo is a startup error rather than a silently-ignored tier.
-func (cfg *PolicyConfig) policy() (tenant.Policy, error) {
+func (cfg *PolicyRules) policy() (tenant.Policy, error) {
 	var p tenant.Policy
 
 	for _, t := range cfg.Precision {

--- a/internal/storagebackend/policy_internal_test.go
+++ b/internal/storagebackend/policy_internal_test.go
@@ -1,0 +1,117 @@
+package storagebackend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/signal"
+	"github.com/oteldb/storage/tenant"
+
+	"github.com/go-faster/yaml"
+)
+
+// resolvePolicy builds the tenancy option from cfg and returns the resolver the storage library
+// would consult.
+func resolvePolicy(t *testing.T, cfg *PolicyConfig) tenant.Resolver {
+	t.Helper()
+
+	opt, err := tenancyOption(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, opt)
+
+	var opts storage.Options
+	opt(&opts)
+	require.NotNil(t, opts.Tenancy)
+
+	return opts.Tenancy
+}
+
+// TestPolicyPerTenant pins that a named tenant gets its own policy and every other tenant gets the
+// default one declared inline.
+func TestPolicyPerTenant(t *testing.T) {
+	r := resolvePolicy(t, &PolicyConfig{
+		PolicyRules: PolicyRules{
+			Retention: &RetentionConfig{MaxAge: 24 * time.Hour},
+		},
+		Tenants: map[string]PolicyRules{
+			"acme": {Retention: &RetentionConfig{MaxAge: 30 * 24 * time.Hour}},
+		},
+	})
+
+	require.Equal(t, 30*24*time.Hour, r.Resolve(signal.TenantID("acme")).Retention.MaxAge)
+	require.Equal(t, 24*time.Hour, r.Resolve(signal.TenantID("globex")).Retention.MaxAge,
+		"an unlisted tenant falls back to the default policy")
+	require.Equal(t, 24*time.Hour, r.Resolve(signal.TenantID("default")).Retention.MaxAge)
+}
+
+// TestPolicyPerTenantWithoutDefault pins that per-tenant policies alone install a resolver, and
+// that an unlisted tenant then gets the zero policy rather than nothing being installed.
+func TestPolicyPerTenantWithoutDefault(t *testing.T) {
+	r := resolvePolicy(t, &PolicyConfig{
+		Tenants: map[string]PolicyRules{
+			"acme": {Retention: &RetentionConfig{MaxAge: time.Hour}},
+		},
+	})
+
+	require.Equal(t, time.Hour, r.Resolve(signal.TenantID("acme")).Retention.MaxAge)
+	require.Zero(t, r.Resolve(signal.TenantID("globex")).Retention.MaxAge)
+}
+
+// TestPolicyPerTenantValidation pins that a bad tenant id or a bad rule inside a tenant's block is a
+// startup error rather than a policy that silently never applies.
+func TestPolicyPerTenantValidation(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cfg  *PolicyConfig
+	}{
+		{
+			name: "InvalidTenantID",
+			cfg: &PolicyConfig{Tenants: map[string]PolicyRules{
+				"acme/_s0": {Retention: &RetentionConfig{MaxAge: time.Hour}},
+			}},
+		},
+		{
+			name: "InvalidRule",
+			cfg: &PolicyConfig{Tenants: map[string]PolicyRules{
+				"acme": {Downsample: []DownsampleTierConfig{{After: time.Hour, Interval: time.Minute, Agg: "nope"}}},
+			}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tenancyOption(tt.cfg)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestPolicyYAMLShape pins that making the policy tenant-keyed did not move the default rules under
+// a nested key: a config written before this change must still parse identically.
+func TestPolicyYAMLShape(t *testing.T) {
+	const src = `
+retention:
+  max_age: 24h
+precision:
+  - after: 1h
+    bits: 10
+tenants:
+  acme:
+    retention:
+      max_age: 720h
+`
+
+	var cfg PolicyConfig
+	require.NoError(t, yaml.Unmarshal([]byte(src), &cfg))
+
+	require.NotNil(t, cfg.Retention)
+	require.Equal(t, 24*time.Hour, cfg.Retention.MaxAge)
+	require.Len(t, cfg.Precision, 1)
+	require.Equal(t, uint8(10), cfg.Precision[0].Bits)
+
+	acme, ok := cfg.Tenants["acme"]
+	require.True(t, ok)
+	require.NotNil(t, acme.Retention)
+	require.Equal(t, 720*time.Hour, acme.Retention.MaxAge)
+}

--- a/internal/storagebackend/profiles.go
+++ b/internal/storagebackend/profiles.go
@@ -31,8 +31,13 @@ var reservedProfileLabels = map[string]struct{}{
 // ProfileTypes implements [profilestorage.Querier]. It enumerates the distinct profile types of the
 // tenant's streams in the window, reading the type out of each series' reserved labels.
 func (q *ProfileQuerier) ProfileTypes(ctx context.Context, opts profilestorage.ProfileTypesOptions) ([]profileql.ProfileType, error) {
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	start, end := seriesWindow(opts.Start, opts.End)
-	series, err := q.b.src.ProfileSeries(ctx, q.b.tenant, nil, start, end)
+	series, err := q.b.src.ProfileSeries(ctx, tenant, nil, start, end)
 	if err != nil {
 		return nil, errors.Wrap(err, "profile series")
 	}
@@ -58,8 +63,13 @@ func (q *ProfileQuerier) LabelNames(ctx context.Context, opts profilestorage.Lab
 	if err != nil {
 		return nil, err
 	}
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	start, end := seriesWindow(opts.Start, opts.End)
-	series, err := q.b.src.ProfileSeries(ctx, q.b.tenant, matchers, start, end)
+	series, err := q.b.src.ProfileSeries(ctx, tenant, matchers, start, end)
 	if err != nil {
 		return nil, errors.Wrap(err, "profile series")
 	}
@@ -78,8 +88,13 @@ func (q *ProfileQuerier) LabelValues(ctx context.Context, label string, opts pro
 	if err != nil {
 		return nil, err
 	}
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	start, end := seriesWindow(opts.Start, opts.End)
-	series, err := q.b.src.ProfileSeries(ctx, q.b.tenant, matchers, start, end)
+	series, err := q.b.src.ProfileSeries(ctx, tenant, matchers, start, end)
 	if err != nil {
 		return nil, errors.Wrap(err, "profile series")
 	}
@@ -104,14 +119,19 @@ func (q *ProfileQuerier) SelectMergeProfile(ctx context.Context, params profiles
 		return nil, err
 	}
 
-	resolver, err := q.b.src.ProfileResolver(ctx, q.b.tenant)
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resolver, err := q.b.src.ProfileResolver(ctx, tenant)
 	if err != nil {
 		return nil, errors.Wrap(err, "profile resolver")
 	}
 
 	lo, hi := fetchWindow(params.Start, params.End)
 	req := fetch.Request{
-		Tenant:     q.b.tenant,
+		Tenant:     tenant,
 		Signal:     signal.Profile,
 		Start:      lo,
 		End:        hi,
@@ -119,7 +139,7 @@ func (q *ProfileQuerier) SelectMergeProfile(ctx context.Context, params profiles
 		Projection: []string{sigprofile.ColStackID, sigprofile.ColValue},
 	}
 
-	it, err := q.b.src.ProfileFetcher(q.b.tenant).Fetch(ctx, req)
+	it, err := q.b.src.ProfileFetcher(tenant).Fetch(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch profiles")
 	}

--- a/internal/storagebackend/scarecrow_scanner.go
+++ b/internal/storagebackend/scarecrow_scanner.go
@@ -68,8 +68,13 @@ func (s *scarecrowScanner) AggregateGrid(
 		lastEnd  = grid.Start + int64(grid.NumSteps-1)*grid.Step
 	)
 
-	named, err := s.b.src.AggregateMetricsWindowNamed(ctx, s.b.tenant, fetch.Request{
-		Tenant: s.b.tenant,
+	tenant, err := s.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	named, err := s.b.src.AggregateMetricsWindowNamed(ctx, tenant, fetch.Request{
+		Tenant: tenant,
 		Scope:  s.scope,
 		// Lead-in: the first window opens a full width before the first step.
 		Start:    (firstEnd - grid.Width + 1) * nsPerMs,
@@ -138,8 +143,13 @@ func (s *scarecrowScanner) AggregateOverTime(
 
 	// scarecrow's window is PromQL's half-open (mint, maxt]; storage's fetch range is inclusive,
 	// so mint is exclusive (start = mint+1 ms) and maxt inclusive.
-	aggs, err := s.b.src.AggregateMetricsNamed(ctx, s.b.tenant, fetch.Request{
-		Tenant:   s.b.tenant,
+	tenant, err := s.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	aggs, err := s.b.src.AggregateMetricsNamed(ctx, tenant, fetch.Request{
+		Tenant:   tenant,
 		Scope:    s.scope,
 		Start:    (mint + 1) * nsPerMs,
 		End:      maxt * nsPerMs,
@@ -178,7 +188,12 @@ func (s *scarecrowScanner) AggregateOverTime(
 func (s *scarecrowScanner) CountSeries(
 	ctx context.Context, mint, maxt int64, matchers []*labels.Matcher,
 ) (uint64, error) {
-	q, err := s.b.queryable().QuerierWithScope(mint, maxt, s.scope)
+	tenant, err := s.b.tenantFor(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	q, err := s.b.queryable(tenant).QuerierWithScope(mint, maxt, s.scope)
 	if err != nil {
 		return 0, errors.Wrap(err, "count pushdown: create querier")
 	}
@@ -200,7 +215,12 @@ func (s *scarecrowScanner) CountSeries(
 func (s *scarecrowScanner) CountSeriesBy(
 	ctx context.Context, mint, maxt int64, label string, matchers []*labels.Matcher,
 ) (map[string]uint64, error) {
-	q, err := s.b.queryable().QuerierWithScope(mint, maxt, s.scope)
+	tenant, err := s.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	q, err := s.b.queryable(tenant).QuerierWithScope(mint, maxt, s.scope)
 	if err != nil {
 		return nil, errors.Wrap(err, "count-by pushdown: create querier")
 	}
@@ -229,8 +249,13 @@ func (s *scarecrowScanner) Series(
 ) ([]labels.Labels, error) {
 	const nsPerMs = int64(time.Millisecond)
 
+	tenant, err := s.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	series, err := s.b.src.MetricSeries(
-		ctx, s.b.tenant, storagepromql.PushableMatchers(matchers), mint*nsPerMs, maxt*nsPerMs,
+		ctx, tenant, storagepromql.PushableMatchers(matchers), mint*nsPerMs, maxt*nsPerMs,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "metric series")
@@ -259,8 +284,13 @@ func (s *scarecrowScanner) Scan(
 ) (scarecrow.SeriesIterator, error) {
 	const nsPerMs = int64(time.Millisecond)
 
-	it, err := s.b.src.Fetcher(s.b.tenant).Fetch(ctx, fetch.Request{
-		Tenant:   s.b.tenant,
+	tenant, err := s.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	it, err := s.b.src.Fetcher(tenant).Fetch(ctx, fetch.Request{
+		Tenant:   tenant,
 		Scope:    s.scope,
 		Start:    mint * nsPerMs,
 		End:      maxt * nsPerMs,

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -45,8 +45,13 @@ type Backend struct {
 	// store is the local engine, set only when this Backend was built over one. Ingestion,
 	// maintenance and the statistics views need engine-local state, so they are the only methods
 	// that reach for it — and they refuse with [ErrNoEngine] when it is nil.
-	store  *storage.Storage
+	store *storage.Storage
+	// tenant is the tenant every read is scoped to when the backend is not per-request tenant-aware
+	// (the default). The empty id normalizes to "default" in the engine.
 	tenant signal.TenantID
+	// requireTenant makes reads resolve their tenant from the request context and refuse a request
+	// that carries none. See [WithTenancy].
+	requireTenant bool
 	// logParallelism is the max number of workers used to materialize log query results across the
 	// fetched record set. <= 1 keeps the sequential path (the default). See [WithLogParallelism].
 	logParallelism int
@@ -197,17 +202,23 @@ func (b *Backend) CompactNow(ctx context.Context) error {
 // Backend-lifetime label cache (b.labels) is shared across queries so series label projections are
 // interned once instead of rebuilt and GC-rescanned every query.
 //
-// The fetcher is scoped to b.tenant (a named tenant, "" ⇒ "default") rather than the no-arg
-// cross-tenant form: in cluster mode a named tenant is served owner-aware (fanned out to the ring
-// owners), whereas the no-arg form reads only tenants local to this node — so a query node that does
-// not own the tenant would see nothing. The record signals already scope by b.tenant the same way.
-func (b *Backend) queryable() *storagepromql.Queryable {
-	return storagepromql.NewQueryableWithCache(b.src.Fetcher(b.tenant), b.tenant, b.labels)
+// The fetcher is scoped to one named tenant ("" ⇒ "default") rather than the no-arg cross-tenant
+// form: in cluster mode a named tenant is served owner-aware (fanned out to the ring owners),
+// whereas the no-arg form reads only tenants local to this node — so a query node that does not own
+// the tenant would see nothing. The record signals scope by the same tenant.
+func (b *Backend) queryable(tenant signal.TenantID) *storagepromql.Queryable {
+	return storagepromql.NewQueryableWithCache(b.src.Fetcher(tenant), tenant, b.labels)
 }
 
-// Querier implements storage.Queryable.
+// Querier implements storage.Queryable. Prometheus resolves a querier without a context, so under
+// [WithTenancy] the tenant-scoped querier is built lazily on the first call that carries one.
 func (b *Backend) Querier(mint, maxt int64) (promstorage.Querier, error) {
-	return b.queryable().Querier(clampQueryMs(mint), clampQueryMs(maxt))
+	mint, maxt = clampQueryMs(mint), clampQueryMs(maxt)
+	if b.requireTenant {
+		return &lazyQuerier{b: b, mint: mint, maxt: maxt}, nil
+	}
+
+	return b.queryable(b.tenant).Querier(mint, maxt)
 }
 
 // clampQueryMs clamps a Prometheus millisecond bound to the open-ended sentinels the storage
@@ -301,7 +312,12 @@ func (s scanners) GroupedSeriesCounter() enginestorage.GroupedSeriesCounter {
 type backendCounter struct{ b *Backend }
 
 func (c backendCounter) CountSeries(ctx context.Context, startMs, endMs int64, matchers ...*labels.Matcher) (uint64, error) {
-	q, err := c.b.queryable().Querier(startMs, endMs)
+	tenant, err := c.b.tenantFor(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	q, err := c.b.queryable(tenant).Querier(startMs, endMs)
 	if err != nil {
 		return 0, errors.Wrap(err, "count pushdown: create querier")
 	}
@@ -325,7 +341,12 @@ type backendGroupCounter struct{ b *Backend }
 func (c backendGroupCounter) CountSeriesBy(
 	ctx context.Context, startMs, endMs int64, label string, matchers ...*labels.Matcher,
 ) (map[string]uint64, error) {
-	q, err := c.b.queryable().Querier(startMs, endMs)
+	tenant, err := c.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	q, err := c.b.queryable(tenant).Querier(startMs, endMs)
 	if err != nil {
 		return nil, errors.Wrap(err, "count-by pushdown: create querier")
 	}
@@ -345,7 +366,7 @@ func (s scanners) NewVectorSelector(
 	hints promstorage.SelectHints,
 	node logicalplan.VectorSelector,
 ) (model.VectorOperator, error) {
-	inner, err := s.windowed(opts, hints)
+	inner, err := s.windowed(ctx, opts, hints)
 	if err != nil {
 		return nil, err
 	}
@@ -365,13 +386,18 @@ func (s scanners) NewMatrixSelector(
 	// folds the sidecar cannot answer (rate/increase/quantile/…).
 	if s.b.overTimePushdown && node.Range > 0 {
 		if fold, ok := overTimeFold[call.Func.Name]; ok {
+			tenant, err := s.b.tenantFor(ctx)
+			if err != nil {
+				return nil, err
+			}
+
 			vs := node.VectorSelector
 			plainInstant := vs.Projection == nil && len(vs.Filters) == 0
 			switch {
 			case opts.IsInstantQuery():
 				if plainInstant {
 					return newAggregateOverTimeOp(
-						s.b.src, s.b.tenant, vs.LabelMatchers, call.Func.Name, fold,
+						s.b.src, tenant, vs.LabelMatchers, call.Func.Name, fold,
 						opts.Start.UnixMilli(), node.Range.Milliseconds(), vs.Offset.Milliseconds(),
 					), nil
 				}
@@ -381,7 +407,7 @@ func (s scanners) NewMatrixSelector(
 			// only push down its absence.
 			case opts.Step > 0 && plainInstant && vs.Timestamp == nil && !vs.SelectTimestamp:
 				return newAggregateOverTimeRangeOp(
-					s.b.src, s.b.tenant, vs.LabelMatchers, call.Func.Name, fold,
+					s.b.src, tenant, vs.LabelMatchers, call.Func.Name, fold,
 					opts.Start.UnixMilli(), opts.End.UnixMilli(), opts.Step.Milliseconds(),
 					node.Range.Milliseconds(), vs.Offset.Milliseconds(), opts.NumStepsPerBatch(),
 				), nil
@@ -389,7 +415,7 @@ func (s scanners) NewMatrixSelector(
 		}
 	}
 
-	inner, err := s.windowed(opts, hints)
+	inner, err := s.windowed(ctx, opts, hints)
 	if err != nil {
 		return nil, err
 	}
@@ -399,12 +425,19 @@ func (s scanners) NewMatrixSelector(
 // windowed builds a Prometheus scanner set whose querier covers the selector window. opts is
 // shallow-copied (the library's own idiom, see query.Options.WithEndTime) with the window
 // overridden to the selector's hints so the storage querier reads the right range.
-func (s scanners) windowed(opts *query.Options, hints promstorage.SelectHints) (*promscanners.Scanners, error) {
+func (s scanners) windowed(
+	ctx context.Context, opts *query.Options, hints promstorage.SelectHints,
+) (*promscanners.Scanners, error) {
+	tenant, err := s.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	o := *opts
 	o.Start = time.UnixMilli(hints.Start)
 	o.End = time.UnixMilli(hints.End)
 
-	sc, err := promscanners.NewPrometheusScanners(s.b.queryable(), &o, nil)
+	sc, err := promscanners.NewPrometheusScanners(s.b.queryable(tenant), &o, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "create prometheus scanners")
 	}

--- a/internal/storagebackend/tenant.go
+++ b/internal/storagebackend/tenant.go
@@ -1,0 +1,134 @@
+package storagebackend
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+	"github.com/prometheus/prometheus/model/labels"
+	promstorage "github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/annotations"
+
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/multitenancy"
+)
+
+// ErrNoTenant is returned by every read when the backend requires per-request tenancy
+// ([WithTenancy]) but the request context carries no tenant.
+//
+// It is a refusal rather than a fallback on purpose: falling back to the default tenant would mean
+// a route that skipped the tenancy middleware silently reads whichever tenant the deployment calls
+// default, which is the failure mode tenancy exists to prevent.
+var ErrNoTenant = errors.New("storagebackend: request carries no tenant")
+
+// WithTenancy makes every read resolve its tenant from the request context (see
+// [multitenancy.WithTenant]) instead of serving the backend's single default tenant, and refuse a
+// request that carries none with [ErrNoTenant].
+//
+// Without it a Backend behaves exactly as before: one tenant — the empty id, which the engine
+// normalizes to "default" — for its whole lifetime.
+func WithTenancy() Option {
+	return func(b *Backend) { b.requireTenant = true }
+}
+
+// tenantFor returns the tenant ctx's request reads.
+//
+// A per-request tenant is threaded through the context rather than baked into a per-request
+// Backend view because a Backend is not free to mint per request: it owns the label cache that
+// interns series→labels projections for the engine's lifetime, and the query APIs are constructed
+// once over one Backend at startup. The context already reaches every read, since each one is
+// already a ctx-taking storage call.
+//
+// Sharing that label cache across tenants is safe: it is keyed by [signal.SeriesID], the
+// content-addressed hash of the series' own attribute set, and its value is a pure projection of
+// that same identity. Two tenants with an identical series share one entry holding the one label
+// set both would have computed, and an entry is only ever looked up for a series the caller's own
+// tenant-scoped fetch returned — so it can memoize work across tenants but cannot carry identities
+// between them.
+func (b *Backend) tenantFor(ctx context.Context) (signal.TenantID, error) {
+	// A backend that has not opted in never looks at the context, so its behavior cannot be
+	// changed by anything a request carries.
+	if !b.requireTenant {
+		return b.tenant, nil
+	}
+
+	t, ok := multitenancy.TenantFromContext(ctx)
+	if !ok {
+		return "", ErrNoTenant
+	}
+
+	return signal.TenantID(t), nil
+}
+
+// lazyQuerier defers building the tenant-scoped querier until a call that carries a context, since
+// [promstorage.Queryable] resolves a querier without one. It is used only under [WithTenancy]; a
+// single-tenant backend builds its querier eagerly, exactly as before.
+//
+// One querier serves one request, so the resolved inner querier is built at most once and needs no
+// synchronization beyond the single-goroutine use Prometheus already assumes of a Querier.
+type lazyQuerier struct {
+	b          *Backend
+	mint, maxt int64
+	inner      promstorage.Querier
+}
+
+func (q *lazyQuerier) resolve(ctx context.Context) (promstorage.Querier, error) {
+	if q.inner != nil {
+		return q.inner, nil
+	}
+
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	inner, err := q.b.queryable(tenant).Querier(q.mint, q.maxt)
+	if err != nil {
+		return nil, err
+	}
+
+	q.inner = inner
+
+	return inner, nil
+}
+
+func (q *lazyQuerier) Select(
+	ctx context.Context, sortSeries bool, hints *promstorage.SelectHints, matchers ...*labels.Matcher,
+) promstorage.SeriesSet {
+	inner, err := q.resolve(ctx)
+	if err != nil {
+		return promstorage.ErrSeriesSet(err)
+	}
+
+	return inner.Select(ctx, sortSeries, hints, matchers...)
+}
+
+func (q *lazyQuerier) LabelValues(
+	ctx context.Context, name string, hints *promstorage.LabelHints, matchers ...*labels.Matcher,
+) ([]string, annotations.Annotations, error) {
+	inner, err := q.resolve(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return inner.LabelValues(ctx, name, hints, matchers...)
+}
+
+func (q *lazyQuerier) LabelNames(
+	ctx context.Context, hints *promstorage.LabelHints, matchers ...*labels.Matcher,
+) ([]string, annotations.Annotations, error) {
+	inner, err := q.resolve(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return inner.LabelNames(ctx, hints, matchers...)
+}
+
+func (q *lazyQuerier) Close() error {
+	if q.inner == nil {
+		return nil
+	}
+
+	return q.inner.Close()
+}

--- a/internal/storagebackend/tenant_test.go
+++ b/internal/storagebackend/tenant_test.go
@@ -1,0 +1,212 @@
+package storagebackend_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/multitenancy"
+	"github.com/oteldb/oteldb/internal/promql"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// routedStore returns an in-memory engine whose write routing follows *route, so a test can put
+// byte-identical telemetry in different tenants — which is how header-routed ingest behaves, and
+// the only way two tenants come to hold the same series identity.
+func routedStore(t *testing.T) (*storage.Storage, *signal.TenantID) {
+	t.Helper()
+
+	route := new(signal.TenantID)
+
+	store, err := storage.InMemory(storage.WithTenant(
+		func(signal.Resource, signal.Scope) signal.TenantID { return *route },
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(context.Background()) })
+
+	return store, route
+}
+
+// gauge builds a one-point OTLP gauge batch.
+func gauge(name string, value float64, ts time.Time) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "svc")
+	m := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName(name)
+	dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	dp.SetDoubleValue(value)
+
+	return md
+}
+
+// instantValues evaluates expr through oteldb's PromQL engine over b and returns the sample values.
+func instantValues(ctx context.Context, t *testing.T, b *storagebackend.Backend, expr string, ts time.Time) []float64 {
+	t.Helper()
+
+	eng, err := promql.New(b, promql.EngineOpts{
+		MaxSamples:    1_000_000,
+		Timeout:       time.Minute,
+		LookbackDelta: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	q, err := eng.NewInstantQuery(ctx, b, nil, expr, ts)
+	require.NoError(t, err)
+	t.Cleanup(q.Close)
+
+	res := q.Exec(ctx)
+	require.NoError(t, res.Err)
+
+	vec, err := res.Vector()
+	require.NoError(t, err)
+
+	out := make([]float64, 0, len(vec))
+	for _, s := range vec {
+		out = append(out, s.F)
+	}
+
+	return out
+}
+
+// TestBackendTenantIsolation proves a request authorized for one tenant cannot read another's data.
+func TestBackendTenantIsolation(t *testing.T) {
+	ctx := context.Background()
+	store, route := routedStore(t)
+	b := storagebackend.New(store, storagebackend.WithTenancy())
+
+	ts := time.Now().Truncate(time.Second)
+
+	*route = "acme"
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("shared_metric", 1, ts)))
+
+	*route = "globex"
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("shared_metric", 2, ts)))
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("globex_only", 3, ts)))
+
+	acme := multitenancy.WithTenant(ctx, "acme")
+	globex := multitenancy.WithTenant(ctx, "globex")
+
+	require.Equal(t, []float64{1}, instantValues(acme, t, b, `shared_metric`, ts),
+		"acme must see only its own value of the shared metric")
+	require.Equal(t, []float64{2}, instantValues(globex, t, b, `shared_metric`, ts))
+
+	require.Empty(t, instantValues(acme, t, b, `globex_only`, ts),
+		"acme must not see a metric only globex wrote")
+	require.Equal(t, []float64{3}, instantValues(globex, t, b, `globex_only`, ts))
+}
+
+// TestBackendTenantIsolationLabels proves the metadata paths — label names and values — are
+// tenant-scoped too, not just sample selection.
+func TestBackendTenantIsolationLabels(t *testing.T) {
+	ctx := context.Background()
+	store, route := routedStore(t)
+	b := storagebackend.New(store, storagebackend.WithTenancy())
+
+	ts := time.Now().Truncate(time.Second)
+
+	*route = "acme"
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("acme_metric", 1, ts)))
+
+	*route = "globex"
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("globex_metric", 2, ts)))
+
+	for _, tt := range []struct {
+		tenant string
+		want   string
+		absent string
+	}{
+		{"acme", "acme_metric", "globex_metric"},
+		{"globex", "globex_metric", "acme_metric"},
+	} {
+		t.Run(tt.tenant, func(t *testing.T) {
+			q, err := b.Querier(ts.Add(-time.Hour).UnixMilli(), ts.Add(time.Hour).UnixMilli())
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = q.Close() })
+
+			values, _, err := q.LabelValues(multitenancy.WithTenant(ctx, tt.tenant), "__name__", nil)
+			require.NoError(t, err)
+			require.Contains(t, values, tt.want)
+			require.NotContains(t, values, tt.absent)
+		})
+	}
+}
+
+// TestBackendTenancyRequiresTenant pins the fail-closed behavior: with tenancy on, a read whose
+// context carries no tenant is refused rather than served from the default tenant, so a route that
+// bypassed the tenancy middleware reads nothing.
+func TestBackendTenancyRequiresTenant(t *testing.T) {
+	ctx := context.Background()
+	store, route := routedStore(t)
+	b := storagebackend.New(store, storagebackend.WithTenancy())
+
+	ts := time.Now().Truncate(time.Second)
+	*route = "acme"
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("acme_metric", 1, ts)))
+
+	q, err := b.Querier(ts.Add(-time.Hour).UnixMilli(), ts.Add(time.Hour).UnixMilli())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	_, _, err = q.LabelNames(ctx, nil)
+	require.ErrorIs(t, err, storagebackend.ErrNoTenant)
+}
+
+// TestBackendWithoutTenancyIgnoresContextTenant pins that a deployment which has not opted in is
+// unchanged: reads serve its single tenant, and a tenant riding the context — which nothing puts
+// there without the middleware — does not redirect them.
+func TestBackendWithoutTenancyIgnoresContextTenant(t *testing.T) {
+	ctx := context.Background()
+
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	b := storagebackend.New(store)
+
+	ts := time.Now().Truncate(time.Second)
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("test_metric", 7, ts)))
+
+	require.Equal(t, []float64{7}, instantValues(ctx, t, b, `test_metric`, ts))
+	require.Equal(t, []float64{7},
+		instantValues(multitenancy.WithTenant(ctx, "acme"), t, b, `test_metric`, ts),
+		"without WithTenancy the backend stays pinned to its single tenant")
+}
+
+// TestBackendLabelCacheNoCrossTenantLeak proves the Backend-lifetime label cache — shared by every
+// tenant and keyed only by content-addressed series id — cannot carry one tenant's series into
+// another's result.
+//
+// Both tenants below write byte-identical series identities, so they collide on one cache entry.
+// Querying acme first populates it; globex must then still see only its own sample, and acme must
+// not gain globex's.
+func TestBackendLabelCacheNoCrossTenantLeak(t *testing.T) {
+	ctx := context.Background()
+	store, route := routedStore(t)
+	b := storagebackend.New(store, storagebackend.WithTenancy())
+
+	ts := time.Now().Truncate(time.Second)
+
+	*route = "acme"
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("collide", 10, ts)))
+
+	*route = "globex"
+	require.NoError(t, b.ConsumeMetrics(ctx, gauge("collide", 20, ts)))
+
+	acme := multitenancy.WithTenant(ctx, "acme")
+	globex := multitenancy.WithTenant(ctx, "globex")
+
+	require.Equal(t, []float64{10}, instantValues(acme, t, b, `collide`, ts))
+	require.Equal(t, []float64{20}, instantValues(globex, t, b, `collide`, ts),
+		"a warm label-cache entry from acme must not carry acme's data into globex's result")
+	require.Equal(t, []float64{10}, instantValues(acme, t, b, `collide`, ts),
+		"nor globex's back into acme's")
+}

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -77,7 +77,12 @@ func (q *TraceQuerier) SelectSpansets(ctx context.Context, params traceqlengine.
 
 // TraceByID implements [tracestorage.Querier]. It fetches every span of one trace by id.
 func (q *TraceQuerier) TraceByID(ctx context.Context, id otelstorage.TraceID, _ tracestorage.TraceByIDOptions) (iterators.Iterator[tracestorage.Span], error) {
-	batches, err := q.b.src.Trace(ctx, q.b.tenant, id[:])
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	batches, err := q.b.src.Trace(ctx, tenant, id[:])
 	if err != nil {
 		return nil, errors.Wrap(err, "trace by id")
 	}
@@ -209,8 +214,13 @@ func (q *TraceQuerier) candidateTraces(
 func (q *TraceQuerier) collectTraceIDs(
 	ctx context.Context, lo, hi int64, group traceFilter, ids map[otelstorage.TraceID]struct{},
 ) error {
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return err
+	}
+
 	req := fetch.Request{
-		Tenant:   q.b.tenant,
+		Tenant:   tenant,
 		Signal:   signal.Trace,
 		Start:    lo,
 		End:      hi,
@@ -224,7 +234,7 @@ func (q *TraceQuerier) collectTraceIDs(
 		req.AllConditions = true
 	}
 
-	it, err := q.b.src.TraceFetcher(q.b.tenant).Fetch(ctx, req)
+	it, err := q.b.src.TraceFetcher(tenant).Fetch(ctx, req)
 	if err != nil {
 		return errors.Wrap(err, "fetch candidate traces")
 	}
@@ -249,9 +259,14 @@ func (q *TraceQuerier) collectTraceIDs(
 func (q *TraceQuerier) scanSpans(
 	ctx context.Context, start, end time.Time, traceIDs map[otelstorage.TraceID]struct{},
 ) ([]tracestorage.Span, error) {
+	tenant, err := q.b.tenantFor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	lo, hi := fetchWindow(start, end)
 	req := fetch.Request{
-		Tenant: q.b.tenant,
+		Tenant: tenant,
 		Signal: signal.Trace,
 		Start:  lo,
 		End:    hi,
@@ -261,7 +276,7 @@ func (q *TraceQuerier) scanSpans(
 		req.AllConditions = true
 	}
 
-	it, err := q.b.src.TraceFetcher(q.b.tenant).Fetch(ctx, req)
+	it, err := q.b.src.TraceFetcher(tenant).Fetch(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetch spans")
 	}


### PR DESCRIPTION
Read-path multi-tenancy for the storage-engine path — the missing half of #820.

The engine has always been multi-tenant; oteldb pinned it. `Backend.tenant` was declared but never
assigned, so every read was scoped to `"default"` while the merged ingest half (#1277 / #1280)
routed writes to `acme/_s*`. The data was stored and replicated correctly and was simply
unaddressable. This makes the read tenant per request, keyed off the caller's credential.

## Design

**Per-request tenant on the context, not a per-request `Backend` view.** A `Backend` is not free to
mint per request — it owns the `LabelCache` interning series→labels projections for the engine's
lifetime, and the query APIs are constructed once over one `Backend` at startup. The context already
reaches every read, since each one is already a ctx-taking storage call. The one seam without a
context is `promstorage.Queryable.Querier(mint, maxt)`, which now returns a lazy querier that builds
its tenant-scoped inner querier on the first ctx-carrying call. That lazy path is taken *only* under
`WithTenancy`; a single-tenant backend still builds eagerly on the same line as before.

**The header is a selector, never a grant.** Reads and writes deliberately do not share a mechanism:
ingest *routes* a trusted sender, queries *authorize* an untrusted caller. Copying the ingest side's
`header > resource attribute > default` precedence onto the read path would import a trusted-sender
model into an untrusted-caller position. So this adopts #1038's shape instead: a `Resolver` maps the
credential to a `Decision`, and `X-Scope-OrgID` may only narrow the set that decision already
permits. What *does* carry over from ingest is the tenant-id validation (`[A-Za-z0-9_.-]`, ≤150
bytes, rejecting `.`/`..` and anything containing `cluster.ShardSep`), because that is a property of
the storage layer, not of where the id came from.

**Set versus single.** `Decision.TenantIDs` is a set; the storage seams are not uniformly a set.
`Fetcher(tenants...)` is variadic and fans out natively, but `MetricSeries`, `LogSeries`, `LogKeys`,
`Trace`, `ProfileSeries`, `ProfileResolver` and `AggregateMetrics*Named` each take exactly one
tenant — and the variadic fetcher *merges by series id*, so two tenants holding an identical series
would be silently federated into one (the library documents this: "add a tenant label upstream if
per-tenant separation is wanted"). Rather than half-implement that, narrowing happens in the
middleware, which is the only layer that can answer a caller:

| credential permits | `X-Scope-OrgID` | result |
|---|---|---|
| tenancy off / `Enabled: false` | ignored | default tenant — today's behaviour, byte-identical |
| one tenant | absent | that tenant |
| one tenant | that tenant | that tenant |
| one tenant | another tenant | **403** |
| several | absent | **400**, listing the permitted tenants |
| several | one of them | that one |
| none (`Enabled`, empty set) | any | **403** |

So a query authorized for several tenants reads exactly one of them per request, chosen by the
caller, and there is no path that silently reads only the first. Every backend below is left with
one tenant per request and cannot read wider than it was authorized to. Genuine cross-tenant
fan-out — one query merging N tenants — is not implemented and would need a tenant label injected
at projection time to keep colliding identities distinct; that is a separate change.

**Fail-closed at both ends.** With tenancy on, a read whose context carries no tenant is refused
with `ErrNoTenant` rather than served the default, so a route that bypassed the middleware reads
nothing instead of reading whatever the deployment calls `default`. And `cmd/oteldb` refuses to
start with tenancy enabled while any signal is still served by ClickHouse, which has no tenant
scoping on this path.

## Threat model, plainly

*Who can read what.* Only a caller presenting a credential listed in `tenancy.tokens` reads
anything; an absent or unknown credential is 401. A credential reads exactly the tenants its entry
names, and nothing else — setting `X-Scope-OrgID` to a tenant it does not name is 403, not a wider
read. Tenant ids that could escape a path segment or collide with a shard key are rejected at config
load and again at request time.

*What an operator must configure to be safe.*

1. Serve every queryable signal from the embedded storage engine (`--embedded`, or all four
   `*_backend: storage`). Enforced — startup fails otherwise.
2. Set `tenancy.enabled: true` and give every consumer its own token with the narrowest `tenants`
   list. Enforced that the list is non-empty and the token table is non-empty.
3. Turn on ingest-side tenancy (#1280) so writes land in the tenants reads address.
4. Terminate TLS in front of the query APIs. Bearer tokens are bearer tokens.

*What is still unsafe / not covered.*

- **Tokens are shared secrets in the config file.** `token_file` keeps them out of the YAML, but
  there is no rotation, no expiry, and no revocation short of a restart. For a hostile environment
  the `httpcb` resolver (below) is the answer, and it is not in this PR.
- **The admin API is not tenant-scoped** and is cross-tenant by definition. It must not be exposed
  to tenants. `StreamCosts` already takes an explicit tenant and is untouched.
- **ClickHouse-backed signals are not covered at all.** Startup refuses the combination rather than
  pretending; #1038 is the ClickHouse half.
- **`Decision.ResourceSelectors` and `Decision.Restrictions` are carried on the context but not
  enforced** by this backend. Selectors are predicate injection, which has no analogue where the
  tenant *is* the namespace; restrictions map onto ClickHouse settings with no storage-engine
  equivalent yet. A deployment that depends on either for isolation is not protected by this PR.
- **No per-tenant read quotas.** `QuotaKey` is plumbed for #823, not enforced.

## Cache audit (every read-path cache whose key omits the tenant)

Audited `internal/storagebackend`, `internal/queryapi`, the LogQL/TraceQL/PromQL engines, the
signal storages, `internal/clusterquery`, both binaries, and the storage library's read path.

- **`Backend.labels` (`storagepromql.LabelCache`)** — the one process-lifetime cache with a
  tenant-less key, `map[signal.SeriesID]labels.Labels`. `SeriesID` hashes resource ‖ scope ‖
  attributes, with no tenant in the pre-image, so two tenants with an identical series collide on
  one entry. **Safe, and verified rather than assumed:** the value is a pure projection of the key's
  own pre-image, so the colliding entry holds the one label set both tenants would have computed;
  and an entry is only ever looked up for a series the caller's own tenant-scoped fetch already
  returned. It memoizes work across tenants; it cannot carry identities between them. `TestBackend
  LabelCacheNoCrossTenantLeak` writes byte-identical identities into two tenants and pins it. The
  fragility worth recording: if the projection ever gains a tenant-dependent term (a tenant label, a
  per-tenant relabel rule) this becomes a real leak with no key change to catch it.
- `query/scale.CacheFetcher` — keys on the sorted tenant set (`Storage.tenantScope`). Correct, and
  not enabled by oteldb anyway (`WithQueryCache` is never called).
- Decode/block caches, `sizeRetentionCache`, `backend.Cached`, profile `Resolver`/`SymbolStore` —
  per-tenant by construction (engines are per-tenant) or per-call.
- `internal/metricscache` (`Key{Hash, Step, Fn}`) has no tenant component but is chstorage-only —
  it is the cache #1038's doc already flags, and it stays #1038's problem.
- Everything else on this path holds only per-query or per-batch maps.

Series-hash collision across tenants (the doc's second trap) is namespaced by construction here: the
shard key is `{tenant}/_s{idx}`, so identical `SeriesID`s live in different shards and different
engines. That is why they can never be confused — not the hash.

## Reused from #1038 vs written fresh

**Reused (shape and, where it survived review, code):** `Decision`, `ResourceSelector`, `MatchOp`,
`QueryRestrictions`, `Operation`, `Resolver`, the context accessors, the `static` resolver, and the
middleware's overall role.

**Changed:** dropped `FilterProvider` (it pulls in `chsql`, and has no analogue where tenancy is
native) — #1038 should keep it. The static resolver now validates every tenant id at construction
and compares credentials in constant time, matching `httpmiddleware.BearerToken`. The middleware
gained the selector-narrowing rules above; #1038's version resolved a decision and stopped there.
Added `ParseTenantID`, which #1038 did not have.

**Not lifted:** `internal/multitenancy/httpcb` + the generated `internal/multitenancyapi`, and
`TenantMapper`. The `Resolver` interface here is unchanged, so `httpcb` drops in with no edits — it
is left out only to keep this PR reviewable, and it is what a hostile environment actually needs.
`TenantMapper` is ingest-side and belongs with whichever path resolves writes.

**On #1038 itself:** it should be **rebased and kept, not superseded**. This PR takes over
`internal/multitenancy` (its front half, now on main) but touches nothing in its ClickHouse half —
`tenant_id` column, ORDER BY prefix, PREWHERE injection, the `hashTimeseries` fix and the
`metricSelectParams.Hash()` cache-key fix are all still needed and all still only there. After a
rebase it should re-add `FilterProvider`, `httpcb` and `multitenancyapi`, and drop its copies of the
types this PR now carries. Whether `internal/multitenancy` should have been lifted out of that
branch as its own change: yes, and that is effectively what the first commit here is.

## Scope and verification

- `cmd/oteldb` (embedded, single-node) and `cmd/odbselect` (stateless query) both work.
- **The cluster read path needs no change, verified rather than assumed:** every `Source` method
  takes a tenant, and `clusterquery.Source.shardKeys` derives the shard key set from whatever tenant
  it is given (`router.ShardKeys(normalize(tenant))`). odbselect inherits this for free.
- **A single-tenant deployment sees nothing.** `tenantFor` returns early before touching the context
  unless `WithTenancy` was passed, so the field is not even read; `Querier` builds eagerly on the
  same line as before; `TenancyMiddleware` returns a nil middleware, so nothing is installed. The
  `PolicyConfig` refactor keeps the YAML byte-for-byte (`,inline`, the `Listener` idiom, pinned by
  `TestPolicyYAMLShape`). Pinned by `TestBackendWithoutTenancyIgnoresContextTenant` and
  `TestTenancyMiddlewareDisabled`.
- Admin/maintenance surfaces untouched.
- `golangci-lint fmt`, `golangci-lint run`, `go test -race ./...` all clean.

## Coordination

`internal/config` is being migrated to go-faster/figureout in #1287. This adds one new file
(`internal/config/tenancy.go`) and one new field on each binary's `Config`, deliberately additive
and based on `main`. **Expect a conflict in #1287** over `internal/config`; `tenancy.go` should
migrate the same way the other blocks do. Not rebased onto or merged with #1287.

Closes half of #820 (the storage-engine path). Refs #1038, #1277, #1280, #823, #1287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
