### PR TITLE
fix(config): give the cluster router a tracer provider

### DIFF
--- a/cmd/odbingest/app.go
+++ b/cmd/odbingest/app.go
@@ -31,7 +31,7 @@ type App struct {
 }
 
 func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*App, error) {
-	rt, err := router.Open(ctx, cfg.Cluster.RouterConfig(lg.Named("cluster")))
+	rt, err := router.Open(ctx, cfg.Cluster.RouterConfig(lg.Named("cluster"), m.TracerProvider()))
 	if err != nil {
 		return nil, errors.Wrap(err, "open cluster router")
 	}

--- a/cmd/odbselect/app.go
+++ b/cmd/odbselect/app.go
@@ -29,7 +29,7 @@ type App struct {
 }
 
 func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *sdkapp.Telemetry) (*App, error) {
-	rt, err := router.Open(ctx, cfg.Cluster.RouterConfig(lg.Named("cluster")))
+	rt, err := router.Open(ctx, cfg.Cluster.RouterConfig(lg.Named("cluster"), m.TracerProvider()))
 	if err != nil {
 		return nil, errors.Wrap(err, "open cluster router")
 	}

--- a/internal/config/cluster.go
+++ b/internal/config/cluster.go
@@ -3,6 +3,7 @@ package config
 import (
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/oteldb/storage/cluster/router"
@@ -29,7 +30,11 @@ type Cluster struct {
 }
 
 // RouterConfig builds the routing view of the cluster described by cfg.
-func (cfg Cluster) RouterConfig(lg *zap.Logger) router.Config {
+//
+// tp is what the routed RPCs report their spans through. A nil provider silently drops every
+// client-side and hedge span while the owners keep reporting their own, which reads as "the fan-out
+// is not instrumented" — so it is passed explicitly rather than defaulted.
+func (cfg Cluster) RouterConfig(lg *zap.Logger, tp trace.TracerProvider) router.Config {
 	return router.Config{
 		Etcd:            cfg.Etcd,
 		Root:            cfg.Root,
@@ -37,5 +42,6 @@ func (cfg Cluster) RouterConfig(lg *zap.Logger) router.Config {
 		ShardsPerTenant: cfg.ShardsPerTenant,
 		DialTimeout:     cfg.DialTimeout,
 		Logger:          lg,
+		TracerProvider:  tp,
 	}
 }

--- a/internal/config/cluster_test.go
+++ b/internal/config/cluster_test.go
@@ -1,0 +1,44 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/oteldb/oteldb/internal/config"
+)
+
+// TestRouterConfigCarriesTracerProvider pins the wiring a nil provider breaks silently: the shard
+// owners keep reporting their own spans, so a cluster query's trace looks instrumented while every
+// client-side and hedge span is dropped.
+func TestRouterConfigCarriesTracerProvider(t *testing.T) {
+	t.Parallel()
+
+	tp := sdktrace.NewTracerProvider()
+	t.Cleanup(func() {
+		_ = tp.Shutdown(t.Context())
+	})
+
+	cfg := config.Cluster{
+		Etcd:            []string{"127.0.0.1:2379"},
+		Root:            "/oteldb",
+		RF:              2,
+		ShardsPerTenant: 4,
+		DialTimeout:     time.Second,
+	}
+
+	got := cfg.RouterConfig(zaptest.NewLogger(t), tp)
+
+	require.NotNil(t, got.TracerProvider, "routed RPCs report no spans without a provider")
+	assert.Same(t, tp, got.TracerProvider)
+
+	assert.Equal(t, cfg.Etcd, got.Etcd)
+	assert.Equal(t, cfg.Root, got.Root)
+	assert.Equal(t, cfg.RF, got.RF)
+	assert.Equal(t, cfg.ShardsPerTenant, got.ShardsPerTenant)
+	assert.Equal(t, cfg.DialTimeout, got.DialTimeout)
+}


### PR DESCRIPTION
## Symptom

On the live cluster, a cluster query's trace looks instrumented but the fan-out is invisible:

```
oteldb  tempo.searchTagValuesV2   58.611ms
oteldb    SearchTagValuesV2       58.530ms
oteldb      cluster.serve.fetch   24.398ms
oteldb        recordengine.fetch  16.917ms
```

Searching every span name oteldb/storage#428 added, only one of them exists anywhere:

```
cluster.serve.fetch   -> found
cluster.fetch         -> {}
cluster.fetch.hedge   -> {}
cluster.series        -> {}
cluster.keys          -> {}
cluster.serve.keys    -> {}
cluster.keys.hedge    -> {}
```

## Cause

`Cluster.RouterConfig` never set `router.Config.TracerProvider`, so odbselect and odbingest opened their router with a nil provider — which storage resolves to a no-op tracer. Every client-side and hedge span was created and immediately discarded.

The shard **owners** are a different process, wired through `storage.Open`, and kept reporting normally. That is what makes the failure so misleading: the trace is not empty, it just silently loses the half that would tell you which owner served a read, how long the remote call took, and whether a hedge or failover fired. It reads as "the fan-out is not instrumented" rather than "the provider is nil".

It also explains why the enumeration RPCs show nothing at all — `cluster.keys` has no server-side counterpart in these traces because the client span is the one that would have been the parent.

## Fix

`RouterConfig` now takes a `trace.TracerProvider` and passes it through; both callers hand it `m.TracerProvider()`, the same provider they already give every API server in `api.go`.

Passing it explicitly rather than defaulting it inside is deliberate — a nil provider fails silently and looks like missing instrumentation, so the parameter should be impossible to forget.

## Test

`TestRouterConfigCarriesTracerProvider` asserts the provider reaches `router.Config` and that the other fields still map, so a future field-mapping slip does not quietly reintroduce this. It is the exact gap the storage-side tests could not catch: they construct `router.Config{TracerProvider: tp}` directly, so they never exercise whether a real caller sets it.