### PR TITLE
test(clusterquery): cover trace-by-id over the cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.159.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.40.1
+	github.com/oteldb/storage v0.41.0
 	github.com/pierrec/lz4/v4 v4.1.29
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1

--- a/go.sum
+++ b/go.sum
@@ -1031,8 +1031,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.40.1 h1:Og7MuUzDZngIuKsANFmq9MGwCpYDFH+MyrvStyIv9Q0=
-github.com/oteldb/storage v0.40.1/go.mod h1:z/Cm8l1Ba8YsG7YH1FAny6yqOOoLFLxvHubeoCha030=
+github.com/oteldb/storage v0.41.0 h1:2k+Be7Aih7y4BdGO70AFL92+axGNvuG8N7T+12PkFNk=
+github.com/oteldb/storage v0.41.0/go.mod h1:K1gS1AhA39dicp5/M2qwyjoID1ucXIHdWs9Ny4WQxww=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/clusterquery/source_test.go
+++ b/internal/clusterquery/source_test.go
@@ -2,6 +2,7 @@ package clusterquery_test
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"slices"
@@ -18,6 +19,7 @@ import (
 	"github.com/oteldb/storage/cluster/router"
 	"github.com/oteldb/storage/query/fetch"
 	"github.com/oteldb/storage/signal"
+	sigtrace "github.com/oteldb/storage/signal/trace"
 
 	"github.com/oteldb/oteldb/internal/clusterquery"
 	"github.com/oteldb/oteldb/internal/etcdtest"
@@ -52,6 +54,9 @@ type fakeNode struct {
 	held map[string][]string
 	// keys maps a shard key to the record-attribute keys the node reports for it.
 	keys map[string][]cluster.KeyInfo
+	// traceIDs maps a shard key to the trace id of each span row the node holds for it. When set,
+	// a read of that shard answers with those rows instead of the metric-shaped streams.
+	traceIDs map[string][]string
 }
 
 func startNode(t *testing.T, endpoint, id string, held map[string][]string) *fakeNode {
@@ -110,6 +115,10 @@ func (n *fakeNode) fetch(
 	streams, err := n.streams(shardKey)
 	if err != nil {
 		return nil, err
+	}
+
+	if ids, ok := n.traceIDs[shardKey]; ok {
+		return []*fetch.Batch{n.spanBatch(start, ids)}, nil
 	}
 
 	out := make([]*fetch.Batch, 0, len(streams))
@@ -325,4 +334,67 @@ func TestLogKeysUnionsShards(t *testing.T) {
 	assert.Equal(t, []string{"host", "level"}, names)
 	assert.Equal(t, uint8(5), scopes["host"], "the scope bits of both shards")
 	assert.Equal(t, uint8(4), scopes["level"])
+}
+
+// spanBatch answers a trace read with one span row per trace id. The conditions a trace-by-id read
+// carries never reach a peer, so this is deliberately every row of the shard.
+func (n *fakeNode) spanBatch(start int64, ids []string) *fetch.Batch {
+	s := series("spans")
+
+	b := &fetch.Batch{
+		ID:     s.Hash(),
+		Series: s,
+		Columns: []fetch.NamedColumn{
+			{Name: sigtrace.ColTraceID},
+			{Name: sigtrace.ColName},
+		},
+	}
+	for i, id := range ids {
+		b.Timestamps = append(b.Timestamps, start+int64(i))
+		b.Columns[0].Bytes = append(b.Columns[0].Bytes, []byte(id))
+		b.Columns[1].Bytes = append(b.Columns[1].Bytes, fmt.Appendf(nil, "span-%d", i))
+	}
+
+	return b
+}
+
+// TestTraceByIDNarrowsToOneTrace pins the read that has no matchers at all: trace-by-id is a single
+// columnar condition, and conditions do not cross the wire. Narrowing a peer's answer by matchers
+// alone left the condition unapplied, so every span the shard held came back as one trace — and a
+// trace id that exists nowhere returned the whole window instead of nothing.
+func TestTraceByIDNarrowsToOneTrace(t *testing.T) {
+	t.Parallel()
+
+	endpoint := etcdtest.Start(t)
+	node := startNode(t, endpoint, "node-a", map[string][]string{
+		string(cluster.DefaultTenant): {"spans"},
+	})
+	node.traceIDs = map[string][]string{
+		string(cluster.DefaultTenant): {"aaa", "bbb", "aaa", "ccc"},
+	}
+
+	src := clusterquery.New(openRouter(t, endpoint, 1, 1))
+
+	rows := func(id string) []string {
+		t.Helper()
+
+		batches, err := src.Trace(t.Context(), "", []byte(id))
+		require.NoError(t, err)
+
+		var out []string
+		for _, b := range batches {
+			col, ok := b.Column(sigtrace.ColTraceID)
+			require.True(t, ok)
+
+			for _, v := range col.Bytes {
+				out = append(out, string(v))
+			}
+		}
+
+		return out
+	}
+
+	assert.Equal(t, []string{"aaa", "aaa"}, rows("aaa"))
+	assert.Equal(t, []string{"bbb"}, rows("bbb"))
+	assert.Empty(t, rows("nope"), "a trace id nothing holds must return nothing, not the window")
 }


### PR DESCRIPTION
Regression test for oteldb/storage#427.

Trace-by-id over a cluster returned the shard's entire window instead of one trace: the fan-out re-applied only matchers, and trace-by-id carries none — its whole predicate is a columnar condition, which does not cross the wire.

Observed on the live rig, odbselect served 760 traces / 1396 spans for one id, and the same 884-trace blob for an id held nowhere.

The test pins all three cases against the real wire codecs:

```go
assert.Equal(t, []string{"aaa", "aaa"}, rows("aaa"))
assert.Equal(t, []string{"bbb"}, rows("bbb"))
assert.Empty(t, rows("nope"), "a trace id nothing holds must return nothing, not the window")
```

Against the pinned storage version all three fail with `[aaa bbb aaa ccc]` — the whole window, every time. Passes with oteldb/storage#427.

**Blocked on** that PR merging and a storage version bump here; the existing `TestFetcherReappliesMatchers` covered matchers only, which is exactly the gap this fills.