### PR TITLE
feat(dev): store the cluster's own telemetry, and tidy the image handling

### DIFF
--- a/dev/local/storage-cluster/README.md
+++ b/dev/local/storage-cluster/README.md
@@ -22,6 +22,13 @@ docker compose -f dev/local/storage-cluster/docker-compose.yml up --build
 Open Grafana at <http://localhost:3000> (anonymous admin) — PromQL, LogQL, and TraceQL datasources
 are pre-provisioned against `oteldb-1`.
 
+### Self-telemetry
+
+The cluster stores its own signals. Every process ships to [`otelcol`](./otelcol.yml), which
+forwards into the ring — so `odbingest.cluster.accepted_points`, `engine.flush` spans and the rest
+are queryable next to whatever you ingest. Change what is kept by editing `otelcol.yml`; the
+services need no change, and `OTELDB_OTLP_ENDPOINT` is the only thing the split overlay overrides.
+
 ### Demo workload
 
 The stack ingests nothing on its own. Add `--profile demo` for a client/server pair that generates

--- a/dev/local/storage-cluster/README.md
+++ b/dev/local/storage-cluster/README.md
@@ -25,8 +25,9 @@ are pre-provisioned against `oteldb-1`.
 ### Self-telemetry
 
 The cluster stores its own signals. Every process ships to [`otelcol`](./otelcol.yml), which
-forwards into the ring — so `odbingest.cluster.accepted_points`, `engine.flush` spans and the rest
-are queryable next to whatever you ingest. Change what is kept by editing `otelcol.yml`; the
+forwards into the ring — so `odbingest.cluster.accepted_points`, `engine.flush` spans and the
+cluster's own log lines are queryable next to whatever you ingest. The sdk tees zap into the OTLP
+bridge, so `docker logs` still works: the records reach the ring *and* stderr. Change what is kept by editing `otelcol.yml`; the
 services need no change, and `OTELDB_OTLP_ENDPOINT` is the only thing the split overlay overrides.
 
 ### Demo workload

--- a/dev/local/storage-cluster/docker-compose.split.yml
+++ b/dev/local/storage-cluster/docker-compose.split.yml
@@ -11,9 +11,9 @@
 # odbselect, which makes the split and embedded paths comparable side by side in one dashboard.
 
 x-odb-process: &odb-process
-  image: ghcr.io/oteldb/oteldb/odbsplit
-  # Its own tag, built from the same source and Dockerfile as the nodes: sharing their tag would
-  # make the build ambiguous when CLUSTER_DOCKERFILE changes which Dockerfile that tag comes from.
+  # The node image already carries every binary, so these reuse it and pick one by entrypoint
+  # rather than building a second, identical image.
+  image: ghcr.io/oteldb/oteldb
   pull_policy: build
   build:
     context: ../../../
@@ -29,8 +29,7 @@ x-odb-process: &odb-process
       condition: service_healthy
 
 services:
-  # Write half. Both images put the binaries on PATH, so overriding the entrypoint selects which
-  # one runs without needing a separate build per process.
+  # Write half. Both Dockerfiles put the binaries on PATH, so the entrypoint selects which runs.
   odbingest:
     <<: *odb-process
     entrypoint: ["odbingest"]

--- a/dev/local/storage-cluster/docker-compose.split.yml
+++ b/dev/local/storage-cluster/docker-compose.split.yml
@@ -14,7 +14,7 @@ x-odb-process: &odb-process
   # The node image already carries every binary, so these reuse it and pick one by entrypoint
   # rather than building a second, identical image.
   image: ghcr.io/oteldb/oteldb
-  pull_policy: build
+  pull_policy: never
   build:
     context: ../../../
     dockerfile: ${CLUSTER_DOCKERFILE:-dev/Dockerfile}

--- a/dev/local/storage-cluster/docker-compose.split.yml
+++ b/dev/local/storage-cluster/docker-compose.split.yml
@@ -20,9 +20,14 @@ x-odb-process: &odb-process
     dockerfile: ${CLUSTER_DOCKERFILE:-dev/Dockerfile}
   environment:
     - OTEL_LOG_LEVEL=info
-    - OTEL_TRACES_EXPORTER=none
-    - OTEL_METRICS_EXPORTER=none
+    # Both halves ship their own telemetry to otelcol, like the nodes do.
+    - OTEL_METRICS_EXPORTER=otlp
+    - OTEL_TRACES_EXPORTER=otlp
     - OTEL_LOGS_EXPORTER=stdout
+    - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+    - OTEL_EXPORTER_OTLP_INSECURE=true
+    - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
+    - OTEL_METRIC_EXPORT_INTERVAL=5000
   restart: unless-stopped
   depends_on:
     etcd:
@@ -57,6 +62,14 @@ services:
   server:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://odbingest:4317
+    depends_on:
+      - odbingest
+
+  # Self-telemetry takes the path under test too: the collector forwards to the write half rather
+  # than to a node's embedded receiver.
+  otelcol:
+    environment:
+      - OTELDB_OTLP_ENDPOINT=odbingest:4317
     depends_on:
       - odbingest
 

--- a/dev/local/storage-cluster/docker-compose.split.yml
+++ b/dev/local/storage-cluster/docker-compose.split.yml
@@ -23,7 +23,7 @@ x-odb-process: &odb-process
     # Both halves ship their own telemetry to otelcol, like the nodes do.
     - OTEL_METRICS_EXPORTER=otlp
     - OTEL_TRACES_EXPORTER=otlp
-    - OTEL_LOGS_EXPORTER=stdout
+    - OTEL_LOGS_EXPORTER=otlp
     - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
     - OTEL_EXPORTER_OTLP_INSECURE=true
     - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317

--- a/dev/local/storage-cluster/docker-compose.yml
+++ b/dev/local/storage-cluster/docker-compose.yml
@@ -36,9 +36,15 @@ x-oteldb-node: &oteldb-node
     - --config=/etc/oteldb/oteldb.yml
   environment:
     - OTEL_LOG_LEVEL=info
-    - OTEL_TRACES_EXPORTER=none
-    - OTEL_METRICS_EXPORTER=none
+    # The cluster stores its own telemetry, as the other demos do, by way of otelcol -- so the
+    # pipeline is one file to edit instead of an environment change per service.
+    - OTEL_METRICS_EXPORTER=otlp
+    - OTEL_TRACES_EXPORTER=otlp
     - OTEL_LOGS_EXPORTER=stdout
+    - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+    - OTEL_EXPORTER_OTLP_INSECURE=true
+    - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
+    - OTEL_METRIC_EXPORT_INTERVAL=5000
   restart: unless-stopped
   depends_on:
     etcd:
@@ -146,6 +152,20 @@ services:
     depends_on:
       - oteldb-1
       - server
+
+  # Pipeline for the cluster's own telemetry: every process ships here, and this forwards to the
+  # ring. Editing otelcol.yml changes what is kept without touching the services.
+  otelcol:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.140.1
+    command: ["--config=/etc/otelcol/config.yml"]
+    volumes:
+      - ./otelcol.yml:/etc/otelcol/config.yml:ro
+    environment:
+      # The ring's front door. The split overlay points this at odbingest instead.
+      - OTELDB_OTLP_ENDPOINT=oteldb-1:4317
+    restart: unless-stopped
+    depends_on:
+      - oteldb-1
 
   grafana:
     image: "grafana/grafana-oss:12.3.1"

--- a/dev/local/storage-cluster/docker-compose.yml
+++ b/dev/local/storage-cluster/docker-compose.yml
@@ -37,10 +37,11 @@ x-oteldb-node: &oteldb-node
   environment:
     - OTEL_LOG_LEVEL=info
     # The cluster stores its own telemetry, as the other demos do, by way of otelcol -- so the
-    # pipeline is one file to edit instead of an environment change per service.
+    # pipeline is one file to edit instead of an environment change per service. The sdk tees zap
+    # into the OTLP bridge, so `docker logs` keeps working while the records also reach the ring.
     - OTEL_METRICS_EXPORTER=otlp
     - OTEL_TRACES_EXPORTER=otlp
-    - OTEL_LOGS_EXPORTER=stdout
+    - OTEL_LOGS_EXPORTER=otlp
     - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
     - OTEL_EXPORTER_OTLP_INSECURE=true
     - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317

--- a/dev/local/storage-cluster/docker-compose.yml
+++ b/dev/local/storage-cluster/docker-compose.yml
@@ -22,8 +22,10 @@ volumes:
 # its hostname, so the three nodes differ only by hostname and data volume.
 x-oteldb-node: &oteldb-node
   image: ghcr.io/oteldb/oteldb
-  # Always build from local source so the cluster wiring is present (not a stale published image).
-  pull_policy: build
+  # Never pull: ghcr.io/oteldb/oteldb is published, so the default policy would fetch a build that
+  # predates the local cluster wiring. `never` still builds when the image is absent, and reuses it
+  # afterwards -- `--build` forces a rebuild, which `build` would otherwise do on every `up`.
+  pull_policy: never
   build:
     context: ../../../
     # CI sets CLUSTER_DOCKERFILE to deploy.Dockerfile, which bakes in binaries already built on the
@@ -46,7 +48,7 @@ x-oteldb-node: &oteldb-node
 # `image:` set, compose tries to pull a tag that is never published.
 x-oteldemo: &oteldemo
   image: ghcr.io/oteldb/oteldb/oteldemo
-  pull_policy: build
+  pull_policy: never
   build:
     context: ../../../
     dockerfile: dev/Dockerfile

--- a/dev/local/storage-cluster/otelcol.yml
+++ b/dev/local/storage-cluster/otelcol.yml
@@ -1,0 +1,51 @@
+# Collector for the cluster's own telemetry.
+#
+# Every oteldb process ships here rather than straight to the ring, so the pipeline is one file to
+# edit: drop a noisy signal, sample traces, add an attribute, or fan out to somewhere else, without
+# touching the services or restarting the cluster's data path.
+#
+# OTELDB_OTLP_ENDPOINT selects the front door: a node in the default topology, odbingest in the
+# split one. That is the only difference between them, so the pipeline itself never forks.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    timeout: 5s
+  # The cluster ingests its own telemetry, so a burst of ingest work produces more ingest work.
+  # This caps that loop rather than trusting it to settle.
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 256
+    spike_limit_mib: 64
+
+exporters:
+  otlp:
+    endpoint: ${env:OTELDB_OTLP_ENDPOINT}
+    tls:
+      insecure: true
+
+extensions:
+  health_check:
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp]


### PR DESCRIPTION
`odbsplit` was never a binary — just a tag for the image `odbingest` and `odbselect` share. The node image already carries every binary (`dev/Dockerfile` builds all six targets, `deploy.Dockerfile` bakes all six in), so the split services only override `entrypoint` to pick one.

The separate tag existed because the old `docker-compose.ci.yml` overrode `dockerfile` for the **node services only**, so sharing their tag would have given one tag two build definitions. #1306 replaced that with `CLUSTER_DOCKERFILE` across every service, so they can no longer disagree — and the comment justifying the tag described a problem that no longer existed.

The cost was visible:

```
ghcr.io/oteldb/oteldb/odbsplit:latest   cb8627943243   444MB
ghcr.io/oteldb/oteldb:latest            1b5b94f93e4b   444MB
```

Same source, two builds, plus a name in compose output suggesting a component that does not exist.

## Verified

Both modes resolve to a single image and build definition:

```
CLUSTER_DOCKERFILE unset:  ghcr.io/oteldb/oteldb <- dev/Dockerfile
                           :: [odbingest, odbselect, oteldb-1, oteldb-2, oteldb-3]
CLUSTER_DOCKERFILE=deploy: ghcr.io/oteldb/oteldb <- ./dev/deploy/deploy.Dockerfile
                           :: [odbingest, odbselect, oteldb-1, oteldb-2, oteldb-3]
```

Then deleted the `odbsplit` image and ran the stack for real:

```
OK: metric, log, and trace ingested on one node and served by another
```

One image left afterwards, and the entrypoint override still selects each binary correctly.