### PR TITLE
chore(dev/storage-cluster): enable drilldown on odbselect, bump Grafana to 13

### DIFF
--- a/dev/local/storage-cluster/docker-compose.yml
+++ b/dev/local/storage-cluster/docker-compose.yml
@@ -169,7 +169,7 @@ services:
       - oteldb-1
 
   grafana:
-    image: "grafana/grafana-oss:12.3.1"
+    image: "grafana/grafana-oss:13.0.2"
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin

--- a/dev/local/storage-cluster/odbselect.yml
+++ b/dev/local/storage-cluster/odbselect.yml
@@ -9,3 +9,8 @@ cluster:
   etcd: ["http://etcd:2379"]
   rf: 2
   root: /oteldb
+
+# Logs Drilldown: index/volume, detected_labels and detected_fields answer for real rather than
+# returning the gated empties Grafana reads as "nothing here".
+loki:
+  drilldown_enabled: true


### PR DESCRIPTION
Two reasons Logs Drilldown did not work against the dev cluster.

**odbselect never got `loki.drilldown_enabled`** that its embedded twin has. With the flag off,
`lokihandler` answers success-shaped empties rather than 404s — `QueryVolume`/`QueryVolumeRange`
return an empty vector, `DetectedLabels` returns `{}` — so Grafana sees a healthy store with nothing
in it. Confirmed on the live stack:

```
oteldb-1  /drilldown-limits → {"limits":{"volume_enabled":true}}
odbselect /drilldown-limits → {"limits":{"volume_enabled":false}}
```

**Grafana 12.3.1 sent Drilldown's resource calls to a doubled prefix**, `/loki/api/v1/loki/api/v1/…`,
which nothing answers:

```
statusCode=404 resourcePath="/loki/api/v1/loki/api/v1/index/volume?…"
```

Same for `detected_labels`, `detected_fields` and `patterns`. Bumped to 13.0.2.

## Not fixed here

`/loki/api/v1/patterns` is a hard stub (`lokihandler.go:605`) returning bare `{}` regardless of its
arguments, so the Patterns tab stays empty. `DetectedFields` on `storagebackend` is a documented
no-op — the backend does not parse record fields — so field-level drilldown is thinner there than on
chstorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)