### PR TITLE
test(etcdtest): retry embedded etcd startup on a lost port race

### DIFF
--- a/cmd/odbingest/app_test.go
+++ b/cmd/odbingest/app_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
@@ -17,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/embed"
 	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/oteldb/storage/cluster"
@@ -33,50 +31,10 @@ import (
 
 	"github.com/prometheus/prometheus/prompb"
 
+	"github.com/oteldb/oteldb/internal/etcdtest"
 	"github.com/oteldb/oteldb/internal/otlpdirect"
 	"github.com/oteldb/oteldb/internal/promrw"
 )
-
-func freeAddr(tb testing.TB) string {
-	tb.Helper()
-
-	var lc net.ListenConfig
-
-	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	require.NoError(tb, err)
-	defer func() { _ = l.Close() }()
-
-	return l.Addr().String()
-}
-
-// startEtcd runs an embedded etcd and returns its client endpoint.
-func startEtcd(t *testing.T) string {
-	t.Helper()
-
-	lc := url.URL{Scheme: "http", Host: freeAddr(t)}
-	lp := url.URL{Scheme: "http", Host: freeAddr(t)}
-
-	cfg := embed.NewConfig()
-	cfg.Dir = t.TempDir()
-	cfg.LogLevel = "error"
-	cfg.ListenClientUrls = []url.URL{lc}
-	cfg.AdvertiseClientUrls = []url.URL{lc}
-	cfg.ListenPeerUrls = []url.URL{lp}
-	cfg.AdvertisePeerUrls = []url.URL{lp}
-	cfg.InitialCluster = cfg.Name + "=" + lp.String()
-
-	e, err := embed.StartEtcd(cfg)
-	require.NoError(t, err)
-	t.Cleanup(e.Close)
-
-	select {
-	case <-e.Server.ReadyNotify():
-	case <-time.After(30 * time.Second):
-		t.Fatal("embedded etcd did not become ready")
-	}
-
-	return lc.String()
-}
 
 // fakeNode is a storage node as far as routing is concerned: it registers in the ring and serves
 // the primary-write endpoint, recording what it was asked to apply.
@@ -94,7 +52,7 @@ func startNode(t *testing.T, endpoint, root, id string) *fakeNode {
 	t.Helper()
 
 	n := &fakeNode{
-		addr:   freeAddr(t),
+		addr:   etcdtest.FreeAddr(t),
 		shards: map[string]int{},
 		series: map[signal.SeriesID]signal.Series{},
 	}
@@ -245,7 +203,7 @@ func TestIngestRoutesHeaderTenant(t *testing.T) {
 
 	const root = "/tenants"
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 	node := startNode(t, endpoint, root, "node-tenant")
 
 	tenants, err := newTenantResolver(TenantConfig{Header: HeaderScopeOrgID})
@@ -285,7 +243,7 @@ func TestIngestRoutesToPrimary(t *testing.T) {
 
 	const root = "/test"
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 	node := startNode(t, endpoint, root, "node-a")
 
 	h := promrw.NewHandler(newTestSink(t, endpoint, root, 1), promrw.HandlerConfig{
@@ -321,7 +279,7 @@ func TestIngestSpreadsAcrossShards(t *testing.T) {
 		shards = 4
 	)
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 	node := startNode(t, endpoint, root, "node-a")
 
 	h := promrw.NewHandler(newTestSink(t, endpoint, root, shards), promrw.HandlerConfig{
@@ -359,7 +317,7 @@ func TestIngestSpreadsAcrossShards(t *testing.T) {
 func TestIngestFailsWhenClusterIsUnreachable(t *testing.T) {
 	t.Parallel()
 
-	endpoint := startEtcd(t) // no nodes join
+	endpoint := etcdtest.Start(t) // no nodes join
 
 	rt, err := router.Open(t.Context(), router.Config{Etcd: []string{endpoint}, Root: "/test", RF: 1})
 	require.NoError(t, err)
@@ -429,7 +387,7 @@ func TestOTLPRoutesEverySignalToPrimary(t *testing.T) {
 
 	const root = "/test"
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 	node := startNode(t, endpoint, root, "node-a")
 
 	mux := http.NewServeMux()

--- a/internal/clusterquery/backend_test.go
+++ b/internal/clusterquery/backend_test.go
@@ -9,6 +9,7 @@ import (
 	sigmetric "github.com/oteldb/storage/signal/metric"
 
 	"github.com/oteldb/oteldb/internal/clusterquery"
+	"github.com/oteldb/oteldb/internal/etcdtest"
 	"github.com/oteldb/oteldb/internal/storagebackend"
 )
 
@@ -20,7 +21,7 @@ func TestBackendServesFromCluster(t *testing.T) {
 
 	const shards = 2
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 
 	keys := shardKeys(shards)
 	startNode(t, endpoint, "node-a", map[string][]string{

--- a/internal/clusterquery/source_test.go
+++ b/internal/clusterquery/source_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"net/url"
 	"slices"
 	"sort"
 	"testing"
@@ -13,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.etcd.io/etcd/server/v3/embed"
 
 	"github.com/oteldb/storage/cluster"
 	"github.com/oteldb/storage/cluster/etcd"
@@ -22,51 +20,11 @@ import (
 	"github.com/oteldb/storage/signal"
 
 	"github.com/oteldb/oteldb/internal/clusterquery"
+	"github.com/oteldb/oteldb/internal/etcdtest"
 )
 
 // clusterRoot is the etcd key prefix these tests coordinate under.
 const clusterRoot = "/test"
-
-func freeAddr(tb testing.TB) string {
-	tb.Helper()
-
-	var lc net.ListenConfig
-
-	l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	require.NoError(tb, err)
-	defer func() { _ = l.Close() }()
-
-	return l.Addr().String()
-}
-
-// startEtcd runs an embedded etcd and returns its client endpoint.
-func startEtcd(t *testing.T) string {
-	t.Helper()
-
-	lc := url.URL{Scheme: "http", Host: freeAddr(t)}
-	lp := url.URL{Scheme: "http", Host: freeAddr(t)}
-
-	cfg := embed.NewConfig()
-	cfg.Dir = t.TempDir()
-	cfg.LogLevel = "error"
-	cfg.ListenClientUrls = []url.URL{lc}
-	cfg.AdvertiseClientUrls = []url.URL{lc}
-	cfg.ListenPeerUrls = []url.URL{lp}
-	cfg.AdvertisePeerUrls = []url.URL{lp}
-	cfg.InitialCluster = cfg.Name + "=" + lp.String()
-
-	e, err := embed.StartEtcd(cfg)
-	require.NoError(t, err)
-	t.Cleanup(e.Close)
-
-	select {
-	case <-e.Server.ReadyNotify():
-	case <-time.After(30 * time.Second):
-		t.Fatal("embedded etcd did not become ready")
-	}
-
-	return lc.String()
-}
 
 // series builds a one-label stream identity.
 func series(name string) signal.Series {
@@ -99,7 +57,7 @@ type fakeNode struct {
 func startNode(t *testing.T, endpoint, id string, held map[string][]string) *fakeNode {
 	t.Helper()
 
-	n := &fakeNode{addr: freeAddr(t), held: held, keys: map[string][]cluster.KeyInfo{}}
+	n := &fakeNode{addr: etcdtest.FreeAddr(t), held: held, keys: map[string][]cluster.KeyInfo{}}
 
 	mux := http.NewServeMux()
 	mux.Handle(cluster.ReadPath, cluster.ReadHandler(n.fetch, n.fetch, n.fetch, n.fetch))
@@ -233,7 +191,7 @@ func TestFetcherGathersEveryShard(t *testing.T) {
 
 	const shards = 4
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 
 	keys := shardKeys(shards)
 	require.Len(t, keys, shards)
@@ -268,7 +226,7 @@ func TestFetcherGathersEveryShard(t *testing.T) {
 func TestFetcherReappliesMatchers(t *testing.T) {
 	t.Parallel()
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 	startNode(t, endpoint, "node-a", map[string][]string{
 		string(cluster.DefaultTenant): {"kept", "dropped"},
 	})
@@ -294,7 +252,7 @@ func TestFetcherReappliesMatchers(t *testing.T) {
 func TestSeriesFailsOverAbsentOwner(t *testing.T) {
 	t.Parallel()
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 
 	key := string(cluster.DefaultTenant)
 
@@ -321,7 +279,7 @@ func TestSeriesFailsOverAbsentOwner(t *testing.T) {
 func TestSeriesEmptyWhenEveryOwnerDisclaims(t *testing.T) {
 	t.Parallel()
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 	startNode(t, endpoint, "node-a", map[string][]string{})
 
 	src := clusterquery.New(openRouter(t, endpoint, 1, 1))
@@ -339,7 +297,7 @@ func TestLogKeysUnionsShards(t *testing.T) {
 
 	const shards = 2
 
-	endpoint := startEtcd(t)
+	endpoint := etcdtest.Start(t)
 
 	keys := shardKeys(shards)
 

--- a/internal/etcdtest/etcdtest.go
+++ b/internal/etcdtest/etcdtest.go
@@ -1,0 +1,110 @@
+// Package etcdtest starts embedded etcd servers for tests.
+package etcdtest
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/server/v3/embed"
+)
+
+// freeAddrs returns n loopback addresses that were unbound when probed.
+//
+// Each listener is held open until every address is allocated, so no two results collide.
+// They are unbound on return, though, so a caller that loses a race to bind one must retry.
+func freeAddrs(n int) ([]string, error) {
+	var (
+		lc        net.ListenConfig
+		listeners = make([]net.Listener, 0, n)
+	)
+	defer func() {
+		for _, l := range listeners {
+			_ = l.Close()
+		}
+	}()
+
+	addrs := make([]string, 0, n)
+	for range n {
+		l, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, errors.Wrapf(err, "listen %d/%d", len(addrs)+1, n)
+		}
+
+		listeners = append(listeners, l)
+		addrs = append(addrs, l.Addr().String())
+	}
+
+	return addrs, nil
+}
+
+// FreeAddr returns a loopback address that was unbound when probed.
+func FreeAddr(tb testing.TB) string {
+	tb.Helper()
+
+	addrs, err := freeAddrs(1)
+	require.NoError(tb, err, "allocate port")
+
+	return addrs[0]
+}
+
+// Start runs an embedded etcd and returns its client endpoint.
+func Start(tb testing.TB) string {
+	tb.Helper()
+
+	// Nothing holds the ports between [freeAddrs] and etcd binding them, so anything else on the
+	// machine can take one first. That is a lost race rather than a broken environment, so retry
+	// with fresh ports instead of failing the test.
+	const attempts = 5
+
+	var err error
+	for range attempts {
+		// Running out of ephemeral ports is an exhausted machine rather than a lost race,
+		// so it fails the test instead of feeding the retry.
+		addrs, allocErr := freeAddrs(2)
+		require.NoError(tb, allocErr, "allocate ports")
+
+		var endpoint string
+		if endpoint, err = tryStart(tb, addrs); err == nil {
+			return endpoint
+		}
+	}
+	require.NoError(tb, err, "start embedded etcd")
+
+	return ""
+}
+
+func tryStart(tb testing.TB, addrs []string) (string, error) {
+	tb.Helper()
+
+	client := url.URL{Scheme: "http", Host: addrs[0]}
+	peer := url.URL{Scheme: "http", Host: addrs[1]}
+
+	cfg := embed.NewConfig()
+	cfg.Dir = tb.TempDir()
+	cfg.LogLevel = "error"
+	cfg.ListenClientUrls = []url.URL{client}
+	cfg.AdvertiseClientUrls = []url.URL{client}
+	cfg.ListenPeerUrls = []url.URL{peer}
+	cfg.AdvertisePeerUrls = []url.URL{peer}
+	cfg.InitialCluster = cfg.Name + "=" + peer.String()
+
+	e, err := embed.StartEtcd(cfg)
+	if err != nil {
+		return "", err
+	}
+
+	select {
+	case <-e.Server.ReadyNotify():
+	case <-time.After(30 * time.Second):
+		e.Close()
+		tb.Fatal("embedded etcd did not become ready")
+	}
+	tb.Cleanup(e.Close)
+
+	return client.String(), nil
+}

--- a/internal/etcdtest/etcdtest_test.go
+++ b/internal/etcdtest/etcdtest_test.go
@@ -1,0 +1,25 @@
+package etcdtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFreeAddrsDistinct(t *testing.T) {
+	for _, n := range []int{1, 2, 8} {
+		addrs, err := freeAddrs(n)
+		require.NoError(t, err)
+		require.Len(t, addrs, n)
+
+		seen := make(map[string]struct{}, n)
+		for _, addr := range addrs {
+			require.NotContains(t, seen, addr)
+			seen[addr] = struct{}{}
+		}
+	}
+}
+
+func TestStartServesClientEndpoint(t *testing.T) {
+	require.NotEmpty(t, Start(t))
+}


### PR DESCRIPTION
`freeAddr` probed an ephemeral port, closed it, and let `embed.StartEtcd` bind it later. Anything else on the machine could take the port in that gap, which is how PR #1258 hit:

```
--- FAIL: TestLogKeysUnionsShards (0.01s)
creating peer listener failed: listen tcp 127.0.0.1:36367: bind: address already in use
```

Only the `-race` job failed — it runs slower, so the window is wider.

## Changes

- Ports are held open until *every* address is allocated, so the client and peer addresses cannot collide with each other.
- Startup retries with fresh ports (5 attempts). Losing the race is an environment condition, not a broken test, so it should not fail the run.
- Extracted to `internal/etcdtest`; `internal/clusterquery` and `cmd/odbingest` had byte-identical copies of both helpers, so the bug existed twice and could drift again.

## Verification

Both retry branches were exercised by temporarily injecting failures into `tryStart`:

- 3 injected failures → `Start` still succeeds, tests pass
- all attempts fail → fails loudly at `start embedded etcd`, no hang and no silent pass

Plus `go test -race -count=2 ./internal/clusterquery/ ./cmd/odbingest/` and `-count=4 ./internal/etcdtest/`.

Note the flake did not reproduce locally, as expected — it needs a loaded runner competing for ephemeral ports. The fix follows from the code path rather than from a local repro.

`lint / run` will still report the 2 pre-existing `SA4023` findings until #1294 lands.