### PR TITLE
build(deps): bump github.com/oteldb/storage to main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.159.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.42.0
+	github.com/oteldb/storage v0.42.1-0.20260830154456-8fbc4a8d372a
 	github.com/pierrec/lz4/v4 v4.1.29
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1

--- a/go.sum
+++ b/go.sum
@@ -1031,8 +1031,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.42.0 h1:CTX60BFRR6kiC/+u3mW3GQJdrFx4KxMb38PVuFUBriw=
-github.com/oteldb/storage v0.42.0/go.mod h1:QG9F3+Wsc7QQC55ckoIMKIYyfeupMDWVVFmFm0QK9WQ=
+github.com/oteldb/storage v0.42.1-0.20260830154456-8fbc4a8d372a h1:HR6J03rfRQUWmichTtjVDoUFSVFPvRe+zTqa4OurLIk=
+github.com/oteldb/storage v0.42.1-0.20260830154456-8fbc4a8d372a/go.mod h1:QG9F3+Wsc7QQC55ckoIMKIYyfeupMDWVVFmFm0QK9WQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=


### PR DESCRIPTION
Untagged pseudo-version (`v0.42.1-0.20260830154456-8fbc4a8d372a`), deliberately — both changes are
wanted before the next storage release.

- **#433** — a node holding a shard without its unflushed head now fails over instead of answering
  its own caller with `ErrShardAbsent`. That is the 500 Grafana's Logs Drilldown got from
  `detected_labels` after a restart.
- **#434** — `storage.head.*` gauges (bytes/items/series/identity_bytes/age), merge byte accounting
  for write amplification, and a `result` attribute on `storage.rpc.attempts`.

`go build ./...`, `go mod tidy`, and the `storagebackend` + `clusterquery` suites pass.

The new instruments are not charted yet — the dashboard rows for head size and RPC error rate are
follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)