### PR TITLE
fix(tempohandler): group trace-by-id spans by resource, not batch id

### DIFF
--- a/internal/storagebackend/traces_resource_test.go
+++ b/internal/storagebackend/traces_resource_test.go
@@ -1,0 +1,79 @@
+package storagebackend_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// TestBackendTraceByIDResource pins that a trace spanning several services keeps each span under
+// its own resource on the by-id read, whether the spans are still in the head, flushed to separate
+// parts, or merged into one — the unbounded-window equality fetch must not collapse stream identity.
+func TestBackendTraceByIDResource(t *testing.T) {
+	for _, mode := range []string{"head", "flushed", "compacted"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			store, err := storage.InMemory()
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = store.Close(ctx) })
+			b := storagebackend.New(store)
+
+			ts := time.Now().Truncate(time.Second)
+			traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+			want := map[string]string{}
+			svcs := []string{"alpha", "beta", "gamma"}
+			for round := range 3 {
+				td := ptrace.NewTraces()
+				for i, svc := range svcs {
+					rs := td.ResourceSpans().AppendEmpty()
+					rs.Resource().Attributes().PutStr("service.name", svc)
+					ss := rs.ScopeSpans().AppendEmpty()
+					for k := range 2 {
+						sp := ss.Spans().AppendEmpty()
+						sp.SetTraceID(traceID)
+						sp.SetSpanID(pcommon.SpanID([8]byte{byte(round + 1), byte(i + 1), byte(k + 1)}))
+						name := fmt.Sprintf("%s.%d.%d", svc, round, k)
+						sp.SetName(name)
+						want[name] = svc
+						at := ts.Add(time.Duration(round*10+i*2+k) * time.Second)
+						sp.SetStartTimestamp(pcommon.Timestamp(at.UnixNano()))
+						sp.SetEndTimestamp(pcommon.Timestamp(at.Add(time.Second).UnixNano()))
+					}
+				}
+				require.NoError(t, b.ConsumeTraces(ctx, td))
+				if mode != "head" {
+					require.NoError(t, store.Admin().Flush(ctx, "default", signal.Trace))
+				}
+			}
+
+			if mode == "compacted" {
+				require.NoError(t, store.Admin().Compact(ctx, "default", signal.Trace))
+			}
+
+			it, err := b.Traces().TraceByID(ctx, otelstorage.TraceID(traceID), tracestorage.TraceByIDOptions{})
+			require.NoError(t, err)
+			got := map[string]string{}
+			var span tracestorage.Span
+			for it.Next(&span) {
+				v, ok := span.ResourceAttrs.AsMap().Get("service.name")
+				require.True(t, ok, "span %s has no service.name", span.Name)
+				got[span.Name] = v.Str()
+			}
+			require.NoError(t, it.Err())
+			require.Equal(t, want, got)
+		})
+	}
+}

--- a/internal/tempohandler/collector.go
+++ b/internal/tempohandler/collector.go
@@ -3,7 +3,6 @@ package tempohandler
 import (
 	"slices"
 
-	"github.com/google/uuid"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
@@ -72,46 +71,54 @@ func (b *metadataCollector) Result() (r []tempoapi.TraceSearchMetadata) {
 }
 
 type spanKey struct {
-	batchID      uuid.UUID
+	resource     otelstorage.Hash
 	scopeName    string
 	scopeVersion string
+	scopeAttrs   otelstorage.Hash
 }
 
 type batchCollector struct {
 	spanCount  int
-	resSpans   map[uuid.UUID]*tracev1.ResourceSpans
+	resOrder   []otelstorage.Hash
+	resSpans   map[otelstorage.Hash]*tracev1.ResourceSpans
 	scopeSpans map[spanKey]*tracev1.ScopeSpans
 }
 
 func (b *batchCollector) init() {
 	if b.resSpans == nil {
-		b.resSpans = make(map[uuid.UUID]*tracev1.ResourceSpans)
+		b.resSpans = make(map[otelstorage.Hash]*tracev1.ResourceSpans)
 	}
 	if b.scopeSpans == nil {
 		b.scopeSpans = make(map[spanKey]*tracev1.ScopeSpans)
 	}
 }
 
+// getScopeSpans returns the batch a span belongs to, grouping by its resource and scope identity.
+// Grouping by anything coarser (the ingest batch id, which not every storage backend even carries)
+// puts spans of different services under one resource, so a multi-service trace renders as one.
 func (b *batchCollector) getScopeSpans(s tracestorage.Span) *tracev1.ScopeSpans {
 	b.init()
 
+	resHash := s.ResourceAttrs.Hash()
 	k := spanKey{
-		batchID:      s.BatchID,
+		resource:     resHash,
 		scopeName:    s.ScopeName,
 		scopeVersion: s.ScopeVersion,
+		scopeAttrs:   s.ScopeAttrs.Hash(),
 	}
 	if ss, ok := b.scopeSpans[k]; ok {
 		return ss
 	}
 
-	resSpan, ok := b.resSpans[s.BatchID]
+	resSpan, ok := b.resSpans[resHash]
 	if !ok {
 		resSpan = &tracev1.ResourceSpans{
 			Resource: &resourcev1.Resource{
 				Attributes: attrsToProto(s.ResourceAttrs),
 			},
 		}
-		b.resSpans[s.BatchID] = resSpan
+		b.resSpans[resHash] = resSpan
+		b.resOrder = append(b.resOrder, resHash)
 	}
 
 	scopeSpan := &tracev1.ScopeSpans{
@@ -140,9 +147,9 @@ func (b *batchCollector) SpanCount() int {
 }
 
 func (b *batchCollector) resourceSpans() []*tracev1.ResourceSpans {
-	result := make([]*tracev1.ResourceSpans, 0, len(b.resSpans))
-	for _, rs := range b.resSpans {
-		result = append(result, rs)
+	result := make([]*tracev1.ResourceSpans, 0, len(b.resOrder))
+	for _, h := range b.resOrder {
+		result = append(result, b.resSpans[h])
 	}
 	return result
 }
@@ -200,10 +207,10 @@ func spanToProto(span tracestorage.Span) *tracev1.Span {
 }
 
 func attrsToProto(attrs otelstorage.Attrs) []*commonv1.KeyValue {
-	m := attrs.AsMap()
-	if m.Len() == 0 {
+	if attrs.Len() == 0 {
 		return nil
 	}
+	m := attrs.AsMap()
 	result := make([]*commonv1.KeyValue, 0, m.Len())
 	m.Range(func(k string, v pcommon.Value) bool {
 		result = append(result, &commonv1.KeyValue{

--- a/internal/tempohandler/collector_test.go
+++ b/internal/tempohandler/collector_test.go
@@ -1,0 +1,61 @@
+package tempohandler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/oteldb/internal/otelstorage"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+func spanOfService(name, service string) tracestorage.Span {
+	attrs := otelstorage.NewAttrs()
+	attrs.AsMap().PutStr("service.name", service)
+
+	return tracestorage.Span{
+		Name:          name,
+		Attrs:         otelstorage.NewAttrs(),
+		ResourceAttrs: attrs,
+		ScopeName:     "oteldb",
+		ScopeAttrs:    otelstorage.NewAttrs(),
+	}
+}
+
+// TestBatchCollectorGroupsByResource pins that a trace's spans keep their own resource. The
+// collector used to group by the ingest batch id, which only the ClickHouse backend fills in, so
+// every span of a multi-service trace collapsed onto whichever resource was collected first.
+func TestBatchCollectorGroupsByResource(t *testing.T) {
+	var c batchCollector
+	for _, span := range []tracestorage.Span{
+		spanOfService("frontend.request", "frontend"),
+		spanOfService("cart.get", "cart"),
+		spanOfService("frontend.render", "frontend"),
+	} {
+		require.NoError(t, c.AddSpan(span))
+	}
+
+	got := map[string]string{}
+	for _, rs := range c.resourceSpans() {
+		var service string
+		for _, kv := range rs.GetResource().GetAttributes() {
+			if kv.GetKey() == "service.name" {
+				service = kv.GetValue().GetStringValue()
+			}
+		}
+
+		for _, ss := range rs.GetScopeSpans() {
+			for _, s := range ss.GetSpans() {
+				got[s.GetName()] = service
+			}
+		}
+	}
+
+	require.Equal(t, map[string]string{
+		"frontend.request": "frontend",
+		"cart.get":         "cart",
+		"frontend.render":  "frontend",
+	}, got)
+	require.Len(t, c.resourceSpans(), 2)
+	require.Equal(t, 3, c.SpanCount())
+}


### PR DESCRIPTION
Fixes #1316.

`batchCollector.getScopeSpans` grouped `ResourceSpans` by `span.BatchID`, but `BatchID` is only
populated by chstorage (`columns_traces.go:189`, `restore_traces.go:142`). `storagebackend`'s
`materializeSpans` never sets it, so every span carried the zero UUID and collapsed into a single
`ResourceSpans` that took whichever resource arrived first — the reported "resources=1, spans=11,
all odbselect".

Search was unaffected because it goes through `metadataCollector`, which reads each span's own
resource. That is why the same span ids answered differently depending on the read path.

Now keyed on resource and scope identity (`ResourceAttrs.Hash()`, scope name/version/attrs), with an
order slice so `resourceSpans()` is deterministic rather than map-ordered. `TraceByIDv2` shares the
collector and was equally affected.

The key is strictly finer-grained than the old one for chstorage as well: identical resources from
different ingest batches now merge into one `ResourceSpans`, which is what OTLP means.

`attrsToProto` now uses `attrs.Len()` instead of `attrs.AsMap().Len()`, which panics on a zero `Attrs`.

## Tests

- `internal/tempohandler/collector_test.go` — `TestBatchCollectorGroupsByResource`. Reverted, it
  reproduces the symptom: `cart.get` comes back attributed to `frontend`.
- `internal/storagebackend/traces_resource_test.go` — `TestBackendTraceByIDResource` reads one trace
  spanning three `service.name` resources via `TraceByID`, in head / separate parts / compacted-merge.
  It passed before this change too; it is here to pin down that the engine's unbounded-window equality
  fetch does not collapse stream identity, which was the original suspicion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)