### PR TITLE
feat(storagebackend): wire storage 0.43.0 per-query read budgets

### DIFF
--- a/cmd/odbselect/app.go
+++ b/cmd/odbselect/app.go
@@ -42,7 +42,7 @@ func newApp(ctx context.Context, cfg Config, lg *zap.Logger, m *sdkapp.Telemetry
 		servers: map[string]*http.Server{},
 	}
 
-	backend := storagebackend.NewQuery(clusterquery.New(rt))
+	backend := storagebackend.NewQuery(clusterquery.New(rt, cfg.maxQueryBytes()))
 
 	if err := app.setupAPIs(backend); err != nil {
 		_ = rt.Close(ctx)

--- a/cmd/odbselect/config.go
+++ b/cmd/odbselect/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-faster/errors"
 
 	"github.com/oteldb/oteldb/internal/config"
+	"github.com/oteldb/oteldb/internal/xbytes"
 )
 
 // Config is the odbselect configuration.
@@ -23,8 +24,27 @@ type Config struct {
 	Pyroscope config.Pyroscope `json:"pyroscope" yaml:"pyroscope"`
 	// Health configures the health/readiness listener.
 	Health config.HealthCheck `json:"health" yaml:"health"`
+	// MaxQueryBytes caps what one query may hold before it is refused. An aggregator needs its own
+	// bound: it holds every shard owner's answer at once to merge them, so the owners' limits do not
+	// add up to one here. Unset ⇒ a share of the detected process budget; 0 ⇒ unbounded.
+	MaxQueryBytes *xbytes.Bytes `json:"max_query_bytes" yaml:"max_query_bytes"`
 	// ShutdownTimeout bounds how long in-flight queries are given to finish. Zero ⇒ 30s.
 	ShutdownTimeout time.Duration `json:"shutdown_timeout" yaml:"shutdown_timeout"`
+}
+
+// maxQueryBytes resolves the per-query read bound for [clusterquery.New], inverting the polarity of
+// the config so it reads like the storage engine's cache settings: unset means "size it from the
+// process budget" (0) and an explicit 0 means "unbounded" (negative).
+func (cfg *Config) maxQueryBytes() int64 {
+	if cfg.MaxQueryBytes == nil {
+		return 0
+	}
+
+	if n := int64(*cfg.MaxQueryBytes); n > 0 {
+		return n
+	}
+
+	return -1
 }
 
 // enabled reports whether an API with this bind should be served. A bind of "-" disables it, which

--- a/docs/storage-integration.md
+++ b/docs/storage-integration.md
@@ -120,9 +120,20 @@ So the pushdown path is: `PushableMatchers` → `AggregateMetricsNamed` → `Mat
   a merge buffers its output part encoded in RAM, so free space alone cannot bound it. Unlike the
   caches oteldb adds no default — unset passes 0 through and the library derives a share of
   `GOMEMLIMIT`; negative is unbounded.
-- **Decode scope:** the record queriers install a `fetch.Scope` on the context
-  (`internal/storagebackend/scope.go`) so the reads of one engine call are admitted against the
-  decode budget once. The metrics path threads a `Scope` through `fetch.Request` directly. The
+- **Query read budget:** `storage.max_query_bytes` (→ `storage.Options.MaxQueryBytes`) caps what a
+  single query may hold before it is refused with `readbudget.ErrExceeded`. It closes the gap
+  `decode_memory_bytes` leaves: that budget queues concurrent metric queries behind a shared ceiling
+  but admits an over-budget query *alone* rather than refusing it, and it never covered the record
+  engines at all. Polarity follows the caches, not the library: unset defers to the library default
+  (a share of the detected process budget), an explicit `0` disables the bound. The record engines
+  reserve an estimate from part metadata before reading and release it when the iterator closes;
+  enumeration reads (tag values, series and key lookups) are *not* admitted, because a distinct
+  set's size is not predictable up front. `cmd/odbselect` carries its own `max_query_bytes`: an
+  aggregator holds every owner's answer at once to merge them, so the owners' limits do not add up
+  to one there, and its allowance is what the fan-out declares to each owner.
+- **Decode scope:** the record queriers install a `fetch.Scope` and the query's read budget on the
+  context (`internal/storagebackend/scope.go`, `Backend.queryContext`) so the reads of one engine
+  call are admitted against the decode budget once and bounded by one allowance. The metrics path threads a `Scope` through `fetch.Request` directly. The
   boundary is one engine call, not one HTTP request: the LogQL/TraceQL engines own the per-request
   boundary above the querier, so a query evaluating several pipeline nodes still opens a scope per
   node.

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.159.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.42.1-0.20260830154456-8fbc4a8d372a
+	github.com/oteldb/storage v0.43.0
 	github.com/pierrec/lz4/v4 v4.1.29
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1
@@ -239,7 +239,7 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.45.0
+	github.com/aws/aws-sdk-go-v2 v1.45.1
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.33.0
 	github.com/aws/aws-sdk-go-v2/credentials v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/aws/aws-msk-iam-sasl-signer-go v1.0.4/go.mod h1:MVYeeOhILFFemC/XlYTCl
 github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
 github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
-github.com/aws/aws-sdk-go-v2 v1.45.0 h1:Fjxm4nBOZtZu9ba/E0txJMGMysAEhLonbWptbqAxKx0=
-github.com/aws/aws-sdk-go-v2 v1.45.0/go.mod h1:bttEH6JqnUL8LepvDVfdrds/fZ5bCIxzpe3abyUrhDU=
+github.com/aws/aws-sdk-go-v2 v1.45.1 h1:iIoG3NaLhV6UZpPXyPXlDj2I9oS8tV/nMcMnITCC6Ks=
+github.com/aws/aws-sdk-go-v2 v1.45.1/go.mod h1:bttEH6JqnUL8LepvDVfdrds/fZ5bCIxzpe3abyUrhDU=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18 h1:LAfOuhAH331fmOjTQpAaOlH+Ftn7RzSDJ2VFwjdMMy4=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.18/go.mod h1:4e5xhuXHx1e4U9EthvbPP1r/DIMp5c2823OL8karzcM=
 github.com/aws/aws-sdk-go-v2/config v1.8.3/go.mod h1:4AEiLtAb8kLs7vgw2ZV3p2VZ1+hBavOc84hqxVNpCyw=
@@ -1029,8 +1029,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.42.1-0.20260830154456-8fbc4a8d372a h1:HR6J03rfRQUWmichTtjVDoUFSVFPvRe+zTqa4OurLIk=
-github.com/oteldb/storage v0.42.1-0.20260830154456-8fbc4a8d372a/go.mod h1:QG9F3+Wsc7QQC55ckoIMKIYyfeupMDWVVFmFm0QK9WQ=
+github.com/oteldb/storage v0.43.0 h1:fYOiPbo6MChM9ZvhAk4VbzDFrwaN8oF482L6ld0sflk=
+github.com/oteldb/storage v0.43.0/go.mod h1:yEwwy2qOjuKxJ5ZjnOHQJfSrldDNhTLWSz/jMd2gHCM=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/clusterquery/backend_test.go
+++ b/internal/clusterquery/backend_test.go
@@ -29,7 +29,7 @@ func TestBackendServesFromCluster(t *testing.T) {
 		keys[1]: {"http_requests_total"},
 	})
 
-	b := storagebackend.NewQuery(clusterquery.New(openRouter(t, endpoint, 1, shards)))
+	b := storagebackend.NewQuery(clusterquery.New(openRouter(t, endpoint, 1, shards), 0))
 
 	q, err := b.Querier(0, 1000)
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestBackendServesFromCluster(t *testing.T) {
 func TestBackendRefusesIngest(t *testing.T) {
 	t.Parallel()
 
-	b := storagebackend.NewQuery(clusterquery.New(nil))
+	b := storagebackend.NewQuery(clusterquery.New(nil, 0))
 
 	require.ErrorIs(t, b.WriteMetrics(t.Context(), sigmetric.Metrics{}), storagebackend.ErrNoEngine)
 	require.ErrorIs(t, b.MaintainNow(t.Context()), storagebackend.ErrNoEngine)

--- a/internal/clusterquery/budget_test.go
+++ b/internal/clusterquery/budget_test.go
@@ -1,0 +1,46 @@
+package clusterquery_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage/readbudget"
+
+	"github.com/oteldb/oteldb/internal/clusterquery"
+)
+
+// The aggregator needs a bound of its own: it holds every shard owner's answer at once to merge
+// them, so the owners' individual limits do not add up to one here.
+func TestSourceQueryBudget(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("sized from the configured limit", func(t *testing.T) {
+		t.Parallel()
+
+		b := readbudget.From(clusterquery.New(nil, 4096).WithQueryBudget(ctx))
+		require.NotNil(t, b)
+		assert.Equal(t, int64(4096), b.Remaining())
+	})
+
+	t.Run("negative leaves reads unbounded", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, readbudget.From(clusterquery.New(nil, -1).WithQueryBudget(ctx)))
+	})
+
+	// A nested install would hand the inner call a fresh allowance and uncap the query it was meant
+	// to bound.
+	t.Run("idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		src := clusterquery.New(nil, 4096)
+		outer := src.WithQueryBudget(ctx)
+
+		assert.Equal(t, readbudget.From(outer), readbudget.From(src.WithQueryBudget(outer)))
+	})
+}

--- a/internal/clusterquery/source.go
+++ b/internal/clusterquery/source.go
@@ -13,8 +13,11 @@
 package clusterquery
 
 import (
+	"context"
+
 	"github.com/oteldb/storage/cluster"
 	"github.com/oteldb/storage/cluster/router"
+	"github.com/oteldb/storage/readbudget"
 	"github.com/oteldb/storage/signal"
 
 	"github.com/oteldb/oteldb/internal/storagebackend"
@@ -23,13 +26,31 @@ import (
 // Source is a read-only view of a storage cluster, resolved through the ring.
 type Source struct {
 	rt *router.Router
+	// maxQueryBytes bounds one query's read memory on this process. An aggregator needs its own
+	// bound: it holds every owner's answer at once to merge them, so the owners' individual limits
+	// do not add up to one here.
+	maxQueryBytes int64
 }
 
 var _ storagebackend.Source = (*Source)(nil)
 
-// New returns a Source over rt.
-func New(rt *router.Router) *Source {
-	return &Source{rt: rt}
+// New returns a Source over rt, bounding each query to maxQueryBytes of read memory. Zero sizes the
+// bound from the detected process budget; negative leaves reads unbounded.
+func New(rt *router.Router, maxQueryBytes int64) *Source {
+	return &Source{rt: rt, maxQueryBytes: readbudget.ProcessShare(maxQueryBytes)}
+}
+
+// WithQueryBudget implements [storagebackend.Source].
+//
+// The allowance installed here is also what the fan-out declares to each owner, so a shard stops
+// serializing an answer this process has no room to accept. Owners may only use it to tighten their
+// own limit, never to raise it.
+func (s *Source) WithQueryBudget(ctx context.Context) context.Context {
+	if readbudget.From(ctx) != nil {
+		return ctx
+	}
+
+	return readbudget.With(ctx, readbudget.New(s.maxQueryBytes))
 }
 
 // shardKeys returns the shard keys a tenant's reads fan out across, in index order.

--- a/internal/clusterquery/source_test.go
+++ b/internal/clusterquery/source_test.go
@@ -211,7 +211,7 @@ func TestFetcherGathersEveryShard(t *testing.T) {
 
 	startNode(t, endpoint, "node-a", held)
 
-	src := clusterquery.New(openRouter(t, endpoint, 1, shards))
+	src := clusterquery.New(openRouter(t, endpoint, 1, shards), 0)
 
 	assert.Equal(t, []string{"a", "b", "c", "d"}, drainNames(t, src.Fetcher(""), nil))
 
@@ -239,7 +239,7 @@ func TestFetcherReappliesMatchers(t *testing.T) {
 		string(cluster.DefaultTenant): {"kept", "dropped"},
 	})
 
-	src := clusterquery.New(openRouter(t, endpoint, 1, 1))
+	src := clusterquery.New(openRouter(t, endpoint, 1, 1), 0)
 
 	// No Spec, so nothing about this matcher reaches the peer.
 	matchers := []fetch.Matcher{{
@@ -272,7 +272,7 @@ func TestSeriesFailsOverAbsentOwner(t *testing.T) {
 	require.Eventually(t, func() bool { return len(rt.Members()) == 2 },
 		10*time.Second, 10*time.Millisecond, "router sees both nodes")
 
-	src := clusterquery.New(rt)
+	src := clusterquery.New(rt, 0)
 
 	got, err := src.MetricSeries(t.Context(), "", nil, 1, 100)
 	require.NoError(t, err)
@@ -290,7 +290,7 @@ func TestSeriesEmptyWhenEveryOwnerDisclaims(t *testing.T) {
 	endpoint := etcdtest.Start(t)
 	startNode(t, endpoint, "node-a", map[string][]string{})
 
-	src := clusterquery.New(openRouter(t, endpoint, 1, 1))
+	src := clusterquery.New(openRouter(t, endpoint, 1, 1), 0)
 
 	got, err := src.MetricSeries(t.Context(), "", nil, 1, 100)
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func TestLogKeysUnionsShards(t *testing.T) {
 	}
 	node.keys[keys[1]] = []cluster.KeyInfo{{Key: []byte("host"), Scope: uint8(4)}}
 
-	src := clusterquery.New(openRouter(t, endpoint, 1, shards))
+	src := clusterquery.New(openRouter(t, endpoint, 1, shards), 0)
 
 	got, err := src.LogKeys(t.Context(), "", 1, 100)
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestTraceByIDNarrowsToOneTrace(t *testing.T) {
 		string(cluster.DefaultTenant): {"aaa", "bbb", "aaa", "ccc"},
 	}
 
-	src := clusterquery.New(openRouter(t, endpoint, 1, 1))
+	src := clusterquery.New(openRouter(t, endpoint, 1, 1), 0)
 
 	rows := func(id string) []string {
 		t.Helper()

--- a/internal/storagebackend/config.go
+++ b/internal/storagebackend/config.go
@@ -42,6 +42,16 @@ type Config struct {
 	// concurrency cannot drive the live heap past the process memory limit. Enabled by default,
 	// fitted to the detected memory limit minus the caches and headroom; set to 0 to disable.
 	DecodeMemoryBytes *xbytes.Bytes `json:"decode_memory_bytes" yaml:"decode_memory_bytes"`
+	// MaxQueryBytes caps what a single query may hold before it is refused. It is the bound
+	// DecodeMemoryBytes leaves open: that budget queues concurrent metric queries behind a shared
+	// ceiling but admits an over-budget query alone rather than refusing it, and the record engines
+	// (logs, traces, profiles) were not covered by it at all — so one unselective read had nothing
+	// between it and the process memory. Unset ⇒ the library default (a share of the detected
+	// process budget); 0 ⇒ unbounded, restoring the pre-0.43.0 behavior.
+	//
+	// It covers record fetches. The enumeration reads (tag values, series and key lookups) are not
+	// admitted, because a distinct set's size is not predictable from part metadata.
+	MaxQueryBytes *xbytes.Bytes `json:"max_query_bytes" yaml:"max_query_bytes"`
 	// MergeMemoryBytes caps the memory all concurrent merges together may hold, and through that the
 	// size a merged part reaches before it is sealed. It is the write-side counterpart of
 	// DecodeMemoryBytes: on a backend that takes objects whole a merge holds its output part encoded

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -80,7 +80,7 @@ func (n *logStreamNode) Traverse(cb logqlengine.NodeVisitor) error { return cb(n
 // The fetch answers with a superset (it keeps every row tying at the boundary timestamp), so the
 // sort+truncate below still decides the exact result.
 func (n *logStreamNode) EvalPipeline(ctx context.Context, params logqlengine.EvalParams) (logqlengine.EntryIterator, error) {
-	ctx = queryScope(ctx)
+	ctx = n.q.b.queryContext(ctx)
 
 	lo, hi := fetchWindow(params.Start, params.End)
 	batches, _, err := n.fetchBatches(ctx, lo, hi, fetchOptions{

--- a/internal/storagebackend/logs_sampling.go
+++ b/internal/storagebackend/logs_sampling.go
@@ -60,7 +60,7 @@ func (n *bucketSamplingNode) EvalSample(ctx context.Context, params logqlengine.
 // per output step in [params.Start, params.End], each holding the per-group sampled total over the
 // trailing window (step-window, step].
 func (n *bucketSamplingNode) EvalBucketedSample(ctx context.Context, params logqlengine.EvalParams, window time.Duration) (logqlengine.StepIterator, error) {
-	ctx = queryScope(ctx)
+	ctx = n.src.q.b.queryContext(ctx)
 
 	step := params.Step
 	if step <= 0 {

--- a/internal/storagebackend/open.go
+++ b/internal/storagebackend/open.go
@@ -105,7 +105,7 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 	caches := resolveCacheSettings(cfg)
 	opts = append(opts, cacheOptions(caches)...)
 
-	store, err := storage.Open(ctx, storage.Options{}, opts...)
+	store, err := storage.Open(ctx, storage.Options{MaxQueryBytes: caches.MaxQuery}, opts...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "open storage")
 	}
@@ -223,6 +223,7 @@ type cacheSettings struct {
 	DecodeCache    int64
 	DecodeMemory   int64
 	MergeMemory    int64
+	MaxQuery       int64
 	AggregateStats bool
 }
 
@@ -244,6 +245,13 @@ func resolveCacheSettings(cfg Config) cacheSettings {
 	// Merge memory has no oteldb-side default: unset stays 0, which the library resolves from the
 	// same memory limit this file's defaults are derived from.
 	s.MergeMemory = resolveCacheBytes(cfg.MergeMemoryBytes, func() int64 { return 0 })
+	// The per-query read bound inverts the polarity the library uses, to match the caches above:
+	// unset means "let the library size it from the memory limit" (0), and an explicit 0 means
+	// "disable", which the library spells as a negative.
+	s.MaxQuery = resolveCacheBytes(cfg.MaxQueryBytes, func() int64 { return 0 })
+	if cfg.MaxQueryBytes != nil && s.MaxQuery == 0 {
+		s.MaxQuery = -1
+	}
 	return s
 }
 

--- a/internal/storagebackend/profiles.go
+++ b/internal/storagebackend/profiles.go
@@ -97,7 +97,7 @@ func (q *ProfileQuerier) LabelValues(ctx context.Context, label string, opts pro
 // each sample's content-addressed stack to function frames, and merges them into a single
 // flamegraph tree.
 func (q *ProfileQuerier) SelectMergeProfile(ctx context.Context, params profilestorage.SelectProfileParams) (*profilestorage.FlameTree, error) {
-	ctx = queryScope(ctx)
+	ctx = q.b.queryContext(ctx)
 
 	matchers, err := profileFetchMatchers(&params.Type, params.Matchers)
 	if err != nil {

--- a/internal/storagebackend/query_budget_internal_test.go
+++ b/internal/storagebackend/query_budget_internal_test.go
@@ -1,0 +1,34 @@
+package storagebackend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oteldb/oteldb/internal/xbytes"
+)
+
+// The config inverts the storage library's polarity so it reads like the cache settings beside it:
+// there, an explicit 0 disables. Getting this backwards would silently leave reads unbounded for an
+// operator who asked for a limit, or refuse every query for one who asked for none.
+func TestResolveMaxQueryBytes(t *testing.T) {
+	t.Parallel()
+
+	size := func(n int64) *xbytes.Bytes { b := xbytes.Bytes(n); return &b }
+
+	for _, tc := range []struct {
+		name string
+		cfg  *xbytes.Bytes
+		want int64
+	}{
+		{"unset defers to the library default", nil, 0},
+		{"explicit size is passed through", size(64 << 20), 64 << 20},
+		{"explicit zero disables the bound", size(0), -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, resolveCacheSettings(Config{MaxQueryBytes: tc.cfg}).MaxQuery)
+		})
+	}
+}

--- a/internal/storagebackend/query_budget_test.go
+++ b/internal/storagebackend/query_budget_test.go
@@ -1,0 +1,126 @@
+package storagebackend_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/backend"
+	"github.com/oteldb/storage/readbudget"
+
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// budgetSpy counts the per-query budget installs a [storagebackend.Source] is asked for, and keeps
+// the allowance each one produced. It delegates everything else to the engine underneath.
+type budgetSpy struct {
+	storagebackend.Source
+
+	calls    int
+	budgets  []*readbudget.Budget
+	installs []context.Context
+}
+
+func (s *budgetSpy) WithQueryBudget(ctx context.Context) context.Context {
+	s.calls++
+	out := s.Source.WithQueryBudget(ctx)
+	s.budgets = append(s.budgets, readbudget.From(out))
+	s.installs = append(s.installs, ctx)
+
+	return out
+}
+
+// openSpied builds a read-only backend whose Source records every per-query budget install.
+func openSpied(
+	t *testing.T, maxQueryBytes int64,
+) (spy *budgetSpy, b *storagebackend.Backend, start, end time.Time) {
+	t.Helper()
+
+	ctx := context.Background()
+	store, err := storage.Open(ctx, storage.Options{MaxQueryBytes: maxQueryBytes},
+		storage.WithBackend(backend.Memory()),
+		storage.WithDurability(storage.DurabilityEphemeral),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	start = time.Now().Add(-10 * time.Minute).Truncate(time.Second)
+	const span = 4 * time.Minute
+	require.NoError(t, storagebackend.New(store).ConsumeLogs(ctx, genSpreadLogs(4000, start, span)))
+
+	spy = &budgetSpy{Source: store}
+
+	return spy, storagebackend.NewQuery(spy), start, start.Add(span)
+}
+
+func evalLogQL(t *testing.T, b *storagebackend.Backend, query string, start, end time.Time) error {
+	t.Helper()
+
+	ctx := context.Background()
+	engine, err := logqlengine.NewEngine(b.Logs(), logqlengine.Options{})
+	require.NoError(t, err)
+
+	q, err := engine.NewQuery(ctx, query)
+	require.NoError(t, err)
+
+	_, err = q.Eval(ctx, logqlengine.EvalParams{
+		Start: start, End: end, Step: 30 * time.Second,
+		Direction: logqlengine.DirectionForward, Limit: -1,
+	})
+
+	return err
+}
+
+// The engine call must open the budget itself. Without this the storage library still bounds each
+// individual fetch, so the query is not unbounded — but the several fetches one query makes each
+// take a fresh allowance, and nothing bounds the query as a whole.
+func TestQueryBudgetInstalledAtEngineBoundary(t *testing.T) {
+	t.Parallel()
+
+	spy, b, start, end := openSpied(t, 1<<30)
+
+	require.NoError(t, evalLogQL(t, b, `{service_name="api"}`, start, end))
+
+	require.NotZero(t, spy.calls, "the engine call did not open a query budget")
+	for i, ctx := range spy.installs {
+		assert.Nil(t, readbudget.From(ctx), "install %d was handed a ctx that already had a budget", i)
+	}
+	for i, b := range spy.budgets {
+		assert.NotNil(t, b, "install %d produced no allowance", i)
+	}
+}
+
+// The allowance must come back when the query ends. A reservation held past the query would shrink
+// every later query until the process answered nothing.
+func TestQueryBudgetReleasedBetweenQueries(t *testing.T) {
+	t.Parallel()
+
+	spy, b, start, end := openSpied(t, 1<<30)
+
+	for range 3 {
+		require.NoError(t, evalLogQL(t, b, `{service_name="api"}`, start, end))
+	}
+
+	require.NotEmpty(t, spy.budgets)
+	for i, budget := range spy.budgets {
+		require.NotNil(t, budget)
+		assert.Equal(t, int64(1<<30), budget.Remaining(),
+			"query %d ended still holding %d bytes", i, int64(1<<30)-budget.Remaining())
+	}
+}
+
+// A configured bound must actually reach the record read path, not merely be stored.
+func TestQueryBudgetRefusesOversizedRead(t *testing.T) {
+	t.Parallel()
+
+	_, b, start, end := openSpied(t, 1)
+
+	err := evalLogQL(t, b, `{service_name="api"}`, start, end)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, readbudget.ErrExceeded)
+}

--- a/internal/storagebackend/scope.go
+++ b/internal/storagebackend/scope.go
@@ -29,3 +29,11 @@ func queryScope(ctx context.Context) context.Context {
 	}
 	return fetch.WithScope(ctx, fetch.NewScope())
 }
+
+// queryContext is the per-query boundary every engine call opens: a [fetch.Scope] so the query's
+// reads are admitted against the decode budget once, and a read-memory budget so the query is
+// refused before it materializes more than the process can hold. Both are idempotent, so a nested
+// call inherits the outer query's allowance instead of starting a fresh one.
+func (b *Backend) queryContext(ctx context.Context) context.Context {
+	return b.src.WithQueryBudget(queryScope(ctx))
+}

--- a/internal/storagebackend/source.go
+++ b/internal/storagebackend/source.go
@@ -68,6 +68,12 @@ type Source interface {
 	) ([]signal.Series, error)
 	// ProfileResolver resolves a tenant's content-addressed stack ids to frames.
 	ProfileResolver(ctx context.Context, tenant signal.TenantID) (*sigprofile.Resolver, error)
+
+	// WithQueryBudget returns ctx carrying one read-memory allowance for the query about to run, so
+	// the several fetches a single query makes share one bound instead of taking a fresh one each.
+	// It is idempotent: a ctx that already carries a budget is returned unchanged, since a nested
+	// install would hand the inner call a new allowance and uncap the query it was meant to bound.
+	WithQueryBudget(ctx context.Context) context.Context
 }
 
 var _ Source = (*storage.Storage)(nil)

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -47,7 +47,7 @@ var (
 // the first N candidates happen to match", which for a selective query is usually fewer than N and
 // often zero. The engine applies the limit once the matchers have run.
 func (q *TraceQuerier) SelectSpansets(ctx context.Context, params traceqlengine.SelectSpansetsParams) (iterators.Iterator[traceqlengine.Trace], error) {
-	ctx = queryScope(ctx)
+	ctx = q.b.queryContext(ctx)
 
 	traceIDs, pushed, err := q.candidateTraces(ctx, params)
 	if err != nil {


### PR DESCRIPTION
Wires the per-query read budget released in `github.com/oteldb/storage` v0.43.0.

## What was already working

The storage engine installs a budget per *fetch* on its own, so no single record fetch was unbounded once the dependency bumped. What was missing is the embedder seam: a query makes several fetches, and each took a fresh allowance, so nothing bounded the query as a whole — and nothing let an operator size or disable the bound.

## Changes

- `Backend.queryContext` opens the budget alongside the existing `fetch.Scope` at the four engine entry points (logs, bucketed sampling, traces, profiles). Both are idempotent, so a nested call inherits the outer query's allowance rather than starting a fresh one.
- `Source` gains `WithQueryBudget`, so a stateless query node provides one too. `*storage.Storage` already satisfies it.
- `storage.max_query_bytes` is passed to `storage.Open`, which previously hardcoded `Options{}`.
- `cmd/odbselect` carries its own `max_query_bytes`. An aggregator needs a bound of its own: it holds every shard owner's answer at once to merge them, so the owners' individual limits do not add up to one there. Its allowance is also what the fan-out declares to each owner.

**Polarity.** `max_query_bytes` follows the neighbouring cache settings rather than the library: unset defers to the library default (a share of the detected process budget), an explicit `0` disables. The library spells "disabled" as a negative, so the resolver inverts. Getting this backwards would silently leave reads unbounded for an operator who asked for a limit, which is why it has its own table test.

## Testing

`TestQueryBudgetInstalledAtEngineBoundary` and `TestQueryBudgetReleasedBetweenQueries` use a `Source` spy to assert the boundary is opened once per engine call, is handed a ctx with no budget, and ends holding nothing. Both were checked against a reverted `logs.go` and **fail** without the seam.

Worth flagging: my first attempt at this test asserted an over-budget query is refused, and it passed with the wiring reverted — the library's own per-fetch bound already refuses it. That test is kept (as `TestQueryBudgetRefusesOversizedRead`) since it guards the bound reaching the record path at all, but it does not test this PR's change, and the two spy tests are what do.

Full suite green, `golangci-lint` clean.

## Not addressed

Enumeration reads — `ColumnValues`, and the per-signal Series and Keys lookups — are outside the budget upstream (oteldb/storage#445): a distinct set's size is not predictable from part metadata, so they need incremental accounting rather than an up-front estimate. This matters here because #1330 deliberately routes TraceQL tag-value lookups onto those paths. It is a large win over materializing spans, but onto a path with no bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)