### PR TITLE
feat(dev): run ingest and query as their own processes

### DIFF
--- a/.github/workflows/cluster-e2e.yml
+++ b/.github/workflows/cluster-e2e.yml
@@ -8,6 +8,10 @@ name: "Cluster E2E"
 # Both storage models run, because they fail differently. shared-nothing exercises partsync
 # (flushed parts mirrored node-to-node); shared-store puts every node on one MinIO bucket, where
 # the bucket index is committed by several writers through a real conditional PUT.
+#
+# The split model changes the processes rather than the storage: ingest and query move out of the
+# nodes into odbingest and odbselect, so a pass proves those two route and fan out correctly
+# instead of only the --embedded path.
 
 on:
   push:
@@ -33,6 +37,13 @@ jobs:
           # with CompareAndSwap (S3 conditional PUT).
           - model: shared-store
             compose: "-f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.shared-store.yml --profile minio"
+          # Ingest and query as their own processes in front of the same three nodes.
+          - model: split
+            compose: "-f docker-compose.yml -f docker-compose.ci.yml -f docker-compose.split.yml -f docker-compose.split.ci.yml"
+            services: "oteldb-1 oteldb-2 oteldb-3 odbingest odbselect"
+            # Ingest through odbingest, query through odbselect: neither stores anything, so a
+            # result proves the whole path -- route to primary, then fan out and merge.
+            verify: "-otlp localhost:24317 -prometheus http://localhost:19090 -loki http://localhost:13100 -tempo http://localhost:13200"
     steps:
       - name: Install Go
         uses: actions/setup-go@v7
@@ -69,15 +80,12 @@ jobs:
 
       - name: Start cluster
         working-directory: dev/local/storage-cluster
-        run: docker compose ${{ matrix.compose }} up -d --build oteldb-1 oteldb-2 oteldb-3
+        run: docker compose ${{ matrix.compose }} up -d --build ${{ matrix.services || 'oteldb-1 oteldb-2 oteldb-3' }}
 
       - name: Verify ingest + cross-node queries
         run: |
           go run ./dev/local/storage-cluster/cmd/cluster-verify \
-            -otlp localhost:14317 \
-            -prometheus http://localhost:9092 \
-            -loki http://localhost:3100 \
-            -tempo http://localhost:3200 \
+            ${{ matrix.verify || '-otlp localhost:14317 -prometheus http://localhost:9092 -loki http://localhost:3100 -tempo http://localhost:3200' }} \
             -timeout 120s
 
       - name: Dump cluster logs

--- a/dev/local/storage-cluster/README.md
+++ b/dev/local/storage-cluster/README.md
@@ -10,6 +10,9 @@ Both storage models are runnable here:
 - **shared-store** ([below](#shared-store-variant)) — every node reads and writes **one object
   store**, so flushed parts need no mirroring.
 
+Either storage model can also be run **split** ([below](#split-process-variant)): ingest and query
+move out of the nodes into `odbingest` and `odbselect`, their own stateless processes.
+
 ## Run
 
 ```bash
@@ -126,17 +129,64 @@ Neither is a substitute for running against the store you deploy on: `If-Match` 
 universal among S3-compatible services, and where it is missing `CompareAndSwap` has no ground to
 stand on.
 
+## Split-process variant
+
+By default every node runs `--embedded`, so one process both stores and serves. In production the
+two halves scale independently, and they are separate binaries:
+
+- **`odbingest`** — takes OTLP and Prometheus remote write, and routes each shard to its ring primary.
+- **`odbselect`** — answers PromQL/LogQL/TraceQL/ProfileQL by fanning out across the ring and
+  merging replicas.
+
+Both are stateless: they follow membership read-only, never join the ring, and hold no data. The
+three nodes are unchanged — they simply stop being the only front door.
+
+```bash
+docker compose -f dev/local/storage-cluster/docker-compose.yml \
+               -f dev/local/storage-cluster/docker-compose.split.yml up --build
+```
+
+The demo `server` ingests through `odbingest` while `client` keeps ingesting at `oteldb-1`, so both
+write paths carry traffic at once, and Grafana gets a second set of datasources ("PromQL (split)"
+and friends) pointing at `odbselect`. The two paths serve the same cluster, so the same data should
+appear through either — which is the point of having both in one dashboard.
+
+| | embedded | split |
+|---|---|---|
+| PromQL | <http://localhost:9090> | <http://localhost:19090> |
+| LogQL | <http://localhost:3100> | <http://localhost:13100> |
+| TraceQL | <http://localhost:3200> | <http://localhost:13200> |
+| ProfileQL | <http://localhost:4040> | <http://localhost:14040> |
+| OTLP gRPC | <localhost:4317> | <localhost:24317> |
+
+This composes with the shared-store overlay: add both files to put split processes in front of
+nodes that share one bucket.
+
 ## Automated test
 
 The **Cluster E2E** CI job (`.github/workflows/cluster-e2e.yml`) starts this stack with the
 [`docker-compose.ci.yml`](./docker-compose.ci.yml) overlay and runs
 [`cmd/cluster-verify`](./cmd/cluster-verify), which pushes one metric, log, and trace via OTLP to one
 node and asserts they are served by the PromQL/LogQL/TraceQL APIs of other nodes — exercising
-cross-node routing and replication for every signal. Run it locally with:
+cross-node routing and replication for every signal.
+
+It runs once per model (`shared-nothing`, `shared-store`, `split`), because they fail differently:
+the first two change where parts live, while `split` changes which process routes and fans out.
+Run it locally with:
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --build oteldb-1 oteldb-2 oteldb-3
 go run ./cmd/cluster-verify -otlp localhost:14317 -prometheus http://localhost:9092 \
   -loki http://localhost:3100 -tempo http://localhost:3200
+```
+
+Or against the split processes:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.ci.yml \
+               -f docker-compose.split.yml -f docker-compose.split.ci.yml \
+               up -d --build oteldb-1 oteldb-2 oteldb-3 odbingest odbselect
+go run ./cmd/cluster-verify -otlp localhost:24317 -prometheus http://localhost:19090 \
+  -loki http://localhost:13100 -tempo http://localhost:13200
 ```
 

--- a/dev/local/storage-cluster/docker-compose.split.ci.yml
+++ b/dev/local/storage-cluster/docker-compose.split.ci.yml
@@ -1,0 +1,11 @@
+# CI override for the split-process overlay (used with docker-compose.split.yml).
+#
+# Same trade as docker-compose.ci.yml makes for the nodes: the binaries are built on the host with
+# the shared Go cache and baked in via deploy.Dockerfile, instead of a cold compile per image.
+services:
+  odbingest:
+    build:
+      dockerfile: ./dev/deploy/deploy.Dockerfile
+  odbselect:
+    build:
+      dockerfile: ./dev/deploy/deploy.Dockerfile

--- a/dev/local/storage-cluster/docker-compose.split.yml
+++ b/dev/local/storage-cluster/docker-compose.split.yml
@@ -1,0 +1,68 @@
+# Split-process overlay for the storage cluster (used with docker-compose.yml).
+#
+# The base demo runs every node with --embedded, so one process both stores and serves. This
+# overlay adds the two halves as their own processes: odbingest takes ingest and routes each shard
+# to its ring primary, odbselect answers queries by fanning out across the ring. Both are stateless
+# and follow membership read-only, so the three oteldb nodes are unchanged -- they simply stop
+# being the only front door.
+#
+# The demo `server` is repointed at odbingest while `client` keeps ingesting at oteldb-1, so both
+# write paths carry traffic at once. Grafana gets a second set of datasources pointing at
+# odbselect, which makes the split and embedded paths comparable side by side in one dashboard.
+
+x-odb-process: &odb-process
+  image: ghcr.io/oteldb/oteldb/odbsplit
+  # Same source and Dockerfile as the nodes, under its own tag: the CI overlay swaps in the
+  # prebuilt-binary image for the nodes, and a shared tag would make that build ambiguous.
+  pull_policy: build
+  build:
+    context: ../../../
+    dockerfile: dev/Dockerfile
+  environment:
+    - OTEL_LOG_LEVEL=info
+    - OTEL_TRACES_EXPORTER=none
+    - OTEL_METRICS_EXPORTER=none
+    - OTEL_LOGS_EXPORTER=stdout
+  restart: unless-stopped
+  depends_on:
+    etcd:
+      condition: service_healthy
+
+services:
+  # Write half. Both images put the binaries on PATH, so overriding the entrypoint selects which
+  # one runs without needing a separate build per process.
+  odbingest:
+    <<: *odb-process
+    entrypoint: ["odbingest"]
+    command: ["--config=/etc/oteldb/odbingest.yml"]
+    volumes:
+      - ./odbingest.yml:/etc/oteldb/odbingest.yml:ro
+    ports:
+      - "24317:4317"  # OTLP gRPC
+      - "19291:19291" # Prometheus remote write
+
+  # Read half.
+  odbselect:
+    <<: *odb-process
+    entrypoint: ["odbselect"]
+    command: ["--config=/etc/oteldb/odbselect.yml"]
+    volumes:
+      - ./odbselect.yml:/etc/oteldb/odbselect.yml:ro
+    ports:
+      - "19090:9090" # Prometheus / PromQL
+      - "13100:3100" # Loki / LogQL
+      - "13200:3200" # Tempo / TraceQL
+      - "14040:4040" # Pyroscope / ProfileQL
+
+  # Ingests through the split write path instead of oteldb-2's embedded one.
+  server:
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://odbingest:4317
+    depends_on:
+      - odbingest
+
+  grafana:
+    volumes:
+      - ./grafana/datasources-split.yml:/etc/grafana/provisioning/datasources/datasources-split.yml:ro
+    depends_on:
+      - odbselect

--- a/dev/local/storage-cluster/grafana/datasources-split.yml
+++ b/dev/local/storage-cluster/grafana/datasources-split.yml
@@ -1,0 +1,56 @@
+apiVersion: 1
+
+# Read path through odbselect, the query half of oteldb running as its own process
+# (docker-compose.split.yml). It stores nothing: it fans out across the ring and merges replicas,
+# so it answers for data ingested at any node. Named "(split)" to sit alongside the embedded
+# datasources from datasources.yml, which point at oteldb-1 -- both serve the same cluster.
+datasources:
+  - name: PromQL (split)
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://odbselect:9090
+    uid: prom-odbselect
+    jsonData:
+      prometheusType: Prometheus
+      exemplarTraceIdDestinations:
+        - datasourceUid: tempo-odbselect
+          name: trace_id
+
+  - name: LogQL (split)
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://odbselect:3100
+    uid: loki-odbselect
+    jsonData:
+      maxLines: 500
+      derivedFields:
+        - datasourceUid: tempo-odbselect
+          matcherType: label
+          matcherRegex: trace_id
+          name: trace
+          url: "$${__value.raw}"
+          urlDisplayLabel: "View Trace"
+
+  - name: TraceQL (split)
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://odbselect:3200
+    uid: tempo-odbselect
+    jsonData:
+      httpMethod: GET
+      tracesToLogsV2:
+        datasourceUid: loki-odbselect
+        spanStartTimeShift: "-1h"
+        spanEndTimeShift: "1h"
+        customQuery: true
+        query: '{$${__tags}} |= "$${__span.traceId}"'
+        tags:
+          - key: service.name
+            value: service_name
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: prom-odbselect

--- a/dev/local/storage-cluster/odbingest.yml
+++ b/dev/local/storage-cluster/odbingest.yml
@@ -1,0 +1,10 @@
+# Config for odbingest in the split-process topology (docker-compose.split.yml).
+#
+# odbingest is the write half of oteldb on its own: it accepts OTLP and Prometheus remote write,
+# converts straight to the engine's ingest model, and routes each shard to its ring primary. It
+# stores nothing and never joins the ring, so all it needs is a way to find the cluster.
+cluster:
+  etcd: ["http://etcd:2379"]
+  # Must match the storage nodes' cluster block in oteldb.yml, or routing lands on the wrong owners.
+  rf: 2
+  root: /oteldb

--- a/dev/local/storage-cluster/odbselect.yml
+++ b/dev/local/storage-cluster/odbselect.yml
@@ -1,0 +1,11 @@
+# Config for odbselect in the split-process topology (docker-compose.split.yml).
+#
+# odbselect is the read half of oteldb on its own: it serves PromQL, LogQL, TraceQL and ProfileQL
+# by fanning out across the ring and merging replicas. Like odbingest it is stateless and follows
+# membership read-only, so it needs nothing but the cluster's etcd.
+#
+# Every API keeps its default bind (:9090, :3100, :3200, :4040); the compose file publishes them.
+cluster:
+  etcd: ["http://etcd:2379"]
+  rf: 2
+  root: /oteldb


### PR DESCRIPTION
The cluster demo only ever ran nodes with `--embedded`, so one process both stored and served. `odbingest` and `odbselect` — the split deployment oteldb actually ships — were exercised by **nothing** in dev or CI. Their shutdown paths are exactly where the two `SA4023` bugs sat for days.

## What this adds

- `docker-compose.split.yml` — `odbingest` (OTLP + Prometheus remote write → ring primary) and `odbselect` (PromQL/LogQL/TraceQL/ProfileQL fan-out) as their own services. Both stateless, both following membership read-only; the three nodes are unchanged.
- `docker-compose.split.ci.yml` — prebuilt-binary images, matching what `docker-compose.ci.yml` does for the nodes.
- A third **Cluster E2E** matrix entry, so this is verified on every PR rather than by hand.
- The demo `server` ingests through `odbingest` while `client` stays on `oteldb-1`, so both write paths carry traffic at once, and Grafana gets a second datasource set pointing at `odbselect` for side-by-side comparison.

Both processes share one image and select their binary by entrypoint, so this adds no extra compile.

## Verified locally, not just `compose config`

Full stack up, then the verifier through the split path end to end:

```
>> pushed metric/log/trace to localhost:24317 (service.name=cluster-e2e)
>> PromQL http://localhost:19090 served the data
>> LogQL http://localhost:13100 served the data
>> TraceQL http://localhost:13200 served the data
OK: metric, log, and trace ingested on one node and served by another
```

Also confirmed: both halves join the ring (`ring rebuilt members=3`); the demo `server`'s telemetry is queryable through `odbselect`, proving the repointed path; and Grafana provisions all six datasources with no uid or name collision.

Composes with the shared-store overlay — split processes in front of nodes sharing one bucket.