### PR TITLE
test(chotele2e): migrate deprecated ch-go OnLog to OnLogs

### DIFF
--- a/integration/chotele2e/e2e_test.go
+++ b/integration/chotele2e/e2e_test.go
@@ -90,10 +90,12 @@ func TestIntegrationTrace(t *testing.T) {
 	require.NoError(t, conn.Do(ctx, ch.Query{
 		Body:   "SELECT 1",
 		Result: discardResult(),
-		OnLog: func(ctx context.Context, l ch.Log) error {
+		OnLogs: func(ctx context.Context, logs []ch.Log) error {
 			sc := trace.SpanContextFromContext(ctx)
 			traceID = sc.TraceID()
-			t.Logf("[%s-%s]: %s", sc.TraceID(), sc.SpanID(), l.Text)
+			for _, l := range logs {
+				t.Logf("[%s-%s]: %s", sc.TraceID(), sc.SpanID(), l.Text)
+			}
 			return nil
 		},
 	}))

--- a/internal/profileql/parser_test.go
+++ b/internal/profileql/parser_test.go
@@ -178,11 +178,12 @@ var parseTests = []parseTestCase{
 	},
 
 	// Errors.
-	{"", Expr{}, true},                                                                      // empty.
-	{`{service_name="frontend"}`, Expr{}, true},                                             // no profile type.
-	{"{}", Expr{}, true},                                                                    // empty selector, no profile type.
-	{"not_a_profile_type", Expr{}, true},                                                    // invalid profile type.
-	{"process_cpu:cpu:nanoseconds:cpu", Expr{}, true},                                       // too few type parts.
+	{"", Expr{}, true},                                // empty.
+	{`{service_name="frontend"}`, Expr{}, true},       // no profile type.
+	{"{}", Expr{}, true},                              // empty selector, no profile type.
+	{"not_a_profile_type", Expr{}, true},              // invalid profile type.
+	{"process_cpu:cpu:nanoseconds:cpu", Expr{}, true}, // too few type parts.
+
 	{`process_cpu:cpu:nanoseconds:cpu:nanoseconds{service_name=}`, Expr{}, true},            // missing value.
 	{`process_cpu:cpu:nanoseconds:cpu:nanoseconds{="frontend"}`, Expr{}, true},              // missing label name.
 	{`process_cpu:cpu:nanoseconds:cpu:nanoseconds{service_name~"x"}`, Expr{}, true},         // bad op.


### PR DESCRIPTION
ch-go v0.74 deprecated the single-entry `OnLog` callback in favour of the batched `OnLogs(ctx, []ch.Log) error`. The handler now iterates the batch.

Verified by running the E2E test for real (it is `E2E=1`-gated, so compiling proves nothing):

```
E2E=1 go test -run TestIntegrationTrace -v ./integration/chotele2e/
--- PASS: TestIntegrationTrace (3.44s)
```

Note: this does **not** fix main's lint failure. That failure is two `SA4023` findings in `cmd/odbingest` and `cmd/odbselect`, caused by `Router.Close` in oteldb/storage v0.39.0 never being able to return nil. The fix is the storage v0.40.1 bump in #1294.