### PR TITLE
fix(storagebackend): return values for TraceQL string intrinsics

### DIFF
--- a/internal/storagebackend/signals_test.go
+++ b/internal/storagebackend/signals_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oteldb/oteldb/internal/profileql"
 	"github.com/oteldb/oteldb/internal/profilestorage"
 	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/traceql"
 	"github.com/oteldb/oteldb/internal/tracestorage"
 )
 
@@ -101,13 +102,18 @@ func TestBackendTracesRoundtrip(t *testing.T) {
 	parent.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
 	parent.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
 	parent.Attributes().PutStr("http.method", "GET")
+	parent.SetKind(ptrace.SpanKindServer)
+	parent.Status().SetCode(ptrace.StatusCodeOk)
 
 	child := ss.Spans().AppendEmpty()
 	child.SetTraceID(traceID)
 	child.SetSpanID(pcommon.SpanID([8]byte{2, 2, 2, 2, 2, 2, 2, 2}))
+	child.SetParentSpanID(parent.SpanID())
 	child.SetName("db.query")
 	child.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
 	child.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
+	child.SetKind(ptrace.SpanKindClient)
+	child.Status().SetCode(ptrace.StatusCodeError)
 
 	require.NoError(t, b.ConsumeTraces(ctx, td))
 
@@ -132,6 +138,76 @@ func TestBackendTracesRoundtrip(t *testing.T) {
 		keys = append(keys, tn.Name)
 	}
 	require.Contains(t, keys, "http.method")
+}
+
+// TestBackendTraceIntrinsicTagValues ingests a two-span trace (one root, one child, with distinct
+// status/kind) and verifies that TagValues enumerates values for the string-ish TraceQL intrinsics:
+// name, status, kind, rootName and rootServiceName.
+func TestBackendTraceIntrinsicTagValues(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "api")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	parent := ss.Spans().AppendEmpty()
+	parent.SetTraceID(traceID)
+	parent.SetSpanID(pcommon.SpanID([8]byte{1, 1, 1, 1, 1, 1, 1, 1}))
+	parent.SetName("GET /")
+	parent.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	parent.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
+	parent.SetKind(ptrace.SpanKindServer)
+	parent.Status().SetCode(ptrace.StatusCodeOk)
+
+	child := ss.Spans().AppendEmpty()
+	child.SetTraceID(traceID)
+	child.SetSpanID(pcommon.SpanID([8]byte{2, 2, 2, 2, 2, 2, 2, 2}))
+	child.SetParentSpanID(parent.SpanID())
+	child.SetName("db.query")
+	child.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	child.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
+	child.SetKind(ptrace.SpanKindClient)
+	child.Status().SetCode(ptrace.StatusCodeError)
+
+	require.NoError(t, b.ConsumeTraces(ctx, td))
+
+	tq := b.Traces()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+
+	values := func(t *testing.T, attr traceql.Attribute) []string {
+		t.Helper()
+		it, err := tq.TagValues(ctx, attr, tracestorage.TagValuesOptions{Start: start, End: end})
+		require.NoError(t, err)
+		tags := drain(t, it)
+		out := make([]string, 0, len(tags))
+		for _, tag := range tags {
+			out = append(out, tag.Value)
+		}
+		return out
+	}
+
+	t.Run("name", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"GET /", "db.query"}, values(t, traceql.Attribute{Prop: traceql.SpanName}))
+	})
+	t.Run("status", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"unset", "ok", "error"}, values(t, traceql.Attribute{Prop: traceql.SpanStatus}))
+	})
+	t.Run("kind", func(t *testing.T) {
+		require.ElementsMatch(t,
+			[]string{"unspecified", "internal", "server", "client", "producer", "consumer"},
+			values(t, traceql.Attribute{Prop: traceql.SpanKind}),
+		)
+	})
+	t.Run("rootName", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"GET /"}, values(t, traceql.Attribute{Prop: traceql.RootSpanName}))
+	})
+	t.Run("rootServiceName", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"api"}, values(t, traceql.Attribute{Prop: traceql.RootServiceName}))
+	})
 }
 
 // TestBackendProfilesRoundtrip ingests an OTLP profile through the storage sink and queries the

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -135,10 +135,30 @@ func (q *TraceQuerier) TagNames(ctx context.Context, opts tracestorage.TagNamesO
 
 // TagValues implements [tracestorage.Querier]. It enumerates the distinct values the attribute takes
 // across the spans in the window.
+//
+// Only the string-ish intrinsics are enumerable: name, status, kind, rootName and rootServiceName.
+// duration, traceDuration and childCount are numeric/unbounded and parent is structural, so — mirroring
+// Tempo and [chstorage.Querier.TagValues] — they yield no autocomplete values.
 func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, opts tracestorage.TagValuesOptions) (iterators.Iterator[tracestorage.Tag], error) {
+	switch attr.Prop {
+	case traceql.SpanStatus:
+		return iterators.Slice(spanStatusTags(attr)), nil
+	case traceql.SpanKind:
+		return iterators.Slice(spanKindTags(attr)), nil
+	case traceql.SpanDuration, traceql.SpanChildCount, traceql.SpanParent, traceql.TraceDuration:
+		return iterators.Empty[tracestorage.Tag](), nil
+	}
+
 	spans, err := q.scanSpans(ctx, opts.Start, opts.End, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	switch attr.Prop {
+	case traceql.SpanName, traceql.RootSpanName:
+		return iterators.Slice(spanNameTags(attr, spans)), nil
+	case traceql.RootServiceName:
+		return iterators.Slice(rootServiceNameTags(attr, spans)), nil
 	}
 
 	seen := map[string]tracestorage.Tag{}
@@ -159,6 +179,77 @@ func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, op
 		out = append(out, tag)
 	}
 	return iterators.Slice(out), nil
+}
+
+// spanStatusTags returns the full [traceql.TypeSpanStatus] enum, formatted the way TraceQL expects
+// (see [SpanMatcher.String]), regardless of which statuses are actually present in the window.
+func spanStatusTags(attr traceql.Attribute) []tracestorage.Tag {
+	name := attr.String()
+	values := [...]string{"unset", "ok", "error"}
+	out := make([]tracestorage.Tag, 0, len(values))
+	for _, v := range values {
+		out = append(out, tracestorage.Tag{Name: name, Value: v, Type: traceql.TypeSpanStatus})
+	}
+	return out
+}
+
+// spanKindTags returns the full [traceql.TypeSpanKind] enum, formatted the way TraceQL expects (see
+// [SpanMatcher.String]), regardless of which kinds are actually present in the window.
+func spanKindTags(attr traceql.Attribute) []tracestorage.Tag {
+	name := attr.String()
+	values := [...]string{"unspecified", "internal", "server", "client", "producer", "consumer"}
+	out := make([]tracestorage.Tag, 0, len(values))
+	for _, v := range values {
+		out = append(out, tracestorage.Tag{Name: name, Value: v, Type: traceql.TypeSpanKind})
+	}
+	return out
+}
+
+// spanNameTags enumerates the distinct span names in spans. For RootSpanName it is restricted to
+// root spans (empty parent span id), since a root span's name is a span-local property and needs no
+// full trace assembly.
+func spanNameTags(attr traceql.Attribute, spans []tracestorage.Span) []tracestorage.Tag {
+	name := attr.String()
+	seen := map[string]struct{}{}
+	var out []tracestorage.Tag
+	for _, span := range spans {
+		if attr.Prop == traceql.RootSpanName && !span.ParentSpanID.IsEmpty() {
+			continue
+		}
+		if span.Name == "" {
+			continue
+		}
+		if _, ok := seen[span.Name]; ok {
+			continue
+		}
+		seen[span.Name] = struct{}{}
+		out = append(out, tracestorage.Tag{Name: name, Value: span.Name, Type: traceql.TypeString})
+	}
+	return out
+}
+
+// rootServiceNameTags enumerates the distinct service.name resource attribute values of root spans
+// (empty parent span id). A root span's own resource is a span-local property, so this needs no full
+// trace assembly.
+func rootServiceNameTags(attr traceql.Attribute, spans []tracestorage.Span) []tracestorage.Tag {
+	name := attr.String()
+	seen := map[string]struct{}{}
+	var out []tracestorage.Tag
+	for _, span := range spans {
+		if !span.ParentSpanID.IsEmpty() {
+			continue
+		}
+		svc, ok := span.ServiceName()
+		if !ok || svc == "" {
+			continue
+		}
+		if _, ok := seen[svc]; ok {
+			continue
+		}
+		seen[svc] = struct{}{}
+		out = append(out, tracestorage.Tag{Name: name, Value: svc, Type: traceql.TypeString})
+	}
+	return out
 }
 
 // candidateTraces resolves the query's span matchers to storage filters and returns the ids of the


### PR DESCRIPTION
## The bug

`/api/v2/search/tags` advertises an `intrinsic` scope — `duration, childCount, name, status, kind, parent, rootName, rootServiceName, traceDuration` — but `/api/v2/search/tag/<intrinsic>/values` returned nothing for any of them. Verified on a live cluster:

```
span.http.route        -> ["/api/v1/query_range", ...]     OK
resource.service.name  -> ["odbselect", "oteldb"]          OK
name                   -> {}    EMPTY
status                 -> {}    EMPTY
kind                   -> {}    EMPTY
rootServiceName        -> {}    EMPTY
```

Attributes autocomplete fine; only intrinsics were empty.

`TraceQuerier.TagValues` resolved every tag through `forEachSpanTag`, which visits only the resource/scope/span attribute maps and never the intrinsic fields — so a name that is not an attribute could never match.

## Fix

`TagValues` now dispatches on `attr.Prop` before falling through to the attribute scan, mirroring `chstorage.Querier.TagValues` so the two backends agree:

| intrinsic | behaviour |
|---|---|
| `status` | static enum `unset` / `ok` / `error` |
| `kind` | static enum `unspecified` / `internal` / `server` / `client` / `producer` / `consumer` |
| `name` | distinct span names in the window |
| `rootName` | distinct span names, restricted to root spans |
| `rootServiceName` | distinct `service.name`, restricted to root spans |
| `duration`, `traceDuration`, `childCount`, `parent` | empty — numeric/structural, not autocomplete values (same as Tempo) |

The enum strings were taken from `chstorage/querier_traces.go`, not invented, so the values are byte-identical between backends.

### One deliberate divergence from chstorage

`rootServiceName` here is restricted to spans with an empty parent span id. chstorage does not restrict it — it aliases the tag to `resource.service.name` under an explicit `FIXME(tdakkota): we don't check if service.name actually coming from a root span`. This side is the stricter, semantically correct reading; worth deciding whether chstorage should follow.

Both root-scoped intrinsics are span-local (empty parent id), so neither needs full trace assembly. The trade-off is that a root span outside the queried window yields nothing rather than an over-broad answer.

## Tests

`TestBackendTraceIntrinsicTagValues` — 5 subtests, all failing before the change with empty result sets, all passing after. `golangci-lint run ./internal/storagebackend/...` → 0 issues.