### PR TITLE
fix(dev): build the demo client image and gate the workload

### DIFF
--- a/dev/local/storage-cluster/README.md
+++ b/dev/local/storage-cluster/README.md
@@ -22,6 +22,15 @@ docker compose -f dev/local/storage-cluster/docker-compose.yml up --build
 Open Grafana at <http://localhost:3000> (anonymous admin) — PromQL, LogQL, and TraceQL datasources
 are pre-provisioned against `oteldb-1`.
 
+### Demo workload
+
+The stack ingests nothing on its own. Add `--profile demo` for a client/server pair that generates
+traffic, or point your own collector at the OTLP endpoints and leave it off:
+
+```bash
+docker compose -f dev/local/storage-cluster/docker-compose.yml --profile demo up --build
+```
+
 ## Topology
 
 ```

--- a/dev/local/storage-cluster/docker-compose.yml
+++ b/dev/local/storage-cluster/docker-compose.yml
@@ -42,6 +42,18 @@ x-oteldb-node: &oteldb-node
     etcd:
       condition: service_healthy
 
+# The demo workload. Both services share one image, so both must know how to build it: with only
+# `image:` set, compose tries to pull a tag that is never published.
+x-oteldemo: &oteldemo
+  image: ghcr.io/oteldb/oteldb/oteldemo
+  pull_policy: build
+  build:
+    context: ../../../
+    dockerfile: dev/Dockerfile
+    args:
+      TARGETS: oteldemo
+      ENTRYPOINT_BIN: oteldemo
+
 services:
   etcd:
     image: quay.io/coreos/etcd:v3.5.17
@@ -96,14 +108,8 @@ services:
 
   # Handles requests from the client; ingests its telemetry at oteldb-2.
   server:
-    image: ghcr.io/oteldb/oteldb/oteldemo
-    pull_policy: build
-    build:
-      context: ../../../
-      dockerfile: dev/Dockerfile
-      args:
-        TARGETS: oteldemo
-        ENTRYPOINT_BIN: oteldemo
+    <<: *oteldemo
+    profiles: [demo]
     command: ["server"]
     restart: always
     environment:
@@ -121,7 +127,8 @@ services:
 
   # Calls the server once per second; ingests its telemetry at oteldb-1.
   client:
-    image: ghcr.io/oteldb/oteldb/oteldemo
+    <<: *oteldemo
+    profiles: [demo]
     command: ["client"]
     restart: always
     environment:


### PR DESCRIPTION
`client` set `image:` with no `build:`, so compose tried to **pull** `ghcr.io/oteldb/oteldb/oteldemo` — a tag that is never published:

```
Error response from daemon: failed to resolve reference
"ghcr.io/oteldb/oteldb/oteldemo:latest": not found
```

It only ever worked when `server` happened to build that tag first in the same run. Starting `client` alone, or first, failed.

Both services now share one `x-oteldemo` build definition, so either can build the image.

## Also: the workload is now opt-in

The demo pair sits behind a `demo` profile. Pointing a real collector or gateway at the cluster no longer means competing with synthetic traffic, which is the case that prompted this.

```bash
# cluster only — feed it yourself
docker compose -f docker-compose.yml -f docker-compose.split.yml up -d --build

# with the self-contained demo workload
docker compose -f docker-compose.yml --profile demo up --build
```

## Verified

Removed the image locally, then ran the exact command that used to fail:

```
$ docker image rm -f ghcr.io/oteldb/oteldb/oteldemo:latest
$ docker compose -f docker-compose.yml --profile demo up -d --build client
 Container storage-cluster-server-1 Started
 Container storage-cluster-client-1 Started
```

And the default `up` now resolves to the cluster alone — etcd, three nodes, odbingest, odbselect, grafana — with no demo containers.