### PR TITLE
build(dev/storage-cluster): give every service a CPU and memory limit

### DIFF
--- a/dev/local/storage-cluster/docker-compose.split.yml
+++ b/dev/local/storage-cluster/docker-compose.split.yml
@@ -29,6 +29,14 @@ x-odb-process: &odb-process
     - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
     - OTEL_METRIC_EXPORT_INTERVAL=5000
   restart: unless-stopped
+  # Both halves are stateless, so their limit is not sizing a working set -- it is the ceiling a
+  # single query may drive this process to. The sdk turns it into GOMEMLIMIT at startup, so the
+  # runtime collects hard before the cgroup kills anything. Overridden per half below.
+  deploy:
+    resources:
+      limits:
+        cpus: "2"
+        memory: 1g
   depends_on:
     etcd:
       condition: service_healthy
@@ -44,6 +52,12 @@ services:
     ports:
       - "24317:4317"  # OTLP gRPC
       - "19291:19291" # Prometheus remote write
+    # Decodes and routes; it holds a batch at a time, not a result set.
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 1g
 
   # Read half.
   odbselect:
@@ -57,6 +71,13 @@ services:
       - "13100:3100" # Loki / LogQL
       - "13200:3200" # Tempo / TraceQL
       - "14040:4040" # Pyroscope / ProfileQL
+    # The aggregator gets the most headroom of the two: it holds every owner's answer at once to
+    # merge them, so it is the process a single unselective query drives hardest.
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 4g
 
   # Ingests through the split write path instead of oteldb-2's embedded one.
   server:

--- a/dev/local/storage-cluster/docker-compose.yml
+++ b/dev/local/storage-cluster/docker-compose.yml
@@ -47,6 +47,17 @@ x-oteldb-node: &oteldb-node
     - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4317
     - OTEL_METRIC_EXPORT_INTERVAL=5000
   restart: unless-stopped
+  # A limit here is not just a blast radius: the sdk reads the cgroup at startup and sets GOMAXPROCS
+  # from the CPU quota and GOMEMLIMIT from the memory limit, and oteldb sizes its read cache, decode
+  # cache, decode-admission budget and max_query_bytes off that same GOMEMLIMIT. So the number below
+  # is what makes the process back off and refuse work, rather than what decides who the OOM killer
+  # takes. Without it every service sees the whole 30 GiB host and sizes itself for a machine it does
+  # not have to itself.
+  deploy:
+    resources:
+      limits:
+        cpus: "4"
+        memory: 4g
   depends_on:
     etcd:
       condition: service_healthy
@@ -82,6 +93,11 @@ services:
       interval: 2s
       timeout: 2s
       retries: 30
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 1g
 
   oteldb-1:
     <<: *oteldb-node
@@ -134,6 +150,12 @@ services:
       - ./odbadmin.yml:/etc/oteldb/odbadmin.yml:ro
     ports:
       - "38090:8090" # cluster-aggregated admin panel (8090/18090/28090 are the per-node ones)
+    # Overrides the node anchor's limit: this one holds no engine, it only merges peer reports.
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 512m
     depends_on:
       - etcd
       - oteldb-1
@@ -156,6 +178,11 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://oteldb-2:4317
       - OTEL_RESOURCE_ATTRIBUTES=service.name=server
       - OTEL_METRIC_EXPORT_INTERVAL=5000
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 256m
     depends_on:
       - oteldb-2
 
@@ -175,6 +202,11 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://oteldb-1:4317
       - OTEL_RESOURCE_ATTRIBUTES=service.name=client
       - OTEL_METRIC_EXPORT_INTERVAL=5000
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 256m
     depends_on:
       - oteldb-1
       - server
@@ -190,6 +222,11 @@ services:
       # The ring's front door. The split overlay points this at odbingest instead.
       - OTELDB_OTLP_ENDPOINT=oteldb-1:4317
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 1g
     depends_on:
       - oteldb-1
 
@@ -207,5 +244,10 @@ services:
       - ./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
       - ./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/default.yml:ro
       - ./grafana/dashboards:/etc/grafana/dashboards:ro
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: 1g
     depends_on:
       - oteldb-1


### PR DESCRIPTION
Re-lands the commit that was left behind when #1334 merged — that PR carried two commits and only the query-budget one landed on main.

## Why

Without a limit each process sees the whole host and sizes itself for a machine it does not have to itself. On the dev cluster odbselect reached **8.5 GiB** answering a single routed trace-by-id (oteldb/storage#447) and drove the host to a load average of 134, taking Grafana and ssh with it.

The number is not only a blast radius. `go-faster/sdk` reads the cgroup at startup and sets `GOMAXPROCS` from the CPU quota and `GOMEMLIMIT` from the memory limit (`app/app.go`), and oteldb sizes its read cache, decode cache, decode-admission budget and `max_query_bytes` off that same `GOMEMLIMIT` (`internal/storagebackend/open.go`). So the limit is what makes a process collect hard and refuse work, rather than what decides who the OOM killer takes.

## Allocation

| service | CPU | memory |
|---|---|---|
| oteldb-1/2/3, odbselect | 4 | 4 GiB |
| odbingest, otelcol, etcd, grafana | 2 | 1 GiB |
| odbadmin | 1 | 512 MiB |
| server, client (demo profile) | 1 | 256 MiB |

Total ceiling 21.0 GiB of the 30.5 GiB dev host, verified through `docker compose --profile demo config`. odbselect gets a node's worth because it holds every owner's answer at once to merge them, so it is the process a single unselective query drives hardest; odbingest holds a batch at a time and gets less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)