### PR TITLE
build(deps): bump storage to v0.42.0 and use its value enumeration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.159.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.41.0
+	github.com/oteldb/storage v0.42.0
 	github.com/pierrec/lz4/v4 v4.1.29
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1
@@ -261,7 +261,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.7 // indirect
-	github.com/aws/smithy-go v1.27.8 // indirect
+	github.com/aws/smithy-go v1.28.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.7 h1:yU/9y2r7s9kSUPbHXbpQTa4LA8kt+CMgpu1OBrhx8p4=
 github.com/aws/aws-sdk-go-v2/service/sts v1.45.7/go.mod h1:0lQTDEBArMevQXpxu443LVGjKxxEeSsSnrw9n8YiTMg=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
-github.com/aws/smithy-go v1.27.8 h1:FR0dxZfIlV7Z8eh2iHfIofdunw382XsDV3Mxt9nUvRY=
-github.com/aws/smithy-go v1.27.8/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.28.1 h1:R/nXH00c8qcfCzQVELtRw+eLQWtzv+VAIEFJ1/xxXlQ=
+github.com/aws/smithy-go v1.28.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/basgys/goxml2json v1.1.1-0.20231018121955-e66ee54ceaad h1:3swAvbzgfaI6nKuDDU7BiKfZRdF+h2ZwKgMHd8Ha4t8=
@@ -1031,8 +1031,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.41.0 h1:2k+Be7Aih7y4BdGO70AFL92+axGNvuG8N7T+12PkFNk=
-github.com/oteldb/storage v0.41.0/go.mod h1:K1gS1AhA39dicp5/M2qwyjoID1ucXIHdWs9Ny4WQxww=
+github.com/oteldb/storage v0.42.0 h1:CTX60BFRR6kiC/+u3mW3GQJdrFx4KxMb38PVuFUBriw=
+github.com/oteldb/storage v0.42.0/go.mod h1:QG9F3+Wsc7QQC55ckoIMKIYyfeupMDWVVFmFm0QK9WQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/clusterquery/series.go
+++ b/internal/clusterquery/series.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-faster/errors"
 
 	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/cluster"
 	"github.com/oteldb/storage/query/fetch"
 	"github.com/oteldb/storage/signal"
 	sigprofile "github.com/oteldb/storage/signal/profile"
@@ -82,6 +83,56 @@ func (s *Source) LogKeys(
 	out := make([]storage.KeyInfo, len(keys))
 	for i, k := range keys {
 		out[i] = storage.KeyInfo{Key: []byte(k), Scope: storage.KeyScope(scopes[k])}
+	}
+
+	return out, nil
+}
+
+// ColumnValues implements [storagebackend.Source]. It enumerates one column's (or one attribute
+// key's) distinct values across every shard and unions them: a value can occur in more than one
+// shard, so unlike [Source.series] the shards' answers overlap and are deduplicated.
+//
+// The per-shard Limit is deliberately the caller's, not a share of it. A shard cannot know which of
+// its values survive the union, so splitting the budget would return fewer than Limit values while
+// more existed. The union is truncated once, after sorting, which is where the limit means what the
+// caller asked for.
+func (s *Source) ColumnValues(
+	ctx context.Context, tenant signal.TenantID, req storage.ValuesRequest,
+) ([][]byte, error) {
+	seen := map[string]struct{}{}
+
+	for _, sk := range s.shardKeys(tenant) {
+		got, err := s.rt.Values(ctx, cluster.ValuesRequest{
+			Signal:  req.Signal,
+			Column:  req.Column,
+			AttrKey: req.AttrKey,
+			Start:   req.Start,
+			End:     req.End,
+			Limit:   req.Limit,
+		}, sk)
+		if err != nil {
+			return nil, errors.Wrapf(err, "list %s values of shard %q", req.Signal, sk)
+		}
+
+		for _, v := range got {
+			seen[string(v)] = struct{}{}
+		}
+	}
+
+	values := make([]string, 0, len(seen))
+	for v := range seen {
+		values = append(values, v)
+	}
+
+	sort.Strings(values)
+
+	if req.Limit > 0 && len(values) > req.Limit {
+		values = values[:req.Limit]
+	}
+
+	out := make([][]byte, len(values))
+	for i, v := range values {
+		out[i] = []byte(v)
 	}
 
 	return out, nil

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -556,7 +556,11 @@ func (q *LogQuerier) LabelNames(ctx context.Context, opts logstorage.LabelsOptio
 }
 
 // LabelValues implements [logstorage.Querier]. It returns the distinct values of labelName across
-// the streams matching the options' selector.
+// the streams matching the options' selector, plus — for an unfiltered listing — the values of any
+// record attribute that normalizes to the same label.
+//
+// The record half mirrors [LogQuerier.LabelNames], which advertises those attribute keys: a name it
+// offers whose values endpoint always answers empty is worse than one it never offered.
 func (q *LogQuerier) LabelValues(ctx context.Context, labelName string, opts logstorage.LabelsOptions) (iterators.Iterator[logstorage.Label], error) {
 	values := map[string]struct{}{}
 	if err := q.forEachLogStreamLabel(ctx, opts.Start, opts.End, opts.Query.Matchers, func(name, value string) {
@@ -566,6 +570,13 @@ func (q *LogQuerier) LabelValues(ctx context.Context, labelName string, opts log
 	}); err != nil {
 		return nil, err
 	}
+
+	if len(opts.Query.Matchers) == 0 {
+		if err := q.recordAttrValues(ctx, labelName, opts, values); err != nil {
+			return nil, err
+		}
+	}
+
 	keys := sortedKeys(values)
 	if opts.Limit > 0 && len(keys) > opts.Limit {
 		keys = keys[:opts.Limit]
@@ -575,6 +586,55 @@ func (q *LogQuerier) LabelValues(ctx context.Context, labelName string, opts log
 		labelsOut[i] = logstorage.Label{Name: labelName, Value: v}
 	}
 	return iterators.Slice(labelsOut), nil
+}
+
+// recordAttrValues adds the values of every record attribute whose key normalizes to labelName.
+//
+// The mapping is resolved forwards, not inverted: [otelstorage.KeyToLabel] is lossy (code.function
+// and code_function are the same label), so the keys are enumerated and normalized to find the ones
+// that match, and a label backed by several keys unions them.
+//
+// It is only sound for an unfiltered listing. A stream selector restricts streams, and a record
+// attribute is not part of stream identity, so there is no way to honor the selector here — the same
+// reason [LogQuerier.LabelNames] folds record keys in only when no matcher is set.
+//
+// The values are a superset for the window: a part overlapping it contributes its whole dictionary.
+// That is the enumeration's contract and is harmless for autocomplete.
+func (q *LogQuerier) recordAttrValues(
+	ctx context.Context, labelName string, opts logstorage.LabelsOptions, values map[string]struct{},
+) error {
+	lo, hi := seriesWindow(opts.Start, opts.End)
+
+	keys, err := q.b.src.LogKeys(ctx, q.b.tenant, lo, hi)
+	if err != nil {
+		return errors.Wrap(err, "log keys")
+	}
+
+	for _, ki := range keys {
+		if ki.Scope&storage.KeyScopeRecord == 0 {
+			continue
+		}
+		if otelstorage.KeyToLabel(string(ki.Key)) != labelName {
+			continue
+		}
+
+		got, err := q.b.src.ColumnValues(ctx, q.b.tenant, storage.ValuesRequest{
+			Signal:  signal.Log,
+			AttrKey: ki.Key,
+			Start:   lo,
+			End:     hi,
+			Limit:   opts.Limit,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "values of log attribute %q", ki.Key)
+		}
+
+		for _, v := range got {
+			values[string(v)] = struct{}{}
+		}
+	}
+
+	return nil
 }
 
 // Series implements [logstorage.Querier]. It returns the label sets of the streams matching any of

--- a/internal/storagebackend/signals_test.go
+++ b/internal/storagebackend/signals_test.go
@@ -211,6 +211,81 @@ func TestBackendTraceIntrinsicTagValues(t *testing.T) {
 	})
 }
 
+// TestBackendTraceTagValuesPushdownMatchesScan proves the storage-side enumeration TagValues now
+// uses for the name intrinsic and a span-scoped attribute (see [storagebackend.TraceQuerier.TagValues])
+// returns exactly the values a full window scan (via SearchTags, which still scans) would produce:
+// pushing the lookup down to the column dictionaries must not change the answer.
+func TestBackendTraceTagValuesPushdownMatchesScan(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+	traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	td := ptrace.NewTraces()
+	rs := td.ResourceSpans().AppendEmpty()
+	rs.Resource().Attributes().PutStr("service.name", "api")
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	newSpan := func(id byte, name, method string) {
+		s := ss.Spans().AppendEmpty()
+		s.SetTraceID(traceID)
+		s.SetSpanID(pcommon.SpanID([8]byte{id, id, id, id, id, id, id, id}))
+		s.SetName(name)
+		s.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		s.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
+		s.Attributes().PutStr("http.method", method)
+	}
+	newSpan(1, "GET /", "GET")
+	newSpan(2, "GET /", "GET") // Duplicate name and value, proving both paths dedup.
+	newSpan(3, "db.query", "POST")
+
+	require.NoError(t, b.ConsumeTraces(ctx, td))
+
+	tq := b.Traces()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+
+	spans := drain(t, mustSearchTags(ctx, t, tq, map[string]string{}, start, end))
+	require.Len(t, spans, 3)
+
+	wantNames := map[string]struct{}{}
+	wantMethods := map[string]struct{}{}
+	for _, span := range spans {
+		wantNames[span.Name] = struct{}{}
+		if v, ok := span.Attrs.AsMap().Get("http.method"); ok {
+			wantMethods[v.AsString()] = struct{}{}
+		}
+	}
+
+	tagValues := func(t *testing.T, attr traceql.Attribute) []string {
+		t.Helper()
+		it, err := tq.TagValues(ctx, attr, tracestorage.TagValuesOptions{Start: start, End: end})
+		require.NoError(t, err)
+		tags := drain(t, it)
+		out := make([]string, 0, len(tags))
+		for _, tag := range tags {
+			out = append(out, tag.Value)
+		}
+		return out
+	}
+
+	t.Run("name", func(t *testing.T) {
+		got := tagValues(t, traceql.Attribute{Prop: traceql.SpanName})
+		require.ElementsMatch(t, mapKeys(wantNames), got)
+	})
+	t.Run("span attribute", func(t *testing.T) {
+		got := tagValues(t, traceql.Attribute{Name: "http.method", Scope: traceql.ScopeSpan})
+		require.ElementsMatch(t, mapKeys(wantMethods), got)
+	})
+}
+
+func mapKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 // TestBackendProfilesRoundtrip ingests an OTLP profile through the storage sink and queries the
 // merged flamegraph back through the profiles querier adapter.
 func TestBackendProfilesRoundtrip(t *testing.T) {

--- a/internal/storagebackend/signals_test.go
+++ b/internal/storagebackend/signals_test.go
@@ -2,6 +2,7 @@ package storagebackend_test
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -303,4 +304,63 @@ func mustSearchTags(ctx context.Context, t *testing.T, tq *storagebackend.TraceQ
 	it, err := tq.SearchTags(ctx, tags, tracestorage.SearchTagsOptions{Start: start, End: end})
 	require.NoError(t, err)
 	return it
+}
+
+// TestBackendLogRecordAttributeValues pins the half of autocomplete that used to be missing:
+// LabelNames advertises a record attribute's key, so LabelValues must be able to answer for it.
+// Stream labels always worked; record attributes returned nothing at all.
+func TestBackendLogRecordAttributeValues(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "api")
+	sl := rl.ScopeLogs().AppendEmpty()
+	for _, method := range []string{"GET", "POST", "GET"} {
+		rec := sl.LogRecords().AppendEmpty()
+		rec.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		rec.Body().SetStr("request served")
+		rec.SetSeverityNumber(plog.SeverityNumberInfo)
+		rec.Attributes().PutStr("http.request.method", method)
+	}
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	var (
+		lq          = b.Logs()
+		start, end  = ts.Add(-time.Hour), ts.Add(time.Hour)
+		opts        = logstorage.LabelsOptions{Start: start, End: end}
+		recordLabel = "http_request_method"
+	)
+
+	names, err := lq.LabelNames(ctx, opts)
+	require.NoError(t, err)
+	require.Contains(t, names, recordLabel, "the record attribute is advertised")
+
+	values := drainLabels(ctx, t, lq, recordLabel, opts)
+	require.Equal(t, []string{"GET", "POST"}, values, "advertised name must resolve to its values")
+
+	// The stream label still resolves, and a name nothing carries still yields nothing.
+	require.Equal(t, []string{"api"}, drainLabels(ctx, t, lq, "service_name", opts))
+	require.Empty(t, drainLabels(ctx, t, lq, "nope", opts))
+}
+
+func drainLabels(
+	ctx context.Context, t *testing.T, lq *storagebackend.LogQuerier,
+	name string, opts logstorage.LabelsOptions,
+) []string {
+	t.Helper()
+
+	it, err := lq.LabelValues(ctx, name, opts)
+	require.NoError(t, err)
+
+	var out []string
+	require.NoError(t, iterators.ForEach(it, func(l logstorage.Label) error {
+		out = append(out, l.Value)
+		return nil
+	}))
+	sort.Strings(out)
+
+	return out
 }

--- a/internal/storagebackend/source.go
+++ b/internal/storagebackend/source.go
@@ -43,6 +43,12 @@ type Source interface {
 	// LogKeys enumerates the distinct attribute keys of a tenant's log records in [start, end] ns.
 	LogKeys(ctx context.Context, tenant signal.TenantID, start, end int64) ([]storage.KeyInfo, error)
 
+	// ColumnValues enumerates the distinct values one record column, or one per-record attribute
+	// key, takes for a tenant. It answers from the parts' column dictionaries, so tag/label value
+	// autocomplete costs O(distinct values) instead of a window scan. The result is a superset:
+	// a part overlapping the window contributes its whole dictionary.
+	ColumnValues(ctx context.Context, tenant signal.TenantID, req storage.ValuesRequest) ([][]byte, error)
+
 	// TraceFetcher returns the traces read seam over the named tenants.
 	TraceFetcher(tenants ...signal.TenantID) fetch.Fetcher
 	// Trace returns every span of one trace.

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
+	"github.com/oteldb/storage"
 	"github.com/oteldb/storage/query/fetch"
 	"github.com/oteldb/storage/signal"
 	sigtrace "github.com/oteldb/storage/signal/trace"
@@ -139,6 +140,22 @@ func (q *TraceQuerier) TagNames(ctx context.Context, opts tracestorage.TagNamesO
 // Only the string-ish intrinsics are enumerable: name, status, kind, rootName and rootServiceName.
 // duration, traceDuration and childCount are numeric/unbounded and parent is structural, so — mirroring
 // Tempo and [chstorage.Querier.TagValues] — they yield no autocomplete values.
+//
+// Two shapes are answered from the parts' column dictionaries via [storagebackend.Source.ColumnValues]
+// instead of a full window scan: the name intrinsic ([sigtrace.ColName]) and a span-scoped attribute
+// (attr.Scope == [traceql.ScopeSpan]). Both are O(distinct values); the result is a superset of the
+// window (a part overlapping it contributes its whole dictionary), which the storage doc calls out as
+// fine for autocomplete and this package already relies on elsewhere.
+//
+// Everything else still scans:
+//   - rootName and rootServiceName filter to root spans (empty parent span id), a predicate a column
+//     enumeration cannot express.
+//   - a resource- or instrumentation-scoped attribute lives on the stream identity, not the per-record
+//     attribute blob AttrKey enumerates, and there is no trace-stream enumeration primitive on [Source]
+//     (unlike [LogQuerier], which has LogSeries) to answer it more cheaply.
+//   - ScopeNone must cover every scope, so it needs both the span-scoped and the stream-scoped values;
+//     since only the former is pushable, the whole lookup falls back to the scan rather than silently
+//     dropping resource/instrumentation values.
 func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, opts tracestorage.TagValuesOptions) (iterators.Iterator[tracestorage.Tag], error) {
 	switch attr.Prop {
 	case traceql.SpanStatus:
@@ -147,6 +164,12 @@ func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, op
 		return iterators.Slice(spanKindTags(attr)), nil
 	case traceql.SpanDuration, traceql.SpanChildCount, traceql.SpanParent, traceql.TraceDuration:
 		return iterators.Empty[tracestorage.Tag](), nil
+	case traceql.SpanName:
+		return q.columnTagValues(ctx, attr, sigtrace.ColName, opts)
+	case traceql.SpanAttribute:
+		if attr.Scope == traceql.ScopeSpan {
+			return q.attrTagValues(ctx, attr, opts)
+		}
 	}
 
 	spans, err := q.scanSpans(ctx, opts.Start, opts.End, nil)
@@ -155,7 +178,7 @@ func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, op
 	}
 
 	switch attr.Prop {
-	case traceql.SpanName, traceql.RootSpanName:
+	case traceql.RootSpanName:
 		return iterators.Slice(spanNameTags(attr, spans)), nil
 	case traceql.RootServiceName:
 		return iterators.Slice(rootServiceNameTags(attr, spans)), nil
@@ -177,6 +200,54 @@ func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, op
 	out := make([]tracestorage.Tag, 0, len(seen))
 	for _, tag := range seen {
 		out = append(out, tag)
+	}
+	return iterators.Slice(out), nil
+}
+
+// columnTagValues enumerates a byte column's distinct values via [Source.ColumnValues].
+func (q *TraceQuerier) columnTagValues(
+	ctx context.Context, attr traceql.Attribute, column string, opts tracestorage.TagValuesOptions,
+) (iterators.Iterator[tracestorage.Tag], error) {
+	lo, hi := seriesWindow(opts.Start, opts.End)
+	values, err := q.b.src.ColumnValues(ctx, q.b.tenant, storage.ValuesRequest{
+		Signal: signal.Trace,
+		Column: column,
+		Start:  lo,
+		End:    hi,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "column values")
+	}
+
+	name := attr.String()
+	out := make([]tracestorage.Tag, 0, len(values))
+	for _, v := range values {
+		out = append(out, tracestorage.Tag{Name: name, Value: string(v), Type: traceql.TypeString})
+	}
+	return iterators.Slice(out), nil
+}
+
+// attrTagValues enumerates a span-scoped attribute's distinct values via [Source.ColumnValues]. It
+// must not be called for any other scope: resource and instrumentation attributes are not part of
+// the per-record attribute blob AttrKey enumerates.
+func (q *TraceQuerier) attrTagValues(
+	ctx context.Context, attr traceql.Attribute, opts tracestorage.TagValuesOptions,
+) (iterators.Iterator[tracestorage.Tag], error) {
+	lo, hi := seriesWindow(opts.Start, opts.End)
+	values, err := q.b.src.ColumnValues(ctx, q.b.tenant, storage.ValuesRequest{
+		Signal:  signal.Trace,
+		AttrKey: []byte(attr.Name),
+		Start:   lo,
+		End:     hi,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "column values")
+	}
+
+	name := attr.String()
+	out := make([]tracestorage.Tag, 0, len(values))
+	for _, v := range values {
+		out = append(out, tracestorage.Tag{Name: name, Value: string(v), Type: traceql.TypeString, Scope: traceql.ScopeSpan})
 	}
 	return iterators.Slice(out), nil
 }


### PR DESCRIPTION
Bumps `github.com/oteldb/storage` to v0.42.0 and wires up `Storage.ColumnValues` (oteldb/storage#429), the distinct-value enumeration behind tag/label autocomplete. It answers from the parts' column dictionaries, so a lookup costs O(distinct values) instead of a window scan, and materializes no attributes, events or links.

Closes #1313.

## 1. The seam (`2fa33d33`)

`storagebackend.Source` gains `ColumnValues`; `*storage.Storage` already satisfies it, and `clusterquery.Source` fans it out across a tenant's shards.

Unlike stream enumeration, the shards' answers **overlap** — a value can occur in several shards — so they are unioned and deduplicated rather than concatenated. The per-shard `Limit` is deliberately the caller's full limit, not a share of it: a shard cannot know which of its values survive the union, so splitting the budget would return fewer than `Limit` while more existed. The union is sorted and truncated once, which is where the limit means what the caller asked for.

## 2. Log record attributes (`5541f521`) — the bug

`LabelNames` advertises record attribute keys; `LabelValues` only walked stream labels. So `/loki/api/v1/labels` offered `method`, `endpoint`, `api`, `code_function_name` and every one of them returned `{"data":[]}` — verified on the live cluster, where only `service_name` and `host_name` resolved.

Two things worth reviewing:

- **The key is matched forwards, not inverted.** `otelstorage.KeyToLabel` is lossy — `code.function` and `code_function` normalize to the same label — and has no inverse. So the keys are enumerated and normalized to find the ones matching the requested label, and a label backed by several keys unions them. Inverting would have been a guess.
- **It applies only to an unfiltered listing**, the same guard `LabelNames` already uses. A record attribute is not part of stream identity, so a stream selector cannot soundly restrict it; honoring the selector here would look filtered while being arbitrary.

Reverting just this hunk reproduces the production symptom exactly:

```
expected: []string{"GET", "POST"}
actual  : []string(nil)
```

## 3. TraceQL tag values (`f55cdaf1`) — the pushdown

`TagValues` scanned the whole window for what is usually a few dozen strings. Now pushed down:

| shape | path |
|---|---|
| `name` intrinsic | `Column: sigtrace.ColName` |
| span-scoped attribute | `AttrKey` |
| `rootName`, `rootServiceName` | **still scans** |
| resource / instrumentation / `ScopeNone` attribute | **still scans** |
| `status`, `kind` | static enum, untouched |
| `duration`, `traceDuration`, `childCount`, `parent` | empty, untouched |

The two deliberate non-pushdowns are the interesting part. `rootName`/`rootServiceName` filter to spans with an empty parent span id, a predicate a column enumeration cannot express. And `AttrKey` enumerates only the per-record blob, so a resource-scoped attribute is not in it — which means `ScopeNone`, having to cover every scope, must keep the scan too. Pushing either down would have silently returned **fewer** values than before; correctness wins over speed here.

`TagValuesOptions` has no `Limit` field, so there is nothing to thread through.

## Verification

- `go build ./...`, `golangci-lint run ./internal/...` → 0 issues, `go test ./...` → exit 0.
- `TestBackendLogRecordAttributeValues` — fails with `[]string(nil)` without the fix.
- `TestBackendTraceTagValuesPushdownMatchesScan` — asserts the pushdown returns exactly what a scan does, using `SearchTags` (which still scans) as an independent oracle.
- That equality test alone would pass even if the pushdown silently fell through to the scan, so I also **fault-injected** — corrupting the column and attribute names handed to `ColumnValues` — and confirmed both it and `TestBackendTraceIntrinsicTagValues/name` fail. The new path is genuinely exercised.
- The old `spanNameTags` skipped empty names and `ColumnValues` documents that it omits empty values, so the two agree rather than the pushdown introducing an empty string.

## Note on semantics

`ColumnValues` returns a **superset** for the window: a part overlapping it contributes its whole dictionary, so a value occurring only just outside the window may appear. That is the enumeration's documented contract and is harmless for autocomplete, but it is a real behaviour change from the scan and is called out in the doc comments on both consumers.