### PR TITLE
build(dev): ship the admin SPA in the image and publish its port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,10 @@ Dockerfile
 
 # remore write queries
 *.rwq
+
+# The admin SPA is built by the bun stage in dev/Dockerfile; keeping a stale local build out of
+# the context makes the image the same whether or not the host ever ran `bun run build`. The
+# .gitkeep placeholder stays so the frontend-skip stage has something to supply.
+internal/adminhandler/frontend/node_modules
+internal/adminhandler/frontend/dist
+!internal/adminhandler/frontend/dist/.gitkeep

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,5 +1,27 @@
 ARG GO_VERSION=latest
 ARG BASE_IMAGE=alpine:latest
+ARG BUN_IMAGE=oven/bun:1-alpine
+
+# Selects which of the frontend-* stages provides internal/adminhandler/frontend/dist:
+# `build` runs the real bun build, `skip` supplies the tracked .gitkeep placeholder so the
+# go:embed directive still compiles without a bun toolchain or a network fetch of npm deps.
+ARG FRONTEND=build
+
+# Builds the admin SPA the same way .github/workflows/frontend.yml does, so a clean checkout
+# embeds a real UI instead of the "not built" placeholder page.
+FROM ${BUN_IMAGE} AS frontend-build
+WORKDIR /frontend
+COPY internal/adminhandler/frontend/package.json internal/adminhandler/frontend/bun.lock ./
+RUN bun install --frozen-lockfile
+# orval generates the typed client from the same spec the ogen server is generated from.
+COPY _oas/admin.yml /_oas/admin.yml
+COPY internal/adminhandler/frontend/ ./
+RUN bun run build
+
+FROM scratch AS frontend-skip
+COPY internal/adminhandler/frontend/dist/.gitkeep /frontend/dist/.gitkeep
+
+FROM frontend-${FRONTEND} AS frontend
 
 FROM golang:${GO_VERSION} AS builder
 ARG GOPROXY=https://proxy.golang.org,direct
@@ -12,6 +34,8 @@ ENV GOPROXY=${GOPROXY}
 RUN go mod download
 
 COPY .. ./
+# After the context copy, so the built SPA wins over any dist/ that leaked in from the host.
+COPY --from=frontend /frontend/dist/ ./internal/adminhandler/frontend/dist/
 RUN set -e; mkdir /out && \
     for target in $TARGETS; do \
       CGO_ENABLED=0 GOOS=linux go build -trimpath -buildvcs=false -o /out/$target ./cmd/$target; \

--- a/dev/local/ch-demo/docker-compose.yml
+++ b/dev/local/ch-demo/docker-compose.yml
@@ -101,6 +101,8 @@ services:
       - OTEL_METRIC_EXPORT_INTERVAL=5000
     command:
       - --config=/etc/oteldb/cfg.yml
+    ports:
+      - "8090:8090" # admin panel (single node, so one port is the whole picture)
     volumes:
       - ./oteldb.yml:/etc/oteldb/cfg.yml:ro
       - ./server.crt:/etc/oteldb/server.crt:ro

--- a/dev/local/storage-cluster/docker-compose.shared-store.yml
+++ b/dev/local/storage-cluster/docker-compose.shared-store.yml
@@ -49,6 +49,16 @@ services:
 
   # go-faster/fs in its single-node filesystem mode: one process, no etcd, no planes. Anonymous
   # auth is fine here because nothing outside the compose network can reach it.
+  #
+  # No counterpart to MinIO's console on 9001, deliberately. v0.13.1 does ship an admin dashboard,
+  # but it is not an object browser: _oas/admin.yml exposes info, access keys, cluster status and
+  # bucket *usage counters* -- nothing lists or fetches an object, so it cannot show the parts the
+  # cluster writes. It is also config-only (`admin.enabled`/`admin.addr`; no flag on `s3`), refuses
+  # to start alongside --insecure-no-auth, and needs a bearer token -- and in filesystem mode its
+  # one bucket page answers 501 "bucket usage accounting is not available on this admin listener",
+  # since the usage index lives in the cluster control plane. Trading this service's anonymous
+  # simplicity for a dashboard of version and uptime is not worth it; browse the parts with `mc`,
+  # or run --profile minio.
   fs:
     image: ghcr.io/go-faster/fs:v0.13.1
     profiles: ["fs"]
@@ -56,7 +66,7 @@ services:
     volumes:
       - objectstore-data:/data
     ports:
-      - "9000:9000"
+      - "9000:9000" # S3 API
     networks:
       default:
         aliases: [objectstore]

--- a/dev/local/storage-cluster/docker-compose.yml
+++ b/dev/local/storage-cluster/docker-compose.yml
@@ -95,6 +95,11 @@ services:
       - "3200:3200" # Tempo / TraceQL
       - "4040:4040" # Pyroscope / ProfileQL
       - "4317:4317" # OTLP gRPC ingestion
+      # The admin panel is per-node: it reports this process's own heap, goroutines, shards and
+      # ingest counters, not the ring's. All three are published (8090/18090/28090, as PromQL gets
+      # 9090/9091/9092) so a single published port cannot be mistaken for a cluster-wide view.
+      # TODO: cmd/odbadmin will serve one cluster-aggregated panel; add it here once it exists.
+      - "8090:8090" # this node's admin panel
 
   oteldb-2:
     <<: *oteldb-node
@@ -105,6 +110,7 @@ services:
     ports:
       - "9091:9090"  # this node's PromQL (to show any node answers the full query)
       - "14317:4317" # this node's OTLP gRPC (host-side ingest target for cmd/cluster-verify)
+      - "18090:8090" # this node's admin panel
 
   oteldb-3:
     <<: *oteldb-node
@@ -114,6 +120,7 @@ services:
       - oteldb-3-data:/data
     ports:
       - "9092:9090"
+      - "28090:8090" # this node's admin panel
 
   # Handles requests from the client; ingests its telemetry at oteldb-2.
   server:

--- a/internal/adminhandler/frontend/.gitignore
+++ b/internal/adminhandler/frontend/.gitignore
@@ -1,5 +1,6 @@
 node_modules
-# dist is committed so `go build` can embed the SPA without a bun toolchain.
-# Remove this comment block if you switch to a build-time generation step.
+# dist is NOT committed: it is built by CI, by the bun stage in dev/Dockerfile, and on
+# release. Only the .gitkeep placeholder is tracked, so `go:embed all:frontend/dist` compiles
+# on a clean checkout.
 *.tsbuildinfo
 .vite

--- a/internal/adminhandler/frontend/README.md
+++ b/internal/adminhandler/frontend/README.md
@@ -72,9 +72,10 @@ lock-step.
 bun run build          # orval + tsc + vite build → dist/
 ```
 
-`dist/` is committed so the Go build embeds the UI without needing a Bun
-toolchain. After a UI change: `bun run build`, then rebuild the binary
-(`go build -o ./oteldb ./cmd/oteldb`).
+`dist/` is not committed: CI builds it, and so does the bun stage in
+`dev/Dockerfile`. For a local `go build`, run `bun run build` yourself first,
+then rebuild the binary (`go build -o ./oteldb ./cmd/oteldb`) — otherwise the
+binary embeds the placeholder and serves the "not built" notice.
 
 ## Requests
 


### PR DESCRIPTION
Three related build/compose changes, one commit each.

## The admin UI never actually shipped

`internal/adminhandler/ui.go` does `//go:embed all:frontend/dist`, but `dist/` is not committed
(only `.gitkeep` is tracked) and `dev/Dockerfile` only ran `go build`. So a clean checkout embedded
a placeholder; it worked locally only if someone had run `bun run build` first.

A `frontend-build` stage on `oven/bun:1-alpine` now runs the same sequence as
`.github/workflows/frontend.yml`, and the Go stage copies `dist/` in **after** `COPY .. ./` so the
built SPA wins over anything in the context. `.dockerignore` additionally excludes a host
`internal/adminhandler/frontend/dist` — that leak was the trap, since a stale local build could
silently win and the result depended on the machine.

`--build-arg FRONTEND=skip` keeps a Go-only/offline build possible, resolved via
`FROM frontend-${FRONTEND}` with a `scratch` stage supplying the tracked `.gitkeep`. Worth knowing
when reviewing: a build with `skip` produces a binary whose admin UI is the placeholder, with no
runtime signal saying why.

Verified by building: `--target frontend` produces a real bundle, the default build embeds
`frontend/dist/assets/index-*.js` (checked with `strings` on the binary), and `FRONTEND=skip` still
builds.

Also fixed two stale comments claiming "dist is committed" (`frontend/.gitignore`, `frontend/README.md`)
which contradicted the root `.gitignore` and `ui.go`.

## The admin port was not published anywhere

Nothing in `dev/local/*` mapped `:8090`. Now `8090`/`18090`/`28090` on the three storage-cluster
nodes — the panel is **per-node** (own heap, goroutines, shards; not the ring's), so publishing one
would show a single replica's view and mislead. Mirrors the existing 9090/9091/9092 PromQL
convention. `ch-demo` gets a single `8090`.

A `TODO` marks where a cluster-aggregated panel would go once `cmd/odbadmin` exists (in progress
separately) — no service wired for a binary that is not on this branch.

All four compose combinations pass `docker compose config -q`.

## go-faster/fs gets no console port, deliberately

The `fs` profile in `docker-compose.shared-store.yml` has no browser UI while its MinIO sibling
publishes a console on 9001. Investigated whether to match it; the answer is no, recorded as a
comment on the service:

- v0.13.1 *does* ship an embedded admin dashboard, but its `_oas/admin.yml` has **no object
  list/download/upload path at all** — so it cannot show the parts the cluster writes, which is the
  entire point of the MinIO console line.
- The listener is config-only (`admin.enabled`/`admin.addr`), not reachable from any `s3` flag.
- It is mutually exclusive with `--insecure-no-auth` ("admin API requires authentication"), so
  enabling it converts a deliberately anonymous single-process store into an authed one with a
  mounted config and a bearer token.
- Its one bucket-ish page returns 501 in filesystem mode — usage accounting lives in the cluster
  control plane (`internal/adminhandler/usage.go:82`).

Net trade would be a version/uptime/access-key page in exchange for auth config. Say so if you'd
rather have it anyway.

## Not addressed

CI's `cluster-e2e.yml` sets `CLUSTER_DOCKERFILE=./dev/deploy/deploy.Dockerfile`, which only copies
host-built binaries and so still bypasses the bun stage. That path is a functional E2E rather than a
UI one, so it was left alone.

Unrelated incidental finding: `mc pipe` against fs v0.13.1 fails with a Content-MD5 mismatch
(`mc mb`/`mc alias set` are fine). Not caused by anything here, but relevant to anyone scripting
against the `fs` profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)