### PR TITLE
refactor: replace sort with slices/cmp across non-generated packages

### DIFF
--- a/cmd/odbadmin/app.go
+++ b/cmd/odbadmin/app.go
@@ -63,7 +63,12 @@ func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *sdkapp.Telemetry
 
 // setupAdmin wires the aggregating admin API and the embedded web UI.
 func (a *App) setupAdmin(m *sdkapp.Telemetry) error {
-	peers, err := clusteradmin.NewRingPeers(a.router, a.cfg.Nodes.Scheme, a.cfg.Nodes.Port)
+	peers, err := clusteradmin.NewRingPeers(clusteradmin.RingPeersOptions{
+		Members:        a.router,
+		Scheme:         a.cfg.Nodes.Scheme,
+		Port:           a.cfg.Nodes.Port,
+		TracerProvider: m.TracerProvider(),
+	})
 	if err != nil {
 		return errors.Wrap(err, "resolve node admin endpoints")
 	}
@@ -81,6 +86,7 @@ func (a *App) setupAdmin(m *sdkapp.Telemetry) error {
 		ReplicationFactor: a.cfg.Cluster.RF,
 		Timeout:           a.cfg.Nodes.Timeout,
 		Logger:            a.lg.Named("clusteradmin"),
+		TracerProvider:    m.TracerProvider(),
 	})
 	if err != nil {
 		return errors.Wrap(err, "create cluster admin handler")

--- a/cmd/otelbench/logs_report.go
+++ b/cmd/otelbench/logs_report.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -191,8 +191,8 @@ func summarizeLogQLQueries(queries []logqlbench.LogQLReportQuery) []logQLSummary
 			ReadRows:  readRows,
 		})
 	}
-	sort.Slice(rows, func(i, j int) bool {
-		return rows[i].Type+rows[i].Title < rows[j].Type+rows[j].Title
+	slices.SortFunc(rows, func(a, b logQLSummaryRow) int {
+		return cmp.Compare(a.Type+a.Title, b.Type+b.Title)
 	})
 	return rows
 }

--- a/cmd/oteldb/admin.go
+++ b/cmd/oteldb/admin.go
@@ -28,6 +28,7 @@ func (app *App) setupAdmin() error {
 		ClickHouseEnabled: app.chClient != nil,
 		Signals:           app.adminSignals(),
 		Components:        app.adminComponents(),
+		TracerProvider:    app.telemetry.TracerProvider(),
 	}
 	if b := app.storageBackend; b != nil {
 		opts.Engine = b

--- a/integration/ch2storagebackende2e/migrate_otlp_test.go
+++ b/integration/ch2storagebackende2e/migrate_otlp_test.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"net"
 	"net/http/httptest"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -131,7 +131,7 @@ func queryLogBodies(t *testing.T, back *storagebackend.Backend, base time.Time) 
 			bodies = append(bodies, v.V)
 		}
 	}
-	sort.Strings(bodies)
+	slices.Sort(bodies)
 
 	return bodies
 }

--- a/integration/prome2e/bench_nodeexporter_test.go
+++ b/integration/prome2e/bench_nodeexporter_test.go
@@ -1,11 +1,12 @@
 package prome2e_test
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"math"
 	"math/rand"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -153,7 +154,7 @@ func genNodeExporter(end time.Time) []prompb.TimeSeries {
 	add := func(name string, base []prompb.Label, extra []prompb.Label, kind neKind, rate, baseVal, amp float64) {
 		labels := append([]prompb.Label{neLabel("__name__", name)}, base...)
 		labels = append(labels, extra...)
-		sort.Slice(labels, func(i, j int) bool { return string(labels[i].Name) < string(labels[j].Name) })
+		slices.SortFunc(labels, func(a, b prompb.Label) int { return cmp.Compare(string(a.Name), string(b.Name)) })
 		out = append(out, prompb.TimeSeries{
 			Labels:  labels,
 			Samples: neSamples(stamps, stepSec, kind, rate, baseVal, amp, rng),

--- a/integration/tempoe2e/storage_test.go
+++ b/integration/tempoe2e/storage_test.go
@@ -3,7 +3,7 @@ package tempoe2e_test
 import (
 	"context"
 	"io"
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,6 +110,6 @@ func apiTraceIDs(traces []tempoapi.TraceSearchMetadata) []string {
 	for _, tr := range traces {
 		ids = append(ids, tr.TraceID)
 	}
-	sort.Strings(ids)
+	slices.Sort(ids)
 	return ids
 }

--- a/internal/adminhandler/adminhandler.go
+++ b/internal/adminhandler/adminhandler.go
@@ -10,6 +10,10 @@ import (
 	"time"
 
 	"github.com/go-faster/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/oteldb/storage"
 	"github.com/oteldb/storage/signal"
@@ -53,6 +57,9 @@ type Options struct {
 	// CHStorage collects deprecated ClickHouse storage statistics. Nil when no signal is served from
 	// ClickHouse.
 	CHStorage StorageStatsCollector
+	// TracerProvider provides the OpenTelemetry tracer for the backend work behind a request. Nil
+	// selects the global provider, which is a noop unless the process configures one.
+	TracerProvider trace.TracerProvider
 }
 
 // EngineStatsProvider exposes embedded-storage engine statistics: the in-memory Inspect snapshot,
@@ -81,14 +88,22 @@ type StorageStatsCollector interface {
 
 // AdminAPI implements adminapi.Handler.
 type AdminAPI struct {
-	opts Options
+	opts   Options
+	tracer trace.Tracer
 }
 
 var _ adminapi.Handler = (*AdminAPI)(nil)
 
 // NewAdminAPI creates a new admin API handler.
 func NewAdminAPI(opts Options) *AdminAPI {
-	return &AdminAPI{opts: opts}
+	if opts.TracerProvider == nil {
+		opts.TracerProvider = otel.GetTracerProvider()
+	}
+
+	return &AdminAPI{
+		opts:   opts,
+		tracer: opts.TracerProvider.Tracer("adminhandler.AdminAPI"),
+	}
 }
 
 // GetInfo implements getInfo operation.
@@ -173,17 +188,51 @@ func (a *AdminAPI) GetStorage(ctx context.Context) (*adminapi.StorageStats, erro
 		stats.Engine = adminapi.NewOptEngineStats(mapEngineStats(a.opts.Engine.Inspect()))
 	}
 	if a.opts.CHStorage != nil {
-		tables, err := a.opts.CHStorage.CollectStorageStats(ctx)
+		tables, err := a.collectCHStats(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "collect clickhouse storage stats")
+			return nil, err
 		}
 		stats.Clickhouse = adminapi.NewOptClickHouseStats(adminapi.ClickHouseStats{Tables: tables})
 	}
 	return stats, nil
 }
 
+// collectCHStats reads the deprecated ClickHouse storage's per-table stats, which is a query against
+// system.parts and the one part of a storage report that leaves the process.
+func (a *AdminAPI) collectCHStats(ctx context.Context) (_ []adminapi.TableStats, rerr error) {
+	ctx, span := a.tracer.Start(ctx, "adminhandler.storage.clickhouse")
+	defer func() {
+		if rerr != nil {
+			span.RecordError(rerr)
+			span.SetStatus(codes.Error, rerr.Error())
+		}
+		span.End()
+	}()
+
+	tables, err := a.opts.CHStorage.CollectStorageStats(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "collect clickhouse storage stats")
+	}
+	span.SetAttributes(attribute.Int("adminhandler.tables", len(tables)))
+
+	return tables, nil
+}
+
 // GetEfficiency implements getEfficiency operation.
-func (a *AdminAPI) GetEfficiency(ctx context.Context, params adminapi.GetEfficiencyParams) (*adminapi.EfficiencyStats, error) {
+func (a *AdminAPI) GetEfficiency(
+	ctx context.Context, params adminapi.GetEfficiencyParams,
+) (_ *adminapi.EfficiencyStats, rerr error) {
+	ctx, span := a.tracer.Start(ctx, "adminhandler.efficiency",
+		trace.WithAttributes(attribute.Bool("adminhandler.parts", params.Parts.Or(false))),
+	)
+	defer func() {
+		if rerr != nil {
+			span.RecordError(rerr)
+			span.SetStatus(codes.Error, rerr.Error())
+		}
+		span.End()
+	}()
+
 	stats := &adminapi.EfficiencyStats{
 		StorageEnabled: a.opts.Engine != nil,
 		Tenants:        []adminapi.TenantEfficiency{},
@@ -195,6 +244,8 @@ func (a *AdminAPI) GetEfficiency(ctx context.Context, params adminapi.GetEfficie
 	if err != nil {
 		return nil, errors.Wrap(err, "collect efficiency stats")
 	}
+	span.SetAttributes(attribute.Int("adminhandler.tenants", len(tenants)))
+
 	for _, t := range tenants {
 		te := mapTenantEfficiency(t)
 		if params.Parts.Or(false) {
@@ -210,7 +261,21 @@ func (a *AdminAPI) GetEfficiency(ctx context.Context, params adminapi.GetEfficie
 // attachParts lists the parts behind each of a tenant's signals. It is a second pass over the
 // backend rather than a by-product of the efficiency walk, which the storage library aggregates
 // before returning, so the two snapshots can disagree by a merge or a flush.
-func (a *AdminAPI) attachParts(ctx context.Context, tenant signal.TenantID, te *adminapi.TenantEfficiency) error {
+func (a *AdminAPI) attachParts(
+	ctx context.Context, tenant signal.TenantID, te *adminapi.TenantEfficiency,
+) (rerr error) {
+	ctx, span := a.tracer.Start(ctx, "adminhandler.efficiency.attachParts",
+		trace.WithAttributes(attribute.String("adminhandler.tenant", string(tenant))),
+	)
+	defer func() {
+		if rerr != nil {
+			span.RecordError(rerr)
+			span.SetStatus(codes.Error, rerr.Error())
+		}
+		span.End()
+	}()
+
+	var total int
 	for i := range te.Signals {
 		sig, err := engineSignal(te.Signals[i].Signal)
 		if err != nil {
@@ -220,8 +285,14 @@ func (a *AdminAPI) attachParts(ctx context.Context, tenant signal.TenantID, te *
 		if err != nil {
 			return errors.Wrapf(err, "list %s/%s parts", tenant, sig)
 		}
+		total += len(parts)
 		te.Signals[i].PartsDetail = mapParts(parts)
 	}
+	span.SetAttributes(
+		attribute.Int("adminhandler.signals", len(te.Signals)),
+		attribute.Int("adminhandler.parts_listed", total),
+	)
+
 	return nil
 }
 

--- a/internal/adminhandler/trace_test.go
+++ b/internal/adminhandler/trace_test.go
@@ -1,0 +1,60 @@
+package adminhandler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/adminapi"
+)
+
+// TestEfficiencySpans pins that the backend work behind an efficiency report is traced, and that
+// the part listing is a span of its own: it is a second pass over the backend, so the request's
+// time splits between the two rather than being one opaque handler span.
+func TestEfficiencySpans(t *testing.T) {
+	rec := tracetest.NewSpanRecorder()
+	eng := &fakeEngine{
+		efficiency: []storage.TenantEfficiency{{
+			Tenant:  signal.TenantID("default"),
+			Signals: []storage.SignalEfficiency{{Signal: signal.Metric, Parts: 2}},
+		}},
+		parts: []storage.PartDetail{
+			{PartInfo: storage.PartInfo{ID: "default/metrics/a", Series: 3, Rows: 10}, Bytes: 100},
+			{PartInfo: storage.PartInfo{ID: "default/metrics/b", Series: 4, Rows: 20}, Bytes: 200},
+		},
+	}
+
+	api := NewAdminAPI(Options{
+		Engine:         eng,
+		TracerProvider: sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec)),
+	})
+
+	_, err := api.GetEfficiency(t.Context(), adminapi.GetEfficiencyParams{Parts: adminapi.NewOptBool(true)})
+	require.NoError(t, err)
+
+	var root, parts tracetest.SpanStub
+	for _, s := range tracetest.SpanStubsFromReadOnlySpans(rec.Ended()) {
+		switch s.Name {
+		case "adminhandler.efficiency":
+			root = s
+		case "adminhandler.efficiency.attachParts":
+			parts = s
+		}
+	}
+
+	require.Equal(t, "adminhandler.efficiency", root.Name)
+	assert.Contains(t, root.Attributes, attribute.Bool("adminhandler.parts", true))
+	assert.Contains(t, root.Attributes, attribute.Int("adminhandler.tenants", 1))
+
+	require.Equal(t, "adminhandler.efficiency.attachParts", parts.Name)
+	assert.Equal(t, root.SpanContext.SpanID(), parts.Parent.SpanID())
+	assert.Contains(t, parts.Attributes, attribute.String("adminhandler.tenant", "default"))
+	assert.Contains(t, parts.Attributes, attribute.Int("adminhandler.parts_listed", 2))
+}

--- a/internal/chembed/config.go
+++ b/internal/chembed/config.go
@@ -2,7 +2,7 @@ package chembed
 
 import (
 	"encoding/xml"
-	"sort"
+	"slices"
 
 	"github.com/go-faster/errors"
 )
@@ -44,7 +44,7 @@ func (c Clusters) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	for k := range c {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	if err := e.EncodeToken(start); err != nil {
 		return errors.Wrap(err, "secret end")
@@ -76,7 +76,7 @@ func (m Map) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	if err := e.EncodeToken(start); err != nil {
 		return errors.Wrap(err, "end")

--- a/internal/clusteradmin/aggregate_test.go
+++ b/internal/clusteradmin/aggregate_test.go
@@ -216,11 +216,15 @@ func (m fakeMembership) Members() []etcd.Member { return m }
 func TestRingPeersEndpoints(t *testing.T) {
 	t.Parallel()
 
-	peers, err := NewRingPeers(fakeMembership{
-		{ID: "oteldb-1", Addr: "oteldb-1:7946"},
-		{ID: "oteldb-2", Addr: "10.20.0.5:7946"},
-		{ID: "oteldb-3"},
-	}, "http", 8090)
+	peers, err := NewRingPeers(RingPeersOptions{
+		Members: fakeMembership{
+			{ID: "oteldb-1", Addr: "oteldb-1:7946"},
+			{ID: "oteldb-2", Addr: "10.20.0.5:7946"},
+			{ID: "oteldb-3"},
+		},
+		Scheme: "http",
+		Port:   8090,
+	})
 	require.NoError(t, err)
 
 	got, err := peers.Peers()
@@ -238,7 +242,7 @@ func TestRingPeersReusesClients(t *testing.T) {
 	t.Parallel()
 
 	members := fakeMembership{{ID: "oteldb-1", Addr: "oteldb-1:7946"}}
-	peers, err := NewRingPeers(members, "http", 8090)
+	peers, err := NewRingPeers(RingPeersOptions{Members: members, Scheme: "http", Port: 8090})
 	require.NoError(t, err)
 
 	first, err := peers.Peers()
@@ -269,7 +273,9 @@ func TestRingPeersRejectsBadConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := NewRingPeers(fakeMembership{}, tt.scheme, tt.port)
+			_, err := NewRingPeers(RingPeersOptions{
+				Members: fakeMembership{}, Scheme: tt.scheme, Port: tt.port,
+			})
 			require.Error(t, err)
 		})
 	}

--- a/internal/clusteradmin/cluster_storage.go
+++ b/internal/clusteradmin/cluster_storage.go
@@ -1,8 +1,9 @@
 package clusteradmin
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
 )
@@ -129,12 +130,8 @@ func (s *storageAggregate) lookup(k signalKey) *signalAggregate {
 // tenants renders the accumulated state, sorted by tenant then signal so a dashboard polling it
 // does not see rows move between refreshes.
 func (s *storageAggregate) tenants() []adminapi.ClusterTenantStorage {
-	sort.Slice(s.order, func(i, j int) bool {
-		if s.order[i].tenant != s.order[j].tenant {
-			return s.order[i].tenant < s.order[j].tenant
-		}
-
-		return s.order[i].signal < s.order[j].signal
+	slices.SortFunc(s.order, func(a, b signalKey) int {
+		return cmp.Or(cmp.Compare(a.tenant, b.tenant), cmp.Compare(a.signal, b.signal))
 	})
 
 	out := []adminapi.ClusterTenantStorage{}

--- a/internal/clusteradmin/clusteradmin.go
+++ b/internal/clusteradmin/clusteradmin.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/go-faster/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
@@ -69,11 +71,15 @@ type Options struct {
 	Timeout time.Duration
 	// Logger records per-node failures, which the response reports but does not explain.
 	Logger *zap.Logger
+	// TracerProvider provides the OpenTelemetry tracer for the fan-out. Nil selects the global
+	// provider, which is a noop unless the process configures one.
+	TracerProvider trace.TracerProvider
 }
 
 // Aggregator implements adminapi.Handler over a cluster's member nodes.
 type Aggregator struct {
-	opts Options
+	opts   Options
+	tracer trace.Tracer
 }
 
 var _ adminapi.Handler = (*Aggregator)(nil)
@@ -95,8 +101,14 @@ func New(opts Options) (*Aggregator, error) {
 	if opts.StartTime.IsZero() {
 		opts.StartTime = time.Now()
 	}
+	if opts.TracerProvider == nil {
+		opts.TracerProvider = otel.GetTracerProvider()
+	}
 
-	return &Aggregator{opts: opts}, nil
+	return &Aggregator{
+		opts:   opts,
+		tracer: opts.TracerProvider.Tracer("clusteradmin.Aggregator"),
+	}, nil
 }
 
 // GetStreamCosts implements getStreamCosts operation. Stream cost attribution decodes every

--- a/internal/clusteradmin/clusteradmin_test.go
+++ b/internal/clusteradmin/clusteradmin_test.go
@@ -73,7 +73,7 @@ func (s staticPeers) Peers() ([]Peer, error) { return s.peers, s.err }
 
 // newTestAggregator serves each node over HTTP and points an aggregator at them, so the fan-out
 // exercises the real ogen client and encoding rather than an in-process call.
-func newTestAggregator(t *testing.T, rf int, nodes map[string]*fakeNode) *Aggregator {
+func newTestAggregator(t *testing.T, rf int, nodes map[string]*fakeNode, override ...func(*Options)) *Aggregator {
 	t.Helper()
 
 	var peers []Peer
@@ -90,11 +90,16 @@ func newTestAggregator(t *testing.T, rf int, nodes map[string]*fakeNode) *Aggreg
 		peers = append(peers, Peer{Node: name, Addr: ts.URL, Client: client})
 	}
 
-	a, err := New(Options{
+	opts := Options{
 		Peers:             staticPeers{peers: peers},
 		ReplicationFactor: rf,
 		Timeout:           10 * time.Second,
-	})
+	}
+	for _, o := range override {
+		o(&opts)
+	}
+
+	a, err := New(opts)
 	require.NoError(t, err)
 
 	return a

--- a/internal/clusteradmin/efficiency.go
+++ b/internal/clusteradmin/efficiency.go
@@ -1,8 +1,9 @@
 package clusteradmin
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"slices"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
 )
@@ -48,7 +49,7 @@ func (a *Aggregator) GetEfficiency(ctx context.Context, _ adminapi.GetEfficiency
 		}
 	}
 
-	sort.Strings(order)
+	slices.Sort(order)
 	for _, name := range order {
 		te := tenants[name]
 		for i := range te.Signals {
@@ -64,15 +65,15 @@ func addTenantEfficiency(into *adminapi.TenantEfficiency, from adminapi.TenantEf
 	for _, s := range from.Signals {
 		s.PartsDetail = nil
 
-		i := sort.Search(len(into.Signals), func(i int) bool { return into.Signals[i].Signal >= s.Signal })
-		if i < len(into.Signals) && into.Signals[i].Signal == s.Signal {
+		i, found := slices.BinarySearchFunc(into.Signals, s.Signal,
+			func(e adminapi.SignalEfficiency, want adminapi.Signal) int { return cmp.Compare(e.Signal, want) },
+		)
+		if found {
 			addSignalEfficiency(&into.Signals[i], s)
 
 			continue
 		}
-		into.Signals = append(into.Signals, adminapi.SignalEfficiency{})
-		copy(into.Signals[i+1:], into.Signals[i:])
-		into.Signals[i] = s
+		into.Signals = slices.Insert(into.Signals, i, s)
 	}
 }
 

--- a/internal/clusteradmin/fanout.go
+++ b/internal/clusteradmin/fanout.go
@@ -2,7 +2,8 @@ package clusteradmin
 
 import (
 	"context"
-	"sort"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -57,7 +58,7 @@ func fanout[T any](
 		return nil, errors.Wrap(err, "resolve cluster members")
 	}
 
-	sort.Slice(peers, func(i, j int) bool { return peers[i].Node < peers[j].Node })
+	slices.SortFunc(peers, func(a, b Peer) int { return strings.Compare(a.Node, b.Node) })
 
 	span.SetAttributes(attribute.Int("clusteradmin.peers", len(peers)))
 

--- a/internal/clusteradmin/fanout.go
+++ b/internal/clusteradmin/fanout.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/go-faster/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
@@ -30,15 +33,33 @@ func (r nodeAnswer[T]) ok() bool { return r.Err == nil }
 //
 // Answers come back in peer order, so an aggregate built from them does not depend on which node
 // replied first.
+//
+// Every node gets a span of its own. The response already carries each node's duration and status,
+// so the spans are not there to repeat them: they place the calls on one timeline, showing how much
+// of the fan-out actually overlapped and how a node's answer split between the aggregator's wait and
+// the node's own work, which the node's server span continues under the same trace.
 func fanout[T any](
 	ctx context.Context, a *Aggregator, name string, call func(context.Context, Peer) (T, error),
-) ([]nodeAnswer[T], error) {
+) (_ []nodeAnswer[T], rerr error) {
+	ctx, span := a.tracer.Start(ctx, "clusteradmin.fanout",
+		trace.WithAttributes(attribute.String("clusteradmin.op", name)),
+	)
+	defer func() {
+		if rerr != nil {
+			span.RecordError(rerr)
+			span.SetStatus(codes.Error, rerr.Error())
+		}
+		span.End()
+	}()
+
 	peers, err := a.opts.Peers.Peers()
 	if err != nil {
 		return nil, errors.Wrap(err, "resolve cluster members")
 	}
 
 	sort.Slice(peers, func(i, j int) bool { return peers[i].Node < peers[j].Node })
+
+	span.SetAttributes(attribute.Int("clusteradmin.peers", len(peers)))
 
 	out := make([]nodeAnswer[T], len(peers))
 
@@ -48,11 +69,23 @@ func fanout[T any](
 			nodeCtx, cancel := context.WithTimeout(ctx, a.opts.Timeout)
 			defer cancel()
 
+			nodeCtx, nodeSpan := a.tracer.Start(nodeCtx, "clusteradmin.fanout.node",
+				trace.WithAttributes(
+					attribute.String("clusteradmin.op", name),
+					attribute.String("clusteradmin.node", p.Node),
+					attribute.String("clusteradmin.addr", p.Addr),
+				),
+			)
+			defer nodeSpan.End()
+
 			started := time.Now()
 			v, err := call(nodeCtx, p)
 			out[i] = nodeAnswer[T]{Peer: p, Value: v, Err: err, Took: time.Since(started)}
 
 			if err != nil {
+				nodeSpan.RecordError(err)
+				nodeSpan.SetStatus(codes.Error, err.Error())
+
 				a.opts.Logger.Warn("Node did not answer",
 					zap.String("op", name), zap.String("node", p.Node), zap.String("addr", p.Addr),
 					zap.Error(err),

--- a/internal/clusteradmin/info.go
+++ b/internal/clusteradmin/info.go
@@ -1,9 +1,10 @@
 package clusteradmin
 
 import (
+	"cmp"
 	"context"
 	"runtime"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
@@ -64,7 +65,7 @@ func (a *Aggregator) GetInfo(ctx context.Context) (*adminapi.InstanceInfo, error
 	for _, s := range signals {
 		info.Signals = append(info.Signals, s)
 	}
-	sort.Slice(info.Signals, func(i, j int) bool { return info.Signals[i].Signal < info.Signals[j].Signal })
+	slices.SortFunc(info.Signals, func(a, b adminapi.SignalInfo) int { return cmp.Compare(a.Signal, b.Signal) })
 
 	return info, nil
 }

--- a/internal/clusteradmin/peers.go
+++ b/internal/clusteradmin/peers.go
@@ -2,11 +2,15 @@ package clusteradmin
 
 import (
 	"net"
+	"net/http"
 	"net/url"
 	"strconv"
 	"sync"
 
 	"github.com/go-faster/errors"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/oteldb/storage/cluster/etcd"
 
@@ -31,30 +35,57 @@ type RingPeers struct {
 	scheme  string
 	port    int
 
+	tracerProvider trace.TracerProvider
+	// httpClient is shared by every node's client so the outbound call carries the trace context to
+	// the node, whose server span then continues it.
+	httpClient *http.Client
+
 	mu      sync.Mutex
 	clients map[string]NodeClient
 }
 
 var _ PeerSet = (*RingPeers)(nil)
 
+// RingPeersOptions configures [RingPeers].
+type RingPeersOptions struct {
+	// Members is the live ring view. Required.
+	Members Membership
+	// Scheme is the admin API scheme, "http" or "https". Required.
+	Scheme string
+	// Port is the admin API port every node serves on. Required.
+	Port int
+	// TracerProvider instruments the calls to the nodes. Nil selects the global provider, which is a
+	// noop unless the process configures one.
+	TracerProvider trace.TracerProvider
+}
+
 // NewRingPeers resolves ring members to admin APIs at scheme://<member host>:port.
-func NewRingPeers(members Membership, scheme string, port int) (*RingPeers, error) {
-	if members == nil {
+func NewRingPeers(opts RingPeersOptions) (*RingPeers, error) {
+	if opts.Members == nil {
 		return nil, errors.New("membership is required")
 	}
-	if port <= 0 || port > 65535 {
-		return nil, errors.Errorf("admin port %d is out of range", port)
+	if opts.Port <= 0 || opts.Port > 65535 {
+		return nil, errors.Errorf("admin port %d is out of range", opts.Port)
 	}
-	switch scheme {
+	switch opts.Scheme {
 	case "http", "https":
 	default:
-		return nil, errors.Errorf("unsupported scheme %q", scheme)
+		return nil, errors.Errorf("unsupported scheme %q", opts.Scheme)
+	}
+	if opts.TracerProvider == nil {
+		opts.TracerProvider = otel.GetTracerProvider()
 	}
 
 	return &RingPeers{
-		members: members,
-		scheme:  scheme,
-		port:    port,
+		members:        opts.Members,
+		scheme:         opts.Scheme,
+		port:           opts.Port,
+		tracerProvider: opts.TracerProvider,
+		httpClient: &http.Client{
+			Transport: otelhttp.NewTransport(http.DefaultTransport,
+				otelhttp.WithTracerProvider(opts.TracerProvider),
+			),
+		},
 		clients: map[string]NodeClient{},
 	}, nil
 }
@@ -77,7 +108,10 @@ func (r *RingPeers) Peers() ([]Peer, error) {
 
 		client, ok := r.clients[addr]
 		if !ok {
-			client, err = adminapi.NewClient(addr)
+			client, err = adminapi.NewClient(addr,
+				adminapi.WithTracerProvider(r.tracerProvider),
+				adminapi.WithClient(r.httpClient),
+			)
 			if err != nil {
 				return nil, errors.Wrapf(err, "admin client for %s", m.ID)
 			}

--- a/internal/clusteradmin/storage.go
+++ b/internal/clusteradmin/storage.go
@@ -1,8 +1,10 @@
 package clusteradmin
 
 import (
+	"cmp"
 	"context"
-	"sort"
+	"maps"
+	"slices"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
 )
@@ -63,7 +65,7 @@ func (a *Aggregator) GetStorage(ctx context.Context) (*adminapi.StorageStats, er
 		return stats, nil
 	}
 
-	sort.Strings(order)
+	slices.Sort(order)
 	for _, name := range order {
 		engine.Tenants = append(engine.Tenants, *tenants[name])
 	}
@@ -115,11 +117,7 @@ func mergeClusterStats(into *adminapi.OptClusterStats, from adminapi.ClusterStat
 		owned[s] = struct{}{}
 	}
 
-	cur.Owned = cur.Owned[:0]
-	for s := range owned {
-		cur.Owned = append(cur.Owned, s)
-	}
-	sort.Strings(cur.Owned)
+	cur.Owned = slices.Sorted(maps.Keys(owned))
 
 	if ps, ok := from.PartSync.Get(); ok {
 		acc, _ := cur.PartSync.Get()
@@ -165,15 +163,15 @@ func addTenantStats(into *adminapi.TenantStats, from adminapi.TenantStats) {
 	into.Admission.Overflowed += from.Admission.Overflowed
 
 	for _, s := range from.Signals {
-		i := sort.Search(len(into.Signals), func(i int) bool { return into.Signals[i].Signal >= s.Signal })
-		if i < len(into.Signals) && into.Signals[i].Signal == s.Signal {
+		i, found := slices.BinarySearchFunc(into.Signals, s.Signal,
+			func(e adminapi.EngineSignalStats, want adminapi.Signal) int { return cmp.Compare(e.Signal, want) },
+		)
+		if found {
 			addSignalStats(&into.Signals[i], s)
 
 			continue
 		}
-		into.Signals = append(into.Signals, adminapi.EngineSignalStats{})
-		copy(into.Signals[i+1:], into.Signals[i:])
-		into.Signals[i] = s
+		into.Signals = slices.Insert(into.Signals, i, s)
 	}
 }
 

--- a/internal/clusteradmin/trace_test.go
+++ b/internal/clusteradmin/trace_test.go
@@ -1,0 +1,162 @@
+package clusteradmin
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/oteldb/oteldb/internal/adminapi"
+)
+
+// spansNamed returns the recorded spans with the given name.
+func spansNamed(spans tracetest.SpanStubs, name string) []tracetest.SpanStub {
+	var out []tracetest.SpanStub
+	for _, s := range spans {
+		if s.Name == name {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+// attrString reads a string attribute off a span, failing if it is absent.
+func attrString(t *testing.T, s tracetest.SpanStub, key string) string {
+	t.Helper()
+
+	for _, kv := range s.Attributes {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	t.Fatalf("span %q has no attribute %s", s.Name, key)
+
+	return ""
+}
+
+// TestFanoutSpans pins that every node the aggregator asks gets a span of its own, under one
+// fan-out span: the response says which node failed, but only the spans say when each call ran and
+// how the failing one spent its time.
+func TestFanoutSpans(t *testing.T) {
+	t.Parallel()
+
+	rec := tracetest.NewSpanRecorder()
+	a := newTestAggregator(t, 2, map[string]*fakeNode{
+		"a": {health: &adminapi.HealthReport{Status: adminapi.HealthStatusHealthy}},
+		"b": {err: errors.New("node is on fire")},
+	}, func(o *Options) {
+		o.TracerProvider = sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	})
+
+	_, err := a.GetHealth(t.Context())
+	require.NoError(t, err)
+
+	spans := tracetest.SpanStubsFromReadOnlySpans(rec.Ended())
+
+	roots := spansNamed(spans, "clusteradmin.fanout")
+	require.Len(t, roots, 1)
+	assert.Equal(t, "health", attrString(t, roots[0], "clusteradmin.op"))
+	assert.Contains(t, roots[0].Attributes, attribute.Int("clusteradmin.peers", 2))
+	assert.Equal(t, codes.Unset, roots[0].Status.Code, "a node failure is a partial answer, not a failed fan-out")
+
+	nodes := spansNamed(spans, "clusteradmin.fanout.node")
+	require.Len(t, nodes, 2, "one span per peer, including the one that failed")
+
+	byNode := map[string]tracetest.SpanStub{}
+	for _, s := range nodes {
+		assert.Equal(t, roots[0].SpanContext.SpanID(), s.Parent.SpanID(), "node spans hang off the fan-out")
+		assert.NotEmpty(t, attrString(t, s, "clusteradmin.addr"))
+		byNode[attrString(t, s, "clusteradmin.node")] = s
+	}
+	require.Contains(t, byNode, "a")
+	require.Contains(t, byNode, "b")
+
+	assert.Equal(t, codes.Unset, byNode["a"].Status.Code)
+	assert.Equal(t, codes.Error, byNode["b"].Status.Code)
+	assert.Contains(t, byNode["b"].Status.Description, "node is on fire")
+	require.Len(t, byNode["b"].Events, 1, "the failure is recorded on the span, not only in the response")
+	assert.Equal(t, "exception", byNode["b"].Events[0].Name)
+}
+
+// TestRingPeersPropagatesTraceContext pins that a call to a node is a real client span and carries
+// the trace context, so the node's own server span continues the aggregator's trace rather than
+// starting a second, unrelated one.
+//
+// It does not run in parallel: the outbound transport injects with the global propagator, which the
+// process configures at startup and this test has to stand in for.
+func TestRingPeersPropagatesTraceContext(t *testing.T) {
+	prev := otel.GetTextMapPropagator()
+	t.Cleanup(func() { otel.SetTextMapPropagator(prev) })
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	api, err := adminapi.NewServer(&fakeNode{info: &adminapi.InstanceInfo{Version: "test"}})
+	require.NoError(t, err)
+
+	var got propagation.HeaderCarrier
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = propagation.HeaderCarrier(r.Header.Clone())
+		api.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+
+	host, port := splitHostPort(t, ts.URL)
+
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+
+	peers, err := NewRingPeers(RingPeersOptions{
+		Members:        fakeMembership{{ID: host, Addr: host}},
+		Scheme:         "http",
+		Port:           port,
+		TracerProvider: tp,
+	})
+	require.NoError(t, err)
+
+	resolved, err := peers.Peers()
+	require.NoError(t, err)
+	require.Len(t, resolved, 1)
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "caller")
+	_, err = resolved[0].Client.GetInfo(ctx)
+	span.End()
+	require.NoError(t, err)
+
+	require.NotNil(t, got, "the node was not called")
+
+	remote := trace.SpanContextFromContext(propagation.TraceContext{}.Extract(t.Context(), got))
+	require.True(t, remote.IsValid(), "no trace context reached the node")
+	assert.Equal(t, span.SpanContext().TraceID(), remote.TraceID())
+
+	var client bool
+	for _, s := range tracetest.SpanStubsFromReadOnlySpans(rec.Ended()) {
+		if s.SpanKind == trace.SpanKindClient {
+			client = true
+		}
+	}
+	assert.True(t, client, "the call to a node is a client span")
+}
+
+func splitHostPort(t *testing.T, rawURL string) (host string, port int) {
+	t.Helper()
+
+	host, portStr, err := net.SplitHostPort(rawURL[len("http://"):])
+	require.NoError(t, err)
+
+	port, err = strconv.Atoi(portStr)
+	require.NoError(t, err)
+
+	return host, port
+}

--- a/internal/clusterquery/series.go
+++ b/internal/clusterquery/series.go
@@ -3,7 +3,7 @@ package clusterquery
 import (
 	"bytes"
 	"context"
-	"sort"
+	"slices"
 
 	"github.com/go-faster/errors"
 
@@ -78,7 +78,7 @@ func (s *Source) LogKeys(
 		keys = append(keys, k)
 	}
 
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	out := make([]storage.KeyInfo, len(keys))
 	for i, k := range keys {
@@ -124,7 +124,7 @@ func (s *Source) ColumnValues(
 		values = append(values, v)
 	}
 
-	sort.Strings(values)
+	slices.Sort(values)
 
 	if req.Limit > 0 && len(values) > req.Limit {
 		values = values[:req.Limit]

--- a/internal/clusterquery/source_test.go
+++ b/internal/clusterquery/source_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"slices"
-	"sort"
 	"testing"
 	"time"
 
@@ -188,7 +187,7 @@ func drainNames(t *testing.T, f fetch.Fetcher, matchers []fetch.Matcher) []strin
 		out = append(out, nameOf(b.Series))
 	}
 
-	sort.Strings(out)
+	slices.Sort(out)
 
 	return out
 }
@@ -224,7 +223,7 @@ func TestFetcherGathersEveryShard(t *testing.T) {
 		names = append(names, nameOf(s))
 	}
 
-	sort.Strings(names)
+	slices.Sort(names)
 	assert.Equal(t, []string{"a", "b", "c", "d"}, names)
 }
 

--- a/internal/profileql/profileqlengine/flamebearer.go
+++ b/internal/profileql/profileqlengine/flamebearer.go
@@ -1,7 +1,8 @@
 package profileqlengine
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	"github.com/oteldb/oteldb/internal/profileql"
 	"github.com/oteldb/oteldb/internal/profilestorage"
@@ -141,9 +142,7 @@ func minValue(root *profilestorage.FlameNode, maxNodes int) int64 {
 	if len(totals) <= maxNodes {
 		return 0
 	}
-	sort.Slice(totals, func(i, j int) bool {
-		return totals[i] > totals[j]
-	})
+	slices.SortFunc(totals, func(a, b int64) int { return cmp.Compare(b, a) })
 	return totals[maxNodes-1]
 }
 

--- a/internal/scarecrow/quantile.go
+++ b/internal/scarecrow/quantile.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -180,7 +180,7 @@ func quantile(q float64, values []float64) float64 {
 		return math.Inf(+1)
 	}
 
-	sort.Float64s(values)
+	slices.Sort(values)
 
 	n := float64(len(values))
 	rank := q * (n - 1)

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"slices"
-	"sort"
 	"time"
 
 	"github.com/go-faster/errors"
@@ -752,7 +751,7 @@ func seriesKey(m map[string]string) string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	var buf []byte
 	for _, k := range keys {
 		buf = append(buf, k...)

--- a/internal/storagebackend/logs_limit_test.go
+++ b/internal/storagebackend/logs_limit_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 	"testing"
 
@@ -29,7 +28,7 @@ func canonicalize(tb testing.TB, data lokiapi.QueryResponseData) limitResult {
 		for k, v := range s.Stream.Value {
 			pairs = append(pairs, k+"="+v)
 		}
-		sort.Strings(pairs)
+		slices.Sort(pairs)
 		key := strings.Join(pairs, ",")
 		require.NotContains(tb, out, key, "duplicate stream in result")
 		out[key] = s.Values

--- a/internal/storagebackend/logs_optimizer_test.go
+++ b/internal/storagebackend/logs_optimizer_test.go
@@ -2,7 +2,7 @@ package storagebackend_test
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -116,7 +116,7 @@ func normalize(t *testing.T, data lokiapi.QueryResponseData) []string {
 		for k := range ls {
 			keys = append(keys, k)
 		}
-		sort.Strings(keys)
+		slices.Sort(keys)
 		var lb strings.Builder
 		for _, k := range keys {
 			fmt.Fprintf(&lb, "%s=%s,", k, ls[k])
@@ -125,6 +125,6 @@ func normalize(t *testing.T, data lokiapi.QueryResponseData) []string {
 			out = append(out, fmt.Sprintf("%s@%g=%s", lb.String(), v.T, v.V))
 		}
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
 }

--- a/internal/storagebackend/logs_parallel_test.go
+++ b/internal/storagebackend/logs_parallel_test.go
@@ -3,7 +3,7 @@ package storagebackend_test
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -85,7 +85,7 @@ func resultRows(tb testing.TB, b *storagebackend.Backend, sel []logql.LabelMatch
 		e.Set.Range(func(k logql.Label, v pcommon.Value) {
 			labels = append(labels, fmt.Sprintf("%s=%s", k, v.AsString()))
 		})
-		sort.Strings(labels)
+		slices.Sort(labels)
 		rows = append(rows, fmt.Sprintf("%d|%s|%v", e.Timestamp, e.Line, labels))
 	}
 	require.NoError(tb, it.Err())

--- a/internal/storagebackend/logs_record_filter_test.go
+++ b/internal/storagebackend/logs_record_filter_test.go
@@ -1,7 +1,7 @@
 package storagebackend_test
 
 import (
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -61,7 +61,7 @@ func TestLogRecordAttrPushdown(t *testing.T) {
 			lines = append(lines, e.Line)
 		}
 		require.NoError(t, it.Err())
-		sort.Strings(lines)
+		slices.Sort(lines)
 		return lines
 	}
 
@@ -110,5 +110,5 @@ func TestLogRecordAttrLabelNames(t *testing.T) {
 	require.Contains(t, names, "service_name") // resource label
 	require.Contains(t, names, "job")          // clean record-attribute key
 	require.Contains(t, names, "http_method")  // dotted record-attribute key, normalized
-	require.True(t, sort.StringsAreSorted(names), "label names must be sorted")
+	require.True(t, slices.IsSorted(names), "label names must be sorted")
 }

--- a/internal/storagebackend/logs_stream_matcher_test.go
+++ b/internal/storagebackend/logs_stream_matcher_test.go
@@ -3,7 +3,7 @@ package storagebackend_test
 import (
 	"encoding/base64"
 	"regexp"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -47,7 +47,7 @@ func TestLogStreamMatcherPushdown(t *testing.T) {
 			lines = append(lines, e.Line)
 		}
 		require.NoError(t, it.Err())
-		sort.Strings(lines)
+		slices.Sort(lines)
 		return lines
 	}
 

--- a/internal/storagebackend/overtime.go
+++ b/internal/storagebackend/overtime.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -185,8 +185,8 @@ func (o *aggregateOverTimeOp) doLoad(ctx context.Context) error {
 	for i := range order {
 		order[i] = i
 	}
-	sort.SliceStable(order, func(a, c int) bool {
-		return labels.Compare(o.series[order[a]], o.series[order[c]]) < 0
+	slices.SortStableFunc(order, func(a, c int) int {
+		return labels.Compare(o.series[a], o.series[c])
 	})
 	sortedSeries := make([]labels.Labels, len(order))
 	sortedVals := make([]float64, len(order))

--- a/internal/storagebackend/profiles.go
+++ b/internal/storagebackend/profiles.go
@@ -1,10 +1,10 @@
 package storagebackend
 
 import (
+	"cmp"
 	"context"
 	"regexp"
 	"slices"
-	"sort"
 
 	"github.com/go-faster/errors"
 
@@ -47,7 +47,7 @@ func (q *ProfileQuerier) ProfileTypes(ctx context.Context, opts profilestorage.P
 	for _, pt := range seen {
 		out = append(out, pt)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].ID() < out[j].ID() })
+	slices.SortFunc(out, func(a, b profileql.ProfileType) int { return cmp.Compare(a.ID(), b.ID()) })
 	return out, nil
 }
 
@@ -292,6 +292,6 @@ func sortedKeys(set map[string]struct{}) []string {
 	for k := range set {
 		out = append(out, k)
 	}
-	sort.Strings(out)
+	slices.Sort(out)
 	return out
 }

--- a/internal/storagebackend/signals_test.go
+++ b/internal/storagebackend/signals_test.go
@@ -2,7 +2,7 @@ package storagebackend_test
 
 import (
 	"context"
-	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -435,7 +435,7 @@ func drainLabels(
 		out = append(out, l.Value)
 		return nil
 	}))
-	sort.Strings(out)
+	slices.Sort(out)
 
 	return out
 }


### PR DESCRIPTION
`modernize` is enabled in `.golangci.yml` and reports 0 issues, but the `sort` package is still used in 18 files. The linter is not wrong — its coverage is just narrower than the name suggests:

- `slicessort` only rewrites the natural-order form `sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })` → `slices.Sort(s)`. Rewriting an arbitrary comparator to `slices.SortFunc` is an explicit `TODO` in [sortslice.go](https://cs.opensource.google/go/x/tools/+/master:go/analysis/passes/modernize/sortslice.go).
- `sort.Strings` / `sort.Float64s` / `sort.StringsAreSorted` are not covered by any modernizer at all.

So this is the manual half of the pass.

## Changes

| From | To |
|---|---|
| `sort.Strings`, `sort.Float64s` | `slices.Sort` |
| `sort.StringsAreSorted` | `slices.IsSorted` |
| `sort.Slice` with a comparator | `slices.SortFunc` + `cmp.Compare` |
| `sort.SliceStable` | `slices.SortStableFunc` |

One change is more than mechanical. In `internal/storagebackend/overtime.go` an index permutation was sorted with `sort.SliceStable(order, ...)`, whose callback receives indices *into* `order`, hence the double indirection `o.series[order[a]]`. `slices.SortStableFunc` passes the *elements* of `order`, so it becomes `o.series[a]` — same ordering, one less hop to reason about.

## Left alone

`sort.Sort(out)` on `promql.Matrix` in `internal/scarecrow` and `internal/storagebackend` — that is Prometheus' own `sort.Interface` implementation, not a comparator we own. Converting it would mean reimplementing their `Less`.

`cmd/otelbench/logs_report.go` keeps its `a.Type+a.Title` concatenation key rather than becoming a `cmp.Or` tuple compare. The concat has different ordering in edge cases, and this is a formatting pass, not a behavior fix.

## Verification

- `go build ./...` clean
- `go test -race` green on all touched packages
- `golangci-lint run` → 0 issues on all touched packages