### PR TITLE
fix(storagebackend): answer trace tag values without materializing spans

### DIFF
--- a/internal/clusterquery/series.go
+++ b/internal/clusterquery/series.go
@@ -29,6 +29,13 @@ func (s *Source) LogSeries(
 	return s.series(ctx, signal.Log, tenant, matchers, start, end)
 }
 
+// TraceSeries implements [storagebackend.Source].
+func (s *Source) TraceSeries(
+	ctx context.Context, tenant signal.TenantID, matchers []fetch.Matcher, start, end int64,
+) ([]signal.Series, error) {
+	return s.series(ctx, signal.Trace, tenant, matchers, start, end)
+}
+
 // ProfileSeries implements [storagebackend.Source].
 func (s *Source) ProfileSeries(
 	ctx context.Context, tenant signal.TenantID, matchers []fetch.Matcher, start, end int64,

--- a/internal/storagebackend/source.go
+++ b/internal/storagebackend/source.go
@@ -51,6 +51,12 @@ type Source interface {
 
 	// TraceFetcher returns the traces read seam over the named tenants.
 	TraceFetcher(tenants ...signal.TenantID) fetch.Fetcher
+	// TraceSeries enumerates a tenant's matching span stream identities in [start, end] ns. It is the
+	// traces twin of LogSeries, and it is what lets a resource- or instrumentation-scoped tag lookup
+	// be answered from the stream identities instead of by materializing every span in the window.
+	TraceSeries(
+		ctx context.Context, tenant signal.TenantID, matchers []fetch.Matcher, start, end int64,
+	) ([]signal.Series, error)
 	// Trace returns every span of one trace.
 	Trace(ctx context.Context, tenant signal.TenantID, traceID []byte) ([]*fetch.Batch, error)
 

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -1,8 +1,10 @@
 package storagebackend
 
 import (
+	"cmp"
 	"context"
 	"maps"
+	"slices"
 	"time"
 
 	"github.com/go-faster/errors"
@@ -147,28 +149,46 @@ func (q *TraceQuerier) TagNames(ctx context.Context, opts tracestorage.TagNamesO
 // window (a part overlapping it contributes its whole dictionary), which the storage doc calls out as
 // fine for autocomplete and this package already relies on elsewhere.
 //
-// Everything else still scans:
-//   - rootName and rootServiceName filter to root spans (empty parent span id), a predicate a column
-//     enumeration cannot express.
-//   - a resource- or instrumentation-scoped attribute lives on the stream identity, not the per-record
-//     attribute blob AttrKey enumerates, and there is no trace-stream enumeration primitive on [Source]
-//     (unlike [LogQuerier], which has LogSeries) to answer it more cheaply.
-//   - ScopeNone must cover every scope, so it needs both the span-scoped and the stream-scoped values;
-//     since only the former is pushable, the whole lookup falls back to the scan rather than silently
-//     dropping resource/instrumentation values.
+// A resource- or instrumentation-scoped attribute lives on the stream identity rather than the
+// per-record attribute blob AttrKey enumerates, so it is answered from [Source.TraceSeries] — the
+// traces twin of LogSeries. ScopeNone needs both halves and takes the union of the two.
+//
+// Everything else still scans, and only these:
+//   - rootName and rootServiceName filter to root spans (empty parent span id), a predicate neither a
+//     column enumeration nor a stream enumeration can express.
+//   - an event- or link-scoped attribute lives inside the events/links blob columns, which carry no
+//     dictionary of their own.
 func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, opts tracestorage.TagValuesOptions) (iterators.Iterator[tracestorage.Tag], error) {
 	switch attr.Prop {
 	case traceql.SpanStatus:
 		return iterators.Slice(spanStatusTags(attr)), nil
 	case traceql.SpanKind:
 		return iterators.Slice(spanKindTags(attr)), nil
-	case traceql.SpanDuration, traceql.SpanChildCount, traceql.SpanParent, traceql.TraceDuration:
+	case traceql.SpanDuration, traceql.SpanChildCount, traceql.SpanParent, traceql.TraceDuration,
+		traceql.NestedSetLeft, traceql.NestedSetRight, traceql.NestedSetParent,
+		traceql.EventTimeSinceStart,
+		traceql.SpanID, traceql.ParentID, traceql.TraceID,
+		traceql.LinkTraceID, traceql.LinkSpanID:
+		// Numeric, structural, or identifier intrinsics: nothing here is worth autocompleting, and the
+		// ids are unbounded cardinality — enumerating trace ids would build a set the size of the
+		// window. These already returned nothing, because the generic fallback below only ever visits
+		// attribute maps and an intrinsic's Name is empty; saying so here is what drops the scan that
+		// was computing that empty answer.
 		return iterators.Empty[tracestorage.Tag](), nil
 	case traceql.SpanName:
 		return q.columnTagValues(ctx, attr, sigtrace.ColName, opts)
+	case traceql.SpanStatusMessage:
+		return q.columnTagValues(ctx, attr, sigtrace.ColStatusMsg, opts)
+	case traceql.InstrumentationName, traceql.InstrumentationVersion:
+		return q.scopeTagValues(ctx, attr, opts)
 	case traceql.SpanAttribute:
-		if attr.Scope == traceql.ScopeSpan {
+		switch attr.Scope {
+		case traceql.ScopeSpan:
 			return q.attrTagValues(ctx, attr, opts)
+		case traceql.ScopeResource, traceql.ScopeInstrumentation:
+			return q.seriesTagValues(ctx, attr, opts)
+		case traceql.ScopeNone:
+			return q.unscopedTagValues(ctx, attr, opts)
 		}
 	}
 
@@ -202,6 +222,147 @@ func (q *TraceQuerier) TagValues(ctx context.Context, attr traceql.Attribute, op
 		out = append(out, tag)
 	}
 	return iterators.Slice(out), nil
+}
+
+// forEachStreamTag calls fn for every (scope, name, value) attribute pair carried by a matching span
+// stream's identity. It is the [forEachSpanTag] of the identity side, and formats values the same way
+// on purpose: an attribute must render identically whichever path answered it.
+//
+// The cost is O(streams), not O(spans) — the per-series pcommon.Map is bounded by stream cardinality,
+// which is what makes this worth doing at all.
+func (q *TraceQuerier) forEachStreamTag(
+	ctx context.Context, opts tracestorage.TagValuesOptions, fn func(scope traceql.AttributeScope, name, value string),
+) error {
+	lo, hi := seriesWindow(opts.Start, opts.End)
+
+	series, err := q.b.src.TraceSeries(ctx, q.b.tenant, nil, lo, hi)
+	if err != nil {
+		return errors.Wrap(err, "trace series")
+	}
+
+	visit := func(scope traceql.AttributeScope, attrs signal.Attributes) {
+		otelAttrs(attrs).AsMap().Range(func(k string, v pcommon.Value) bool {
+			fn(scope, k, v.AsString())
+
+			return true
+		})
+	}
+
+	for _, ser := range series {
+		visit(traceql.ScopeResource, ser.Resource.Attributes)
+		visit(traceql.ScopeInstrumentation, ser.Scope.Attributes)
+	}
+
+	return nil
+}
+
+// seriesTagValues enumerates a resource- or instrumentation-scoped attribute's values from the stream
+// identities. It must not be called for [traceql.ScopeSpan], whose values live in the per-record
+// attribute blob and are cheaper still through [TraceQuerier.attrTagValues].
+func (q *TraceQuerier) seriesTagValues(
+	ctx context.Context, attr traceql.Attribute, opts tracestorage.TagValuesOptions,
+) (iterators.Iterator[tracestorage.Tag], error) {
+	seen := map[string]tracestorage.Tag{}
+
+	if err := q.forEachStreamTag(ctx, opts, func(scope traceql.AttributeScope, name, value string) {
+		if name != attr.Name || scope != attr.Scope {
+			return
+		}
+
+		seen[value] = tracestorage.Tag{Name: name, Value: value, Type: traceql.TypeString, Scope: scope}
+	}); err != nil {
+		return nil, err
+	}
+
+	return iterators.Slice(sortedTags(seen)), nil
+}
+
+// unscopedTagValues answers an unscoped attribute — the shape Grafana's autocomplete sends — as the
+// union of the span-scoped values (the per-record attribute dictionary) and the stream-scoped ones
+// (the identities). Both halves are needed: dropping either would silently hide values that exist.
+//
+// Values are deduplicated by value alone, exactly as the scan did. Two scopes carrying the same value
+// collapse to one tag, and which scope it reports is arbitrary — the Tempo responses use only the
+// value and its type, never the scope.
+func (q *TraceQuerier) unscopedTagValues(
+	ctx context.Context, attr traceql.Attribute, opts tracestorage.TagValuesOptions,
+) (iterators.Iterator[tracestorage.Tag], error) {
+	seen := map[string]tracestorage.Tag{}
+
+	spanScoped := attr
+	spanScoped.Scope = traceql.ScopeSpan
+
+	iter, err := q.attrTagValues(ctx, spanScoped, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := iterators.ForEach(iter, func(tag tracestorage.Tag) error {
+		seen[tag.Value] = tag
+
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "span-scoped values")
+	}
+
+	if err := q.forEachStreamTag(ctx, opts, func(scope traceql.AttributeScope, name, value string) {
+		if name != attr.Name {
+			return
+		}
+
+		seen[value] = tracestorage.Tag{Name: name, Value: value, Type: traceql.TypeString, Scope: scope}
+	}); err != nil {
+		return nil, err
+	}
+
+	return iterators.Slice(sortedTags(seen)), nil
+}
+
+// scopeTagValues enumerates the instrumentation scope name/version intrinsics, which live on the
+// stream identity next to its attributes.
+func (q *TraceQuerier) scopeTagValues(
+	ctx context.Context, attr traceql.Attribute, opts tracestorage.TagValuesOptions,
+) (iterators.Iterator[tracestorage.Tag], error) {
+	lo, hi := seriesWindow(opts.Start, opts.End)
+
+	series, err := q.b.src.TraceSeries(ctx, q.b.tenant, nil, lo, hi)
+	if err != nil {
+		return nil, errors.Wrap(err, "trace series")
+	}
+
+	name := attr.String()
+	seen := map[string]tracestorage.Tag{}
+
+	for _, ser := range series {
+		field := ser.Scope.Name
+		if attr.Prop == traceql.InstrumentationVersion {
+			field = ser.Scope.Version
+		}
+
+		if len(field) == 0 {
+			continue
+		}
+
+		value := string(field)
+		seen[value] = tracestorage.Tag{
+			Name: name, Value: value, Type: traceql.TypeString, Scope: traceql.ScopeInstrumentation,
+		}
+	}
+
+	return iterators.Slice(sortedTags(seen)), nil
+}
+
+// sortedTags flattens a value-keyed tag set into a deterministic slice. Map order would otherwise
+// reshuffle an autocomplete list between identical requests.
+func sortedTags(seen map[string]tracestorage.Tag) []tracestorage.Tag {
+	out := make([]tracestorage.Tag, 0, len(seen))
+	for _, tag := range seen {
+		out = append(out, tag)
+	}
+
+	slices.SortFunc(out, func(a, b tracestorage.Tag) int { return cmp.Compare(a.Value, b.Value) })
+
+	return out
 }
 
 // columnTagValues enumerates a byte column's distinct values via [Source.ColumnValues].

--- a/internal/storagebackend/traces_tagvalues_test.go
+++ b/internal/storagebackend/traces_tagvalues_test.go
@@ -1,0 +1,180 @@
+package storagebackend_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage"
+
+	"github.com/oteldb/oteldb/internal/iterators"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/traceql"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// tagValueFixture ingests two services, each with its own scope, span attributes and status message,
+// so every routing branch of TagValues has something distinct to find.
+func tagValueFixture(t *testing.T) *storagebackend.Backend {
+	t.Helper()
+
+	ctx := context.Background()
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	b := storagebackend.New(store)
+	ts := time.Now().Truncate(time.Second)
+
+	td := ptrace.NewTraces()
+
+	for i, svc := range []string{"frontend", "cart"} {
+		rs := td.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("service.name", svc)
+		rs.Resource().Attributes().PutStr("deployment.environment", "prod")
+
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.Scope().SetName("otelhttp")
+		ss.Scope().SetVersion("1.2.3")
+		ss.Scope().Attributes().PutStr("library.tier", "http")
+
+		sp := ss.Spans().AppendEmpty()
+		sp.SetTraceID(pcommon.TraceID([16]byte{byte(i + 1)}))
+		sp.SetSpanID(pcommon.SpanID([8]byte{byte(i + 1)}))
+		sp.SetName(svc + ".handle")
+		sp.Attributes().PutStr("http.method", "GET")
+		sp.Status().SetMessage("boom-" + svc)
+		sp.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		sp.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
+	}
+
+	require.NoError(t, b.ConsumeTraces(ctx, td))
+
+	return b
+}
+
+func tagValues(t *testing.T, b *storagebackend.Backend, attr traceql.Attribute) []string {
+	t.Helper()
+
+	iter, err := b.Traces().TagValues(context.Background(), attr, tracestorage.TagValuesOptions{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = iter.Close() })
+
+	var out []string
+
+	require.NoError(t, iterators.ForEach(iter, func(tag tracestorage.Tag) error {
+		out = append(out, tag.Value)
+
+		return nil
+	}))
+
+	return out
+}
+
+// The reported bug: service.name is a resource attribute, so it used to fall through to a scan of
+// every span in the window to produce a handful of strings.
+func TestTraceTagValuesResourceScope(t *testing.T) {
+	t.Parallel()
+
+	b := tagValueFixture(t)
+
+	assert.Equal(t, []string{"cart", "frontend"},
+		tagValues(t, b, traceql.Attribute{Name: "service.name", Scope: traceql.ScopeResource}))
+	assert.Equal(t, []string{"prod"},
+		tagValues(t, b, traceql.Attribute{Name: "deployment.environment", Scope: traceql.ScopeResource}))
+}
+
+func TestTraceTagValuesInstrumentationScope(t *testing.T) {
+	t.Parallel()
+
+	b := tagValueFixture(t)
+
+	assert.Equal(t, []string{"http"},
+		tagValues(t, b, traceql.Attribute{Name: "library.tier", Scope: traceql.ScopeInstrumentation}))
+}
+
+// The shape Grafana's autocomplete actually sends: no scope at all. It must union the per-record
+// attribute dictionary with the stream identities, because dropping either half silently hides
+// values that exist.
+func TestTraceTagValuesUnscopedUnionsBothHalves(t *testing.T) {
+	t.Parallel()
+
+	b := tagValueFixture(t)
+
+	assert.Equal(t, []string{"cart", "frontend"},
+		tagValues(t, b, traceql.Attribute{Name: "service.name"}), "the resource half")
+	assert.Equal(t, []string{"GET"},
+		tagValues(t, b, traceql.Attribute{Name: "http.method"}), "the span half")
+}
+
+func TestTraceTagValuesSpanScopeUnchanged(t *testing.T) {
+	t.Parallel()
+
+	b := tagValueFixture(t)
+
+	assert.Equal(t, []string{"GET"},
+		tagValues(t, b, traceql.Attribute{Name: "http.method", Scope: traceql.ScopeSpan}))
+	assert.Empty(t, tagValues(t, b, traceql.Attribute{Name: "service.name", Scope: traceql.ScopeSpan}),
+		"a resource attribute is not a span attribute")
+}
+
+func TestTraceTagValuesStatusMessage(t *testing.T) {
+	t.Parallel()
+
+	b := tagValueFixture(t)
+
+	assert.ElementsMatch(t, []string{"boom-cart", "boom-frontend"},
+		tagValues(t, b, traceql.Attribute{Prop: traceql.SpanStatusMessage}),
+		"status message has its own column, so it needs no scan")
+}
+
+func TestTraceTagValuesInstrumentationIntrinsics(t *testing.T) {
+	t.Parallel()
+
+	b := tagValueFixture(t)
+
+	assert.Equal(t, []string{"otelhttp"},
+		tagValues(t, b, traceql.Attribute{Prop: traceql.InstrumentationName}))
+	assert.Equal(t, []string{"1.2.3"},
+		tagValues(t, b, traceql.Attribute{Prop: traceql.InstrumentationVersion}))
+}
+
+// These used to scan the whole window and then return nothing, because the generic fallback only
+// visits attribute maps and an intrinsic's Name is empty. Two of them are also unbounded
+// cardinality: enumerating trace ids would build a set the size of the window.
+func TestTraceTagValuesUnenumerableIntrinsics(t *testing.T) {
+	t.Parallel()
+
+	b := tagValueFixture(t)
+
+	for _, prop := range []traceql.SpanProperty{
+		traceql.SpanDuration, traceql.SpanChildCount, traceql.SpanParent, traceql.TraceDuration,
+		traceql.NestedSetLeft, traceql.NestedSetRight, traceql.NestedSetParent,
+		traceql.EventTimeSinceStart,
+		traceql.SpanID, traceql.ParentID, traceql.TraceID,
+		traceql.LinkTraceID, traceql.LinkSpanID,
+	} {
+		assert.Empty(t, tagValues(t, b, traceql.Attribute{Prop: prop}),
+			"prop %v yields no autocomplete values", prop)
+	}
+}
+
+// The intrinsics and scopes that still work exactly as before.
+func TestTraceTagValuesEnumerableIntrinsicsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	b := tagValueFixture(t)
+
+	assert.ElementsMatch(t, []string{"cart.handle", "frontend.handle"},
+		tagValues(t, b, traceql.Attribute{Prop: traceql.SpanName}))
+	assert.ElementsMatch(t, []string{"unset", "ok", "error"},
+		tagValues(t, b, traceql.Attribute{Prop: traceql.SpanStatus}))
+	assert.ElementsMatch(t, []string{"frontend", "cart"},
+		tagValues(t, b, traceql.Attribute{Prop: traceql.RootServiceName}))
+}


### PR DESCRIPTION
Fixes the OOM on the storage-cluster stack: a Tempo `service.name` tag lookup materialized **every span in the window** to answer with 8 strings.

## Cause

`service.name` is a *resource* attribute. `traceql.Attribute{Name: "service.name"}` has `Prop = SpanAttribute` and `Scope = ScopeNone` (both `iota` zero), so `TagValues` hit `case traceql.SpanAttribute`, failed the `Scope == ScopeSpan` guard that enables pushdown, fell out of the switch, and landed on `scanSpans(ctx, start, end, nil)` — a `fetch.Request` with **no conditions at all**, drained whole, then a `tracestorage.Span` (attribute maps included) allocated per row.

Measured on a live deployment before the fix — identical 307-byte response every time:

| window | time |
|---|---|
| 1 min | 36 ms |
| 10 min | 32 ms |
| 1 h | 747 ms |

Flat while served from the in-memory head, then a step up once sealed parts are in range. Grafana populating the dropdown over a multi-day range is that same scan across ~200M spans.

## Fix

`Source.TraceSeries` already existed in `oteldb/storage`, documented as the traces twin of `LogSeries` "so an embedder can build tag-name/tag-value responses without materializing spans". It was simply never on oteldb's `Source` interface, so nothing could reach it. Added there and to the routed `clusterquery` source. No dependency bump — the pinned version has it.

| Lookup | Now answered by |
|---|---|
| `resource.*` (incl. `service.name`) | `TraceSeries` → stream identity |
| `instrumentation.*`, `InstrumentationName/Version` | `TraceSeries` → stream scope |
| unscoped `.foo` | union of the attribute dictionary and the identities |
| `SpanStatusMessage` | `ColStatusMsg` dictionary |

The union matters: dropping either half silently hides values that exist, which is why the original code fell back to a scan for `ScopeNone` rather than pushing down half of it.

## The part I didn't expect

`forEachSpanTag` visits only the resource, instrumentation and span attribute *maps* — never intrinsics. An intrinsic's `Name` is empty, so the `name != attr.Name` guard rejected every entry. `SpanStatusMessage`, `SpanID`, `ParentID`, `TraceID`, `NestedSetLeft/Right/Parent`, `EventTimeSinceStart`, `LinkTraceID`, `LinkSpanID` all scanned the whole window and then returned **empty**.

Those now return empty up front. Two are also unbounded cardinality — a `trace:id` values request would have scanned the window *and* built a set of millions of distinct ids, a bigger gun than `service.name` and reachable from the same autocomplete surface.

## Still scans, legitimately

`RootSpanName`/`RootServiceName` (the empty-parent predicate is expressible as neither a column nor a stream enumeration) and event/link-scoped attributes (nested blob columns, no dictionary).

## Also

Values are sorted, so an autocomplete list no longer reshuffles between identical requests. That is what made `TestTraceTagValuesResourceScope` fail against the old code even though its content was already correct.

## Verification

`go test ./...` and `golangci-lint` clean. New tests were run against the pre-change code to confirm they bite: `ResourceScope`, `StatusMessage` and `InstrumentationIntrinsics` fail there, and nothing else does — so the pushdown changed no existing result.

## Known gap, not fixed here

`TagNames` (`/api/v2/search/tags`, the other autocomplete call) still scans unconditionally. Fixing it properly needs a `TraceKeys` on the storage side — `recordengine.Engine.Keys` and `clusterKeys` are already signal-generic, so it is a ~15-line mirror of `LogKeys`, but it is a separate repo. Meanwhile oteldb/storage#442 + #443 make it fail loudly instead of taking the process down.