### PR TITLE
feat(ch2storagebackend): add an OTLP destination

### DIFF
--- a/cmd/ch2storagebackend/main.go
+++ b/cmd/ch2storagebackend/main.go
@@ -34,6 +34,8 @@ func run(ctx context.Context) error {
 	var (
 		dsn        = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL")
 		storageDir = flag.String("storage-dir", "", "Directory for the embedded storage engine's file backend (empty uses an ephemeral in-memory backend)")
+		otlpAddr   = flag.String("otlp", "", "Export to this OTLP gRPC endpoint (host:port) instead of a local engine; use it to load a cluster through odbingest")
+		otlpMaxMsg = flag.Int("otlp-max-msg-bytes", 64<<20, "Cap on a single OTLP export message; should match the receiver's max_body_bytes")
 		batchSize  = flag.Int("batch", 5_000, "Number of records/spans to convert and ingest per batch")
 		signals    = flag.String("signals", "logs,traces,metrics", "Comma-separated list of signals to migrate (logs, traces, metrics)")
 
@@ -108,20 +110,36 @@ func run(ctx context.Context) error {
 		return printEstimates(ctx, m, *signals, window)
 	}
 
-	store, err := openStore(ctx, *storageDir, *flushInterval, *maxPartBytes, lg)
-	if err != nil {
-		return errors.Wrap(err, "open storage engine")
-	}
-	defer func() {
-		_ = store.Close(ctx)
-	}()
-	back := storagebackend.New(store)
-
-	m := ch2storagebackend.NewMigrator(client, chstorage.DefaultTables(), back, lg,
+	opts := []ch2storagebackend.Option{
 		ch2storagebackend.WithThrottle(*throttle),
 		ch2storagebackend.WithCheckpoint(checkpoint),
-		ch2storagebackend.WithSync(syncStore(store)),
-	)
+	}
+
+	// An OTLP destination owns no engine: the cluster on the other end flushes on its own cadence,
+	// so there is no local store to open or sync.
+	var back *storagebackend.Backend
+	if *otlpAddr != "" {
+		lg.Info("Exporting over OTLP", zap.String("endpoint", *otlpAddr))
+		opts = append(opts, ch2storagebackend.WithOTLP(*otlpAddr, *otlpMaxMsg))
+	} else {
+		store, err := openStore(ctx, *storageDir, *flushInterval, *maxPartBytes, lg)
+		if err != nil {
+			return errors.Wrap(err, "open storage engine")
+		}
+		defer func() {
+			_ = store.Close(ctx)
+		}()
+		back = storagebackend.New(store)
+		opts = append(opts, ch2storagebackend.WithSync(syncStore(store)))
+	}
+
+	m := ch2storagebackend.NewMigrator(client, chstorage.DefaultTables(), back, lg, opts...)
+	if err := m.Err(); err != nil {
+		return errors.Wrap(err, "set up destination")
+	}
+	defer func() {
+		_ = m.Close()
+	}()
 
 	for sig := range strings.SplitSeq(*signals, ",") {
 		switch sig {

--- a/integration/ch2storagebackende2e/migrate_otlp_test.go
+++ b/integration/ch2storagebackende2e/migrate_otlp_test.go
@@ -1,0 +1,259 @@
+// Package ch2storagebackende2e_test, OTLP destination.
+//
+// The migrator's OTLP path exists to load a cluster, where writes must go through ingest routing
+// rather than into one node's backend. These tests stand in odbingest's own receiving stack --
+// [otlpdirect.Handler] over gRPC -- in front of a memory-backed engine, and assert that migrating
+// through it lands the same data as writing the engine directly. That equality is the point: the
+// two destinations convert differently (internal model vs pdata), so they can drift.
+package ch2storagebackende2e_test
+
+import (
+	"context"
+	"net"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"google.golang.org/grpc"
+
+	"github.com/oteldb/oteldb/internal/iterators"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/backend"
+	sigprofile "github.com/oteldb/storage/signal/profile"
+
+	"github.com/oteldb/oteldb/integration"
+	"github.com/oteldb/oteldb/internal/ch2storagebackend"
+	"github.com/oteldb/oteldb/internal/chstorage"
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/lokiapi"
+	"github.com/oteldb/oteldb/internal/lokihandler"
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// otlpSink adapts a [storagebackend.Backend] to [otlpdirect.Sink]. Only profiles need adapting:
+// chstorage stores none, so the migrator never sends any and this method is unreachable.
+type otlpSink struct {
+	*storagebackend.Backend
+}
+
+func (otlpSink) WriteProfiles(context.Context, *sigprofile.Profiles) error {
+	return errors.New("ch2storagebackend does not migrate profiles")
+}
+
+// startOTLPReceiver serves the same OTLP handler odbingest runs, writing into back, and returns
+// its address.
+func startOTLPReceiver(t *testing.T, back *storagebackend.Backend) string {
+	t.Helper()
+
+	h := otlpdirect.NewHandler(otlpSink{back}, otlpdirect.HandlerConfig{
+		Logger: integration.Logger(t),
+	})
+
+	srv := grpc.NewServer(h.GRPCServerOptions()...)
+	h.RegisterGRPC(srv)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() {
+		_ = srv.Serve(ln)
+	}()
+	t.Cleanup(srv.Stop)
+
+	return ln.Addr().String()
+}
+
+// openMemoryBackend opens an ephemeral in-memory engine.
+func openMemoryBackend(t *testing.T) *storagebackend.Backend {
+	t.Helper()
+
+	store, err := storage.Open(t.Context(), storage.Options{},
+		storage.WithBackend(backend.Memory()),
+		storage.WithDurability(storage.DurabilityEphemeral),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = store.Close(context.WithoutCancel(t.Context()))
+	})
+
+	return storagebackend.New(store)
+}
+
+// queryLogBodies returns every log body the engine serves in the window around base, sorted.
+func queryLogBodies(t *testing.T, back *storagebackend.Backend, base time.Time) []string {
+	t.Helper()
+
+	provider := integration.TraceProvider(t)
+
+	engine, err := logqlengine.NewEngine(back.Logs(), logqlengine.Options{
+		ParseOptions:   logql.ParseOptions{AllowDots: true},
+		Optimizers:     logqlengine.DefaultOptimizers(),
+		TracerProvider: provider,
+	})
+	require.NoError(t, err)
+
+	api := lokihandler.NewLokiAPI(back.Logs(), engine, lokihandler.LokiAPIOptions{})
+	h, err := lokiapi.NewServer(api, lokiapi.WithTracerProvider(provider))
+	require.NoError(t, err)
+
+	s := httptest.NewServer(h)
+	t.Cleanup(s.Close)
+
+	c, err := lokiapi.NewClient(s.URL, lokiapi.WithClient(s.Client()), lokiapi.WithTracerProvider(provider))
+	require.NoError(t, err)
+
+	resp, err := c.QueryRange(t.Context(), lokiapi.QueryRangeParams{
+		Query: `{service_name=~".+"}`,
+		Start: lokiapi.NewOptLokiTime(asLokiTime(base.Add(-time.Minute))),
+		End:   lokiapi.NewOptLokiTime(asLokiTime(base.Add(time.Minute))),
+		Limit: lokiapi.NewOptInt(100),
+	})
+	require.NoError(t, err)
+
+	streams, ok := resp.Data.GetStreamsResult()
+	require.True(t, ok)
+
+	var bodies []string
+	for _, stream := range streams.Result {
+		require.True(t, stream.Stream.Set)
+		require.Contains(t, stream.Stream.Value, "service_name")
+		for _, v := range stream.Values {
+			bodies = append(bodies, v.V)
+		}
+	}
+	sort.Strings(bodies)
+
+	return bodies
+}
+
+func TestMigrateLogsOverOTLP(t *testing.T) {
+	integration.Skip(t)
+	var (
+		ctx      = t.Context()
+		provider = integration.TraceProvider(t)
+	)
+
+	_, client, tables := integration.SetupCH(t, integration.SetupCHOptions{
+		Name:           "ch2storagebackend",
+		TablePrefix:    uniqueTablePrefix(),
+		TracerProvider: provider,
+	})
+
+	inserter, err := chstorage.NewInserter(client, chstorage.InserterOptions{
+		Tables:         tables,
+		TracerProvider: provider,
+	})
+	require.NoError(t, err)
+
+	consumer, err := logstorage.NewConsumer(inserter, logstorage.ConsumerOptions{})
+	require.NoError(t, err)
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, consumer.ConsumeLogs(ctx, buildLogs(base)))
+
+	// Same source, both destinations.
+	direct := openMemoryBackend(t)
+	viaOTLP := openMemoryBackend(t)
+
+	dm := ch2storagebackend.NewMigrator(client, tables, direct, integration.Logger(t))
+	require.NoError(t, dm.Err())
+	directStats, err := dm.MigrateLogs(ctx, chstorage.Window{}, 2)
+	require.NoError(t, err)
+
+	om := ch2storagebackend.NewMigrator(client, tables, nil, integration.Logger(t),
+		ch2storagebackend.WithOTLP(startOTLPReceiver(t, viaOTLP), 64<<20),
+	)
+	require.NoError(t, om.Err())
+	t.Cleanup(func() {
+		_ = om.Close()
+	})
+	// A batch size below the record count forces more than one export.
+	otlpStats, err := om.MigrateLogs(ctx, chstorage.Window{}, 2)
+	require.NoError(t, err)
+
+	require.Equal(t, 4, otlpStats.Records)
+	require.Equal(t, 2, otlpStats.Batches)
+	require.Equal(t, directStats.Records, otlpStats.Records)
+
+	want := queryLogBodies(t, direct, base)
+	require.Len(t, want, 4)
+	require.Equal(t, want, queryLogBodies(t, viaOTLP, base),
+		"OTLP destination served different logs than the direct one")
+}
+
+func TestMigrateTracesOverOTLP(t *testing.T) {
+	integration.Skip(t)
+	var (
+		ctx      = t.Context()
+		provider = integration.TraceProvider(t)
+	)
+
+	_, client, tables := integration.SetupCH(t, integration.SetupCHOptions{
+		Name:           "ch2storagebackend",
+		TablePrefix:    uniqueTablePrefix(),
+		TracerProvider: provider,
+	})
+
+	inserter, err := chstorage.NewInserter(client, chstorage.InserterOptions{
+		Tables:         tables,
+		TracerProvider: provider,
+	})
+	require.NoError(t, err)
+
+	consumer := tracestorage.NewConsumer(inserter)
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	traceID := pcommon.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	require.NoError(t, consumer.ConsumeTraces(ctx, buildTraces(base, traceID)))
+
+	viaOTLP := openMemoryBackend(t)
+
+	m := ch2storagebackend.NewMigrator(client, tables, nil, integration.Logger(t),
+		ch2storagebackend.WithOTLP(startOTLPReceiver(t, viaOTLP), 64<<20),
+	)
+	require.NoError(t, m.Err())
+	t.Cleanup(func() {
+		_ = m.Close()
+	})
+
+	stats, err := m.MigrateTraces(ctx, chstorage.Window{}, 1)
+	require.NoError(t, err)
+	require.Equal(t, 2, stats.Spans)
+	// One span per batch, so the export path runs more than once.
+	require.Equal(t, 2, stats.Batches)
+
+	it, err := viaOTLP.Traces().TraceByID(ctx, otelstorage.TraceID(traceID), tracestorage.TraceByIDOptions{})
+	require.NoError(t, err)
+
+	spans := map[string]tracestorage.Span{}
+	require.NoError(t, iterators.ForEach(it, func(s tracestorage.Span) error {
+		spans[s.Name] = s
+		return nil
+	}))
+	require.Len(t, spans, 2)
+	require.Contains(t, spans, "root")
+	require.Contains(t, spans, "child")
+
+	root := spans["root"]
+	serviceName, ok := root.ServiceName()
+	require.True(t, ok)
+	require.Equal(t, "traceService", serviceName)
+	v, ok := root.Attrs.AsMap().Get("http.method")
+	require.True(t, ok, "root span missing http.method attribute")
+	require.Equal(t, "GET", v.AsString())
+
+	require.Equal(t,
+		otelstorage.SpanID(pcommon.SpanID{1, 2, 3, 4, 5, 6, 7, 8}),
+		spans["child"].ParentSpanID,
+	)
+}

--- a/internal/ch2storagebackend/destination.go
+++ b/internal/ch2storagebackend/destination.go
@@ -1,0 +1,67 @@
+package ch2storagebackend
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/metricstorage"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// destination receives migrated data.
+//
+// It is not a pdata interface: the embedded engine takes the internal signal model directly, and
+// routing every row through pdata to satisfy a shared signature would undo that. Each destination
+// converts from the source model in whatever way suits it.
+type destination interface {
+	WriteLogs(ctx context.Context, records []logstorage.Record) error
+	WriteTraces(ctx context.Context, spans []tracestorage.Span) error
+	WriteNumberPoints(ctx context.Context, points []metricstorage.NumberPoint) error
+	WriteMetrics(ctx context.Context, md pmetric.Metrics) error
+	Close() error
+}
+
+// backendDest writes into an embedded [storagebackend.Backend], bypassing pdata for everything the
+// engine can take in its own model.
+type backendDest struct {
+	back  *storagebackend.Backend
+	attrs *attrConv
+}
+
+func (d *backendDest) WriteLogs(ctx context.Context, records []logstorage.Record) error {
+	if err := d.back.WriteLogs(ctx, ConvertLogs(records, d.attrs)); err != nil {
+		return errors.Wrap(err, "write logs")
+	}
+
+	return nil
+}
+
+func (d *backendDest) WriteTraces(ctx context.Context, spans []tracestorage.Span) error {
+	if err := d.back.WriteTraces(ctx, ConvertTraces(spans, d.attrs)); err != nil {
+		return errors.Wrap(err, "write traces")
+	}
+
+	return nil
+}
+
+func (d *backendDest) WriteNumberPoints(ctx context.Context, points []metricstorage.NumberPoint) error {
+	if err := d.back.WriteMetrics(ctx, ConvertNumberPoints(points, d.attrs)); err != nil {
+		return errors.Wrap(err, "write metrics")
+	}
+
+	return nil
+}
+
+func (d *backendDest) WriteMetrics(ctx context.Context, md pmetric.Metrics) error {
+	if err := d.back.ConsumeMetrics(ctx, md); err != nil {
+		return errors.Wrap(err, "consume metrics")
+	}
+
+	return nil
+}
+
+func (d *backendDest) Close() error { return nil }

--- a/internal/ch2storagebackend/migrator.go
+++ b/internal/ch2storagebackend/migrator.go
@@ -79,11 +79,13 @@ type Migrator struct {
 	logs       *chstorage.LogsSource
 	traces     *chstorage.TracesSource
 	metrics    *chstorage.MetricsSource
-	back       *storagebackend.Backend
+	dst        destination
 	logger     *zap.Logger
 	throttle   time.Duration
 	checkpoint *Checkpoint
 	sync       func(context.Context) error
+	// dialErr defers an [Option] failure to [Migrator.Err], since options cannot return one.
+	dialErr error
 	// attrs memoizes attribute-set projections across the whole migration (see convert.go). It is
 	// shared by every signal: a resource attribute set is typically common to all of them.
 	attrs *attrConv
@@ -91,6 +93,23 @@ type Migrator struct {
 
 // Option configures a [Migrator].
 type Option func(*Migrator)
+
+// WithOTLP sends everything to an OTLP gRPC endpoint instead of the embedded engine. It is how a
+// cluster is loaded: writes go through the same routing and replication as live traffic, whereas
+// the engine destination would put parts in one node's backend that the ring never assigned it.
+//
+// maxSendBytes caps a single export message; batches large enough to exceed the receiver's limit
+// fail outright, so it should match the ingest side's max_body_bytes.
+func WithOTLP(endpoint string, maxSendBytes int) Option {
+	return func(m *Migrator) {
+		dst, err := dialOTLP(endpoint, maxSendBytes)
+		if err != nil {
+			m.dialErr = err
+			return
+		}
+		m.dst = dst
+	}
+}
 
 // WithThrottle sleeps d after every ingested batch. A bulk migration can
 // ingest orders of magnitude faster than the storage engine's background flush/compaction
@@ -126,10 +145,10 @@ func NewMigrator(client chstorage.ClickHouseClient, tables chstorage.Tables, bac
 		logs:    chstorage.NewLogsSource(client, tables, logger.Named("logs_source")),
 		traces:  chstorage.NewTracesSource(client, tables, logger.Named("traces_source")),
 		metrics: chstorage.NewMetricsSource(client, tables, logger.Named("metrics_source")),
-		back:    back,
 		logger:  logger,
 		attrs:   newAttrConv(),
 	}
+	m.dst = &backendDest{back: back, attrs: m.attrs}
 	for _, opt := range opts {
 		opt(m)
 	}
@@ -218,8 +237,8 @@ func (m *Migrator) MigrateLogs(ctx context.Context, w chstorage.Window, batchSiz
 
 		dayRecords := 0
 		err := m.logs.Scan(ctx, d.From, d.To, batchSize, func(ctx context.Context, records []logstorage.Record) error {
-			if err := m.back.WriteLogs(ctx, ConvertLogs(records, m.attrs)); err != nil {
-				return errors.Wrap(err, "write logs")
+			if err := m.dst.WriteLogs(ctx, records); err != nil {
+				return err
 			}
 			dayRecords += len(records)
 			stats.Records += len(records)
@@ -271,8 +290,8 @@ func (m *Migrator) MigrateTraces(ctx context.Context, w chstorage.Window, batchS
 
 		daySpans := 0
 		err := m.traces.Scan(ctx, d.From, d.To, batchSize, func(ctx context.Context, spans []tracestorage.Span) error {
-			if err := m.back.WriteTraces(ctx, ConvertTraces(spans, m.attrs)); err != nil {
-				return errors.Wrap(err, "write traces")
+			if err := m.dst.WriteTraces(ctx, spans); err != nil {
+				return err
 			}
 			daySpans += len(spans)
 			stats.Spans += len(spans)
@@ -333,8 +352,8 @@ func (m *Migrator) MigrateMetrics(ctx context.Context, w chstorage.Window, batch
 
 		dayPoints := 0
 		err := scan.ScanNumbers(ctx, d.From, d.To, batchSize, func(ctx context.Context, points []metricstorage.NumberPoint) error {
-			if err := m.back.WriteMetrics(ctx, ConvertNumberPoints(points, m.attrs)); err != nil {
-				return errors.Wrap(err, "write metrics")
+			if err := m.dst.WriteNumberPoints(ctx, points); err != nil {
+				return err
 			}
 			dayPoints += len(points)
 			stats.Points += len(points)
@@ -346,9 +365,8 @@ func (m *Migrator) MigrateMetrics(ctx context.Context, w chstorage.Window, batch
 		}
 
 		err = scan.ScanExpHistograms(ctx, d.From, d.To, batchSize, func(ctx context.Context, points []metricstorage.ExpHistogramPoint) error {
-			md := metricstorage.ExpHistogramsToMetrics(points)
-			if err := m.back.ConsumeMetrics(ctx, md); err != nil {
-				return errors.Wrap(err, "consume exp histograms")
+			if err := m.dst.WriteMetrics(ctx, metricstorage.ExpHistogramsToMetrics(points)); err != nil {
+				return err
 			}
 			dayPoints += len(points)
 			stats.ExpHistograms += len(points)
@@ -375,3 +393,10 @@ func (m *Migrator) MigrateMetrics(ctx context.Context, w chstorage.Window, batch
 	}
 	return stats, nil
 }
+
+// Err reports a failure from an [Option] that could not return one, such as [WithOTLP] failing to
+// connect. It must be checked before migrating.
+func (m *Migrator) Err() error { return m.dialErr }
+
+// Close releases the destination.
+func (m *Migrator) Close() error { return m.dst.Close() }

--- a/internal/ch2storagebackend/otlp.go
+++ b/internal/ch2storagebackend/otlp.go
@@ -1,0 +1,97 @@
+package ch2storagebackend
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/oteldb/oteldb/internal/logstorage"
+	"github.com/oteldb/oteldb/internal/metricstorage"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// otlpDest exports over OTLP gRPC instead of writing an engine directly.
+//
+// Pointed at odbingest, this is the only way to load a cluster: data enters through the same
+// routing and replication as live traffic, rather than landing in one node's backend where the
+// ring never assigned it.
+type otlpDest struct {
+	conn    *grpc.ClientConn
+	logs    plogotlp.GRPCClient
+	traces  ptraceotlp.GRPCClient
+	metrics pmetricotlp.GRPCClient
+}
+
+// dialOTLP connects to an OTLP gRPC endpoint (host:port).
+func dialOTLP(endpoint string, maxSendBytes int) (*otlpDest, error) {
+	conn, err := grpc.NewClient(endpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(maxSendBytes)),
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "dial %q", endpoint)
+	}
+
+	return &otlpDest{
+		conn:    conn,
+		logs:    plogotlp.NewGRPCClient(conn),
+		traces:  ptraceotlp.NewGRPCClient(conn),
+		metrics: pmetricotlp.NewGRPCClient(conn),
+	}, nil
+}
+
+func (d *otlpDest) WriteLogs(ctx context.Context, records []logstorage.Record) error {
+	req := plogotlp.NewExportRequestFromLogs(logstorage.RecordsToLogs(records))
+	resp, err := d.logs.Export(ctx, req)
+	if err != nil {
+		return errors.Wrap(err, "export logs")
+	}
+	if n := resp.PartialSuccess().RejectedLogRecords(); n > 0 {
+		return errors.Errorf("rejected %d log records: %s", n, resp.PartialSuccess().ErrorMessage())
+	}
+
+	return nil
+}
+
+func (d *otlpDest) WriteTraces(ctx context.Context, spans []tracestorage.Span) error {
+	req := ptraceotlp.NewExportRequestFromTraces(tracestorage.SpansToTraces(spans))
+	resp, err := d.traces.Export(ctx, req)
+	if err != nil {
+		return errors.Wrap(err, "export traces")
+	}
+	if n := resp.PartialSuccess().RejectedSpans(); n > 0 {
+		return errors.Errorf("rejected %d spans: %s", n, resp.PartialSuccess().ErrorMessage())
+	}
+
+	return nil
+}
+
+func (d *otlpDest) WriteNumberPoints(ctx context.Context, points []metricstorage.NumberPoint) error {
+	return d.WriteMetrics(ctx, metricstorage.NumberPointsToMetrics(points))
+}
+
+func (d *otlpDest) WriteMetrics(ctx context.Context, md pmetric.Metrics) error {
+	resp, err := d.metrics.Export(ctx, pmetricotlp.NewExportRequestFromMetrics(md))
+	if err != nil {
+		return errors.Wrap(err, "export metrics")
+	}
+	if n := resp.PartialSuccess().RejectedDataPoints(); n > 0 {
+		return errors.Errorf("rejected %d data points: %s", n, resp.PartialSuccess().ErrorMessage())
+	}
+
+	return nil
+}
+
+func (d *otlpDest) Close() error {
+	if err := d.conn.Close(); err != nil {
+		return errors.Wrap(err, "close otlp connection")
+	}
+
+	return nil
+}


### PR DESCRIPTION
`ch2storagebackend` only ever wrote an embedded engine (`NewMigrator` takes a `*storagebackend.Backend`), so it could populate one node's directory but could not load a cluster — parts would land in a backend the ring never assigned them to.

`-otlp host:port` exports over OTLP gRPC instead. Pointed at `odbingest`, data enters through the same routing and replication as live traffic.

## Design

- `destination` is deliberately **not** a pdata interface. The engine takes the internal signal model directly; forcing every row through pdata to share one signature would drop that fast path for the case that doesn't need it. `backendDest` keeps the direct calls, only `otlpDest` converts.
- Every export checks `PartialSuccess()` — a receiver silently dropping records otherwise looks exactly like success.
- With `-otlp`, no local store is opened and no `WithSync` installed: the cluster flushes on its own cadence.
- `WithOTLP` defers its dial error to `Err()`, since `Option` cannot return one and a failed connection must not be swallowed.

## Verified

`go build`, `go vet`, `golangci-lint run` (0 issues), `go test -race` all pass.

Against the split cluster with real ClickHouse data (2 days of homelab telemetry):

```
Migrated logs   {"records": 1119028,  "batches": 225,  "days": 3}
Migrated traces {"spans":   13196704, "batches": 2641, "days": 3}
Done
```

Zero errors, and both counts match ClickHouse exactly (1.12M / 13.0M). Read-back through `odbselect` was confirmed on a smaller run — a real `kube-apiserver.service` log came back through the Loki API, proving ClickHouse → migrator → OTLP → odbingest → ring → odbselect end to end.

## Not verified

Read-back **after the full 13.2M-span load** could not be confirmed: the local Docker environment fell over mid-verification (two containers became phantoms — dead PIDs, no `die` events, `exec` failing with `task not found`, surviving `down`+`up`; buildx also failing with an http2 error). In that state I can't distinguish a storage problem from the container runtime dying, so I'm not claiming either.

One observation worth re-testing on a healthy machine: `odbselect` returned `500 "shard not held by peer"` from a trace-by-ID fan-out, i.e. it asked a node that does not own the shard. That may be a real read-path bug or just a symptom of nodes disappearing underneath it.

Separately, `dev/local/storage-cluster/oteldb.yml` sets no `shards_per_tenant`, so the tenant is the shard: with RF=2 across three nodes, one node holds nothing for single-tenant data.