### PR TITLE
feat(dev): run the storage cluster against a shared object store

### DIFF
--- a/.github/workflows/cluster-e2e.yml
+++ b/.github/workflows/cluster-e2e.yml
@@ -1,9 +1,13 @@
 name: "Cluster E2E"
 
-# End-to-end test for the storage-engine cluster (dev/local/storage-cluster): three oteldb nodes on
-# local file backends, replicating over an etcd ring. A metric, a log, and a trace are ingested at
-# one node via OTLP and queried back through the PromQL / LogQL / TraceQL APIs of *other* nodes, so a
-# pass proves cross-node routing + replication across all three signals.
+# End-to-end test for the storage-engine cluster (dev/local/storage-cluster): three oteldb nodes
+# replicating over an etcd ring. A metric, a log, and a trace are ingested at one node via OTLP and
+# queried back through the PromQL / LogQL / TraceQL APIs of *other* nodes, so a pass proves
+# cross-node routing + replication across all three signals.
+#
+# Both storage models run, because they fail differently. shared-nothing exercises partsync
+# (flushed parts mirrored node-to-node); shared-store puts every node on one MinIO bucket, where
+# the bucket index is committed by several writers through a real conditional PUT.
 
 on:
   push:
@@ -17,6 +21,18 @@ permissions:
 jobs:
   cluster:
     runs-on: ubuntu-latest
+    name: ${{ matrix.model }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Each node on its own disk; flushed parts mirrored over partsync.
+          - model: shared-nothing
+            compose: "-f docker-compose.yml -f docker-compose.ci.yml"
+          # Every node on one MinIO bucket; parts exchanged through the store, index committed
+          # with CompareAndSwap (S3 conditional PUT).
+          - model: shared-store
+            compose: "-f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.shared-store.yml --profile minio"
     steps:
       - name: Install Go
         uses: actions/setup-go@v7
@@ -53,7 +69,7 @@ jobs:
 
       - name: Start cluster
         working-directory: dev/local/storage-cluster
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --build oteldb-1 oteldb-2 oteldb-3
+        run: docker compose ${{ matrix.compose }} up -d --build oteldb-1 oteldb-2 oteldb-3
 
       - name: Verify ingest + cross-node queries
         run: |
@@ -67,9 +83,9 @@ jobs:
       - name: Dump cluster logs
         if: failure()
         working-directory: dev/local/storage-cluster
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml logs --no-color
+        run: docker compose ${{ matrix.compose }} logs --no-color
 
       - name: Cleanup
         if: always()
         working-directory: dev/local/storage-cluster
-        run: docker compose -f docker-compose.yml -f docker-compose.ci.yml down --remove-orphans --volumes --timeout 10
+        run: docker compose ${{ matrix.compose }} down --remove-orphans --volumes --timeout 10

--- a/dev/local/storage-cluster/README.md
+++ b/dev/local/storage-cluster/README.md
@@ -1,9 +1,14 @@
 # Clustered storage-engine demo
 
-A three-node **oteldb cluster on the embedded storage engine** — no ClickHouse and **no shared
-object store**. Each node keeps its data on a **local file backend** and replicates writes to its
-peers (RF=2) over an etcd-coordinated [rendezvous-hash](https://en.wikipedia.org/wiki/Rendezvous_hashing)
-ring. This is the shared-nothing model: data is sharded and replicated across the nodes' own disks.
+A three-node **oteldb cluster on the embedded storage engine** — no ClickHouse. Nodes coordinate
+through an etcd-backed [rendezvous-hash](https://en.wikipedia.org/wiki/Rendezvous_hashing) ring.
+
+Both storage models are runnable here:
+
+- **shared-nothing** (default) — each node keeps its data on a **local file backend** and replicates
+  writes to its peers (RF=2). Data is sharded and replicated across the nodes' own disks.
+- **shared-store** ([below](#shared-store-variant)) — every node reads and writes **one object
+  store**, so flushed parts need no mirroring.
 
 ## Run
 
@@ -78,6 +83,48 @@ would all have no source. A deployment where every node points at the same objec
 
 To scale out, add another `oteldb-N` service (with its own `hostname` and data volume) pointing at
 the same etcd — it joins the ring and takes ownership of a share of the data automatically.
+
+## Shared-store variant
+
+The default stack above is **shared-nothing**: each node owns its disk and mirrors flushed parts to
+its peers. The other deployment model is **shared-store** — every node reads and writes one object
+store under one prefix, so a flushed part is already visible to every peer and there is nothing to
+mirror.
+
+```bash
+docker compose -f dev/local/storage-cluster/docker-compose.yml \
+               -f dev/local/storage-cluster/docker-compose.shared-store.yml \
+               --profile minio up --build
+```
+
+Same three nodes, same etcd, same ring; [`oteldb-shared.yml`](./oteldb-shared.yml) replaces the file
+backend with `backend: s3` and flips `private_backend` to `false`. The WAL stays on each node's own
+volume — it holds head data that has not reached the bucket yet, so it has to survive a restart of
+*that* node. Browse what the cluster writes at <http://localhost:9001> (MinIO console,
+`oteldb`/`oteldbsecret`).
+
+### What this exercises that the default cannot
+
+Several writers committing **one bucket index**. Each node commits through
+`backend.CompareAndSwap`, which on S3 is a conditional PUT (`If-Match`, or `If-None-Match: *` for
+the first write) — the *store* evaluates the condition, so two nodes committing at once cannot
+overwrite each other's parts. Nothing but a real object store evaluates that the way a deployment
+would, which is the whole reason this variant exists as a runnable stack rather than a unit test.
+
+### Choosing the object store
+
+| profile | store | why |
+|---|---|---|
+| `minio` (default) | MinIO | An independent, widely deployed implementation. A green run is evidence about oteldb. |
+| `fs` | [go-faster/fs](https://github.com/go-faster/fs) in single-node filesystem mode | A sibling project. Lighter, but a green run says the two agree — not the same claim. |
+
+Pick deliberately. If the conditional-PUT path breaks against a store you also maintain, you cannot
+tell from the failure which side is wrong. Use `--profile fs` when you want to exercise go-faster/fs
+against a real workload, and `--profile minio` when you want to make a claim about oteldb.
+
+Neither is a substitute for running against the store you deploy on: `If-Match` on PUT is not
+universal among S3-compatible services, and where it is missing `CompareAndSwap` has no ground to
+stand on.
 
 ## Automated test
 

--- a/dev/local/storage-cluster/docker-compose.shared-store.yml
+++ b/dev/local/storage-cluster/docker-compose.shared-store.yml
@@ -1,0 +1,104 @@
+# Shared-store overlay: the same three-node cluster, but every node keeps its parts in ONE object
+# store instead of on its own disk.
+#
+#   docker compose -f dev/local/storage-cluster/docker-compose.yml \
+#                  -f dev/local/storage-cluster/docker-compose.shared-store.yml \
+#                  --profile minio up --build
+#
+# Swap `--profile minio` for `--profile fs` to run the same cluster against go-faster/fs instead.
+# Pick deliberately: MinIO is an independent, widely deployed implementation, so a green run is
+# evidence about oteldb. go-faster/fs is a sibling project, so a green run there says the two agree
+# — useful, but not the same claim. MinIO is the default for that reason.
+#
+# What this exercises that the shared-nothing default cannot: several writers committing one bucket
+# index. Every node's commit goes through backend.CompareAndSwap (S3 conditional PUT, If-Match), and
+# nothing but a real store evaluates that condition the way a deployment would.
+#
+# The overlay mounts its config at a different path and repoints --config at it, rather than
+# replacing the base mount — compose merges volume lists, and two entries on one target is a
+# conflict rather than an override.
+
+# Applied to each oteldb node: read the shared-store config, and wait for the bucket to exist.
+x-shared-store-node: &shared-store-node
+  command:
+    - --embedded
+    - --config=/etc/oteldb/oteldb-shared.yml
+  volumes:
+    - ./oteldb-shared.yml:/etc/oteldb/oteldb-shared.yml:ro
+  depends_on:
+    objectstore-init:
+      condition: service_completed_successfully
+
+services:
+  # MinIO (default). Reaches the cluster as `objectstore`, the alias oteldb-shared.yml points at.
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    profiles: ["minio"]
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      - MINIO_ROOT_USER=oteldb
+      - MINIO_ROOT_PASSWORD=oteldbsecret
+    volumes:
+      - objectstore-data:/data
+    ports:
+      - "9000:9000" # S3 API
+      - "9001:9001" # MinIO console (browse the parts the cluster writes)
+    networks:
+      default:
+        aliases: [objectstore]
+
+  # go-faster/fs in its single-node filesystem mode: one process, no etcd, no planes. Anonymous
+  # auth is fine here because nothing outside the compose network can reach it.
+  fs:
+    image: ghcr.io/go-faster/fs:v0.13.1
+    profiles: ["fs"]
+    command: ["s3", "--addr", ":9000", "--root", "/data", "--insecure-no-auth"]
+    volumes:
+      - objectstore-data:/data
+    ports:
+      - "9000:9000"
+    networks:
+      default:
+        aliases: [objectstore]
+
+  # Creates the bucket, whichever store is running. It polls rather than waiting on a healthcheck so
+  # it needs no knowledge of which profile is active.
+  #
+  # The depends_on entries are `required: false` because exactly one of the two stores exists in any
+  # given run. They are still needed: without them, naming services explicitly ("up oteldb-1") pulls
+  # in this init container but *not* the store it talks to, and it would poll until the deadline.
+  objectstore-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    depends_on:
+      minio:
+        condition: service_started
+        required: false
+      fs:
+        condition: service_started
+        required: false
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        for i in $$(seq 1 60); do
+          mc alias set os http://objectstore:9000 oteldb oteldbsecret && break
+          echo "waiting for the object store ($$i/60)"; sleep 1
+        done
+        if ! mc alias list os >/dev/null 2>&1; then
+          echo "no object store answered on http://objectstore:9000 --"
+          echo "pass --profile minio (or --profile fs) so one of them starts."
+          exit 1
+        fi
+        mc mb --ignore-existing os/oteldb
+
+  oteldb-1:
+    <<: *shared-store-node
+
+  oteldb-2:
+    <<: *shared-store-node
+
+  oteldb-3:
+    <<: *shared-store-node
+
+volumes:
+  objectstore-data:

--- a/dev/local/storage-cluster/oteldb-shared.yml
+++ b/dev/local/storage-cluster/oteldb-shared.yml
@@ -1,0 +1,33 @@
+# Shared config for every node in the SHARED-STORE variant of the storage cluster. Every node reads
+# and writes one object store under one prefix, so flushed parts are exchanged through the bucket
+# rather than mirrored node-to-node. Contrast oteldb.yml, the shared-nothing variant.
+#
+# The node's ring identity and replication address still default to its hostname, so all three
+# services use this one file unchanged.
+storage:
+  backend: s3
+  # The WAL stays node-local even though the parts do not: it holds head data that has not reached
+  # the bucket yet, so it must survive a restart of *this* node.
+  wal_dir: /data
+  s3:
+    bucket: oteldb
+    prefix: cluster/
+    region: us-east-1
+    # objectstore is a network alias, so the same config serves whichever store the profile started.
+    endpoint: http://objectstore:9000
+    # S3-compatible stores address objects as endpoint/bucket/key, not virtual-host style.
+    force_path_style: true
+    access_key_id: oteldb
+    secret_access_key: oteldbsecret
+  cluster:
+    etcd: ["http://etcd:2379"]
+    # id and addr are derived from the container hostname (e.g. oteldb-1 -> addr oteldb-1:7946).
+    port: 7946
+    # Replication factor for head (unflushed) writes. Flushed parts need no replication here —
+    # they are already in a store every node can read.
+    rf: 2
+    root: /oteldb
+    # The whole point of this variant: one store, many writers. Every node's commit of the bucket
+    # index goes through backend.CompareAndSwap, so two nodes committing at once cannot lose each
+    # other's parts.
+    private_backend: false

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.159.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.39.0
+	github.com/oteldb/storage v0.40.1
 	github.com/pierrec/lz4/v4 v4.1.28
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1
@@ -169,7 +169,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect
 	github.com/hashicorp/go-metrics v0.6.0 // indirect
-	github.com/klauspost/reedsolomon v1.14.1 // indirect
+	github.com/klauspost/reedsolomon v1.14.2 // indirect
 	github.com/maypok86/otter/v2 v2.3.0 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect

--- a/go.sum
+++ b/go.sum
@@ -721,8 +721,8 @@ github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzh
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
-github.com/klauspost/reedsolomon v1.14.1 h1:swE9kzyWXD/wVG+l5Pe8bWnQ0giIY7D1GjCBKk3kG2U=
-github.com/klauspost/reedsolomon v1.14.1/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
+github.com/klauspost/reedsolomon v1.14.2 h1:SafJYwpBBQBI6amHUygcjxZjXeN2HpiENHQDwuPWCCQ=
+github.com/klauspost/reedsolomon v1.14.2/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
 github.com/knadh/koanf v1.5.0 h1:q2TSd/3Pyc/5yP9ldIrSdIz26MCcyNQzW0pEAugLPNs=
 github.com/knadh/koanf v1.5.0/go.mod h1:Hgyjp4y8v44hpZtPzs7JZfRAW5AhN7KfZcwv1RYggDs=
 github.com/knadh/koanf/providers/env/v2 v2.0.0 h1:Ad5H3eun722u+FvchiIcEIJZsZ2M6oxCkgZfWN5B5KY=
@@ -1031,8 +1031,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.39.0 h1:g/KDpaJ9nzYsElA0JczFm0QOrbmk/LoMS3t2XLq+LBg=
-github.com/oteldb/storage v0.39.0/go.mod h1:6CM7jbZpdhlpJCB3HHyZw3FhPll5d5X11HDgWd9Qnj4=
+github.com/oteldb/storage v0.40.1 h1:Og7MuUzDZngIuKsANFmq9MGwCpYDFH+MyrvStyIv9Q0=
+github.com/oteldb/storage v0.40.1/go.mod h1:z/Cm8l1Ba8YsG7YH1FAny6yqOOoLFLxvHubeoCha030=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=


### PR DESCRIPTION
The `dev/local/storage-cluster` demo only covered **shared-nothing** (each node on its own disk,
flushed parts mirrored over partsync). The other deployment model — every node on one object store —
had nowhere to run, which meant the least-validated commit path in the stack was exercised only by
unit tests against an in-process fake.

## What this adds

- **[`oteldb-shared.yml`](dev/local/storage-cluster/oteldb-shared.yml)** — `backend: s3`,
  `private_backend: false`, and a node-local `wal_dir` (head data that has not reached the bucket
  still has to survive *that* node's restart).
- **[`docker-compose.shared-store.yml`](dev/local/storage-cluster/docker-compose.shared-store.yml)** —
  overlay putting all three nodes on one store, with `minio` and `fs` profiles behind a shared
  `objectstore` network alias so one config serves either.
- **README** — a shared-store section, and an intro that presents both models.
- **`cluster-e2e.yml`** — a matrix so both models run in CI rather than the profile rotting.

```bash
docker compose -f dev/local/storage-cluster/docker-compose.yml \
               -f dev/local/storage-cluster/docker-compose.shared-store.yml \
               --profile minio up --build
```

## What it exercises that the default cannot

Several writers committing **one bucket index**. Each node commits through
`backend.CompareAndSwap` — on S3 a conditional PUT (`If-Match`, or `If-None-Match: *` for the first
write) evaluated by the store. Nothing but a real object store evaluates that the way a deployment
does.

## Why MinIO is the default

`--profile fs` runs the same cluster against [go-faster/fs](https://github.com/go-faster/fs), which
is lighter and already a dependency. But it is a sibling project: a green run there says the two
implementations agree, and if the conditional-PUT path breaks you cannot tell which side is wrong.
MinIO is one we do not maintain, so a green run is evidence about oteldb. Use `fs` to exercise
go-faster/fs against a real workload; use `minio` to make a claim about this repo.

## The dependency bump is not incidental

oteldb pinned `storage v0.39.0`, which predates every multi-writer fix. On that version a node still
minted part ids as `fmt.Sprintf("%s/%010d", prefix, seq)` and committed the index unconditionally —
so this profile on v0.39.0 would have demonstrated *exactly* the data-loss configuration
(oteldb/storage#392) while looking like validation. Confirmed by running it: the first bucket
listing contained `cluster/default/logs/0000000000/`.

`v0.40.1` also carries column checksums, disk-pressure rejection, per-writer WAL epochs, lease
fencing, and the fix for `Router.Close` / `Admin.Rebalance` never reporting success
(oteldb/storage#419 — found by staticcheck SA4023 on this repo's call sites while investigating the
pre-existing lint failure).

## Verification

Run for real, not just `docker compose config`:

- Three nodes up on MinIO; `cluster-verify` green across PromQL / LogQL / TraceQL (ingest at one
  node, served by another).
- 23 objects in the bucket, including `bucket-index.bin` per signal.
- On `v0.40.1` the part ids are ULIDs — `cluster/default/logs/01M0K4JCH0JBYDG86MQMYN5SA5/` — instead
  of the `0000000000` sequence, confirming the fixed path is the one running.
- `go build ./...` and the full `go test ./...` suite pass against v0.40.1.

Two bugs found by testing rather than by reading:

- naming services explicitly (`up oteldb-1`, which is what CI does) started `objectstore-init` but
  **not** the profiled store, so it polled to its deadline — fixed with `required: false`
  dependencies on both stores, verified for each profile;
- a forgotten `--profile` hung forever — the init is now bounded and says which flag to pass.

Draft until reviewed: it changes a shared workflow and a core dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Note on CI:** `lint / run` fails here, but it fails identically on `main` (run on `6cc5ebd`, before this branch existed) with the same four findings — a `goimports` issue in `internal/profileql/parser_test.go`, two `SA4023`, and one `SA1019`. This PR changes no Go code beyond `go.mod`/`go.sum`. The two SA4023 findings are what led to oteldb/storage#419; they will clear once the `odbingest`/`odbselect` call sites stop being always-true, which v0.40.1 makes possible.
