### PR TITLE
perf(storagebackend): answer TraceQuerier.TagNames without scanning spans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.159.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.159.0
 	github.com/oteldb/promql-engine v0.10.0
-	github.com/oteldb/storage v0.43.0
+	github.com/oteldb/storage v0.44.0
 	github.com/pierrec/lz4/v4 v4.1.29
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/common v0.70.1

--- a/go.sum
+++ b/go.sum
@@ -1029,8 +1029,8 @@ github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LD
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/oteldb/promql-engine v0.10.0 h1:CT3ffpna47gbih3Mff8moOHS4J9UVDP3gUf20ylNWIE=
 github.com/oteldb/promql-engine v0.10.0/go.mod h1:1zs5GoXb9XmZf+AC9TmsHgIg8VKVhQLxoORuM9JptiY=
-github.com/oteldb/storage v0.43.0 h1:fYOiPbo6MChM9ZvhAk4VbzDFrwaN8oF482L6ld0sflk=
-github.com/oteldb/storage v0.43.0/go.mod h1:yEwwy2qOjuKxJ5ZjnOHQJfSrldDNhTLWSz/jMd2gHCM=
+github.com/oteldb/storage v0.44.0 h1:d72+ru/+C3XIeI9bj2EGGqN4zBWOLVJInJ9ElqE8gS0=
+github.com/oteldb/storage v0.44.0/go.mod h1:yEwwy2qOjuKxJ5ZjnOHQJfSrldDNhTLWSz/jMd2gHCM=
 github.com/outscale/osc-sdk-go/v2 v2.34.0 h1:hHH5W9Fmgt6b8nGUmDyu4vVP+zqJ+W0zflzjgsGEGUQ=
 github.com/outscale/osc-sdk-go/v2 v2.34.0/go.mod h1:6J8WRznaSIEXXVHhhTXisGJQgvE5fYzbf8hAw7YIGfQ=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=

--- a/internal/clusterquery/series.go
+++ b/internal/clusterquery/series.go
@@ -62,17 +62,31 @@ func (s *Source) series(
 	return all, nil
 }
 
-// LogKeys implements [storagebackend.Source]. A key can appear on streams in more than one shard,
-// so the shards' answers are unioned with their scope bits OR-ed per distinct key.
+// LogKeys implements [storagebackend.Source].
 func (s *Source) LogKeys(
 	ctx context.Context, tenant signal.TenantID, start, end int64,
+) ([]storage.KeyInfo, error) {
+	return s.keys(ctx, signal.Log, tenant, start, end)
+}
+
+// TraceKeys implements [storagebackend.Source].
+func (s *Source) TraceKeys(
+	ctx context.Context, tenant signal.TenantID, start, end int64,
+) ([]storage.KeyInfo, error) {
+	return s.keys(ctx, signal.Trace, tenant, start, end)
+}
+
+// keys enumerates a tenant's distinct attribute keys across every shard. A key can appear on streams
+// in more than one shard, so the shards' answers are unioned with their scope bits OR-ed per key.
+func (s *Source) keys(
+	ctx context.Context, sig signal.Signal, tenant signal.TenantID, start, end int64,
 ) ([]storage.KeyInfo, error) {
 	scopes := map[string]uint8{}
 
 	for _, sk := range s.shardKeys(tenant) {
-		got, err := s.rt.Keys(ctx, signal.Log, sk, start, end)
+		got, err := s.rt.Keys(ctx, sig, sk, start, end)
 		if err != nil {
-			return nil, errors.Wrapf(err, "list log keys of shard %q", sk)
+			return nil, errors.Wrapf(err, "list %s keys of shard %q", sig, sk)
 		}
 
 		for _, k := range got {

--- a/internal/clusterquery/source_test.go
+++ b/internal/clusterquery/source_test.go
@@ -367,7 +367,7 @@ func TestTraceKeysEnumeratesTraceSignal(t *testing.T) {
 		{Key: []byte("db.system"), Scope: uint8(4)},
 	}
 
-	src := clusterquery.New(openRouter(t, endpoint, 1, shards))
+	src := clusterquery.New(openRouter(t, endpoint, 1, shards), 0)
 
 	got, err := src.TraceKeys(t.Context(), "", 1, 100)
 	require.NoError(t, err)

--- a/internal/clusterquery/source_test.go
+++ b/internal/clusterquery/source_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -56,6 +57,10 @@ type fakeNode struct {
 	// traceIDs maps a shard key to the trace id of each span row the node holds for it. When set,
 	// a read of that shard answers with those rows instead of the metric-shaped streams.
 	traceIDs map[string][]string
+
+	mu sync.Mutex
+	// keySignals records the signal of every key enumeration the node served.
+	keySignals []signal.Signal
 }
 
 func startNode(t *testing.T, endpoint, id string, held map[string][]string) *fakeNode {
@@ -137,8 +142,12 @@ func (n *fakeNode) series(
 }
 
 func (n *fakeNode) keyList(
-	_ context.Context, _ signal.Signal, shardKey string, _, _ int64,
+	_ context.Context, sig signal.Signal, shardKey string, _, _ int64,
 ) ([]cluster.KeyInfo, error) {
+	n.mu.Lock()
+	n.keySignals = append(n.keySignals, sig)
+	n.mu.Unlock()
+
 	if _, ok := n.held[shardKey]; !ok {
 		return nil, cluster.ErrShardAbsent
 	}
@@ -333,6 +342,50 @@ func TestLogKeysUnionsShards(t *testing.T) {
 	assert.Equal(t, []string{"host", "level"}, names)
 	assert.Equal(t, uint8(5), scopes["host"], "the scope bits of both shards")
 	assert.Equal(t, uint8(4), scopes["level"])
+
+	node.mu.Lock()
+	defer node.mu.Unlock()
+	assert.Equal(t, []signal.Signal{signal.Log, signal.Log}, node.keySignals)
+}
+
+// TestTraceKeysEnumeratesTraceSignal pins that the traces twin routes the enumeration under
+// [signal.Trace]: it shares the shard union with LogKeys, so only the signal tells the peers which
+// engine to read.
+func TestTraceKeysEnumeratesTraceSignal(t *testing.T) {
+	t.Parallel()
+
+	const shards = 2
+
+	endpoint := etcdtest.Start(t)
+
+	keys := shardKeys(shards)
+
+	node := startNode(t, endpoint, "node-a", map[string][]string{keys[0]: nil, keys[1]: nil})
+	node.keys[keys[0]] = []cluster.KeyInfo{{Key: []byte("http.method"), Scope: uint8(4)}}
+	node.keys[keys[1]] = []cluster.KeyInfo{
+		{Key: []byte("http.method"), Scope: uint8(1)},
+		{Key: []byte("db.system"), Scope: uint8(4)},
+	}
+
+	src := clusterquery.New(openRouter(t, endpoint, 1, shards))
+
+	got, err := src.TraceKeys(t.Context(), "", 1, 100)
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(got))
+	scopes := map[string]uint8{}
+
+	for _, k := range got {
+		names = append(names, string(k.Key))
+		scopes[string(k.Key)] = uint8(k.Scope)
+	}
+
+	assert.Equal(t, []string{"db.system", "http.method"}, names, "unioned and sorted")
+	assert.Equal(t, uint8(5), scopes["http.method"], "the scope bits of both shards")
+
+	node.mu.Lock()
+	defer node.mu.Unlock()
+	assert.Equal(t, []signal.Signal{signal.Trace, signal.Trace}, node.keySignals)
 }
 
 // spanBatch answers a trace read with one span row per trace id. The conditions a trace-by-id read

--- a/internal/storagebackend/source.go
+++ b/internal/storagebackend/source.go
@@ -57,6 +57,11 @@ type Source interface {
 	TraceSeries(
 		ctx context.Context, tenant signal.TenantID, matchers []fetch.Matcher, start, end int64,
 	) ([]signal.Series, error)
+	// TraceKeys enumerates the distinct attribute keys of a tenant's spans in [start, end] ns, each
+	// tagged with the scope(s) it appears in. It is the traces twin of LogKeys, and it is what lets a
+	// span-scoped tag-name lookup be answered from the parts' key dictionaries instead of by
+	// materializing every span in the window.
+	TraceKeys(ctx context.Context, tenant signal.TenantID, start, end int64) ([]storage.KeyInfo, error)
 	// Trace returns every span of one trace.
 	Trace(ctx context.Context, tenant signal.TenantID, traceID []byte) ([]*fetch.Batch, error)
 

--- a/internal/storagebackend/traces.go
+++ b/internal/storagebackend/traces.go
@@ -113,26 +113,62 @@ func (q *TraceQuerier) SearchTags(ctx context.Context, tags map[string]string, o
 
 // TagNames implements [tracestorage.Querier]. It enumerates the distinct attribute names seen on the
 // spans in the window, restricted to the requested scope.
+//
+// Neither half scans. Span-scoped names come from the parts' attribute-key dictionaries via
+// [Source.TraceKeys]; resource- and instrumentation-scoped names come from the stream identities via
+// [Source.TraceSeries], the same split [TraceQuerier.TagValues] makes. A scoped request only pays for
+// the half it asks about.
+//
+// The two sources cannot be swapped for one another. TraceKeys does report resource/scope bits, but
+// it derives them from the stream identity and also synthesizes the otel.scope.name/version labels,
+// which are intrinsics here rather than attributes — enumerating them as tag names would invent names
+// the scan never returned. So the identity half stays on TraceSeries, which carries exactly the
+// attribute maps the old per-span walk read.
+//
+// Like every enumeration path here the answer is a superset of the window: a part overlapping it
+// contributes its whole key dictionary. That is the autocomplete tradeoff [TraceQuerier.TagValues]
+// already documents.
 func (q *TraceQuerier) TagNames(ctx context.Context, opts tracestorage.TagNamesOptions) ([]tracestorage.TagName, error) {
-	spans, err := q.scanSpans(ctx, opts.Start, opts.End, nil)
-	if err != nil {
-		return nil, err
-	}
+	lo, hi := seriesWindow(opts.Start, opts.End)
 
 	seen := map[tracestorage.TagName]struct{}{}
-	for _, span := range spans {
-		forEachSpanTag(span, func(scope traceql.AttributeScope, name, _ string) {
-			if opts.Scope != traceql.ScopeNone && opts.Scope != scope {
-				return
+	add := func(scope traceql.AttributeScope, name string) {
+		if opts.Scope != traceql.ScopeNone && opts.Scope != scope {
+			return
+		}
+		seen[tracestorage.TagName{Scope: scope, Name: name}] = struct{}{}
+	}
+
+	if opts.Scope == traceql.ScopeNone || opts.Scope == traceql.ScopeSpan {
+		keys, err := q.b.src.TraceKeys(ctx, q.b.tenant, lo, hi)
+		if err != nil {
+			return nil, errors.Wrap(err, "trace keys")
+		}
+		for _, k := range keys {
+			if k.Scope&storage.KeyScopeRecord != 0 {
+				add(traceql.ScopeSpan, string(k.Key))
 			}
-			seen[tracestorage.TagName{Scope: scope, Name: name}] = struct{}{}
-		})
+		}
+	}
+
+	if opts.Scope == traceql.ScopeNone || opts.Scope == traceql.ScopeResource || opts.Scope == traceql.ScopeInstrumentation {
+		if err := q.forEachStreamAttr(ctx, lo, hi, func(scope traceql.AttributeScope, name, _ string) {
+			add(scope, name)
+		}); err != nil {
+			return nil, err
+		}
 	}
 
 	out := make([]tracestorage.TagName, 0, len(seen))
 	for tn := range seen {
 		out = append(out, tn)
 	}
+	slices.SortFunc(out, func(a, b tracestorage.TagName) int {
+		if c := cmp.Compare(a.Scope, b.Scope); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
 	return out, nil
 }
 
@@ -235,6 +271,14 @@ func (q *TraceQuerier) forEachStreamTag(
 ) error {
 	lo, hi := seriesWindow(opts.Start, opts.End)
 
+	return q.forEachStreamAttr(ctx, lo, hi, fn)
+}
+
+// forEachStreamAttr is [TraceQuerier.forEachStreamTag] over an already-resolved nanosecond window,
+// so the tag-name path can share it without building a [tracestorage.TagValuesOptions].
+func (q *TraceQuerier) forEachStreamAttr(
+	ctx context.Context, lo, hi int64, fn func(scope traceql.AttributeScope, name, value string),
+) error {
 	series, err := q.b.src.TraceSeries(ctx, q.b.tenant, nil, lo, hi)
 	if err != nil {
 		return errors.Wrap(err, "trace series")

--- a/internal/storagebackend/traces_tagnames_internal_test.go
+++ b/internal/storagebackend/traces_tagnames_internal_test.go
@@ -1,0 +1,209 @@
+package storagebackend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/traceql"
+	"github.com/oteldb/oteldb/internal/tracestorage"
+)
+
+// legacyTagNames is the scan-based TagNames this package used to ship, kept verbatim as the oracle
+// the enumeration-based one is diffed against: the whole point of the rewrite is that it answers
+// exactly the same set without materializing a span.
+func (q *TraceQuerier) legacyTagNames(ctx context.Context, opts tracestorage.TagNamesOptions) ([]tracestorage.TagName, error) {
+	spans, err := q.scanSpans(ctx, opts.Start, opts.End, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[tracestorage.TagName]struct{}{}
+	for _, span := range spans {
+		forEachSpanTag(span, func(scope traceql.AttributeScope, name, _ string) {
+			if opts.Scope != traceql.ScopeNone && opts.Scope != scope {
+				return
+			}
+			seen[tracestorage.TagName{Scope: scope, Name: name}] = struct{}{}
+		})
+	}
+
+	out := make([]tracestorage.TagName, 0, len(seen))
+	for tn := range seen {
+		out = append(out, tn)
+	}
+	return out, nil
+}
+
+// tagNamesFixture ingests two services, each with resource, instrumentation-scope and span
+// attributes of its own, plus a set instrumentation scope name/version — the intrinsics that must not
+// leak into the tag-name list even though the key dictionary reports them.
+func tagNamesFixture(t *testing.T) (b *Backend, start, end time.Time) {
+	t.Helper()
+
+	ctx := context.Background()
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	b = New(store)
+	ts := time.Now().Truncate(time.Second)
+
+	td := ptrace.NewTraces()
+
+	for i, svc := range []string{"frontend", "cart"} {
+		rs := td.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("service.name", svc)
+		rs.Resource().Attributes().PutStr("deployment.environment", "prod")
+		rs.Resource().Attributes().PutStr("resource.only."+svc, "x")
+
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.Scope().SetName("otelhttp")
+		ss.Scope().SetVersion("1.2.3")
+		ss.Scope().Attributes().PutStr("library.tier", "http")
+		ss.Scope().Attributes().PutStr("scope.only."+svc, "x")
+
+		sp := ss.Spans().AppendEmpty()
+		sp.SetTraceID(pcommon.TraceID([16]byte{byte(i + 1)}))
+		sp.SetSpanID(pcommon.SpanID([8]byte{byte(i + 1)}))
+		sp.SetName(svc + ".handle")
+		sp.Attributes().PutStr("http.method", "GET")
+		sp.Attributes().PutStr("span.only."+svc, "x")
+		sp.SetStartTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		sp.SetEndTimestamp(pcommon.Timestamp(ts.Add(time.Second).UnixNano()))
+	}
+
+	require.NoError(t, b.ConsumeTraces(ctx, td))
+
+	return b, ts.Add(-time.Minute), ts.Add(time.Minute)
+}
+
+// TestTraceTagNamesMatchesScan is the differential test for the rewrite: for every scope the API can
+// ask about, the enumeration-based answer must equal the scan-based one it replaced.
+func TestTraceTagNamesMatchesScan(t *testing.T) {
+	t.Parallel()
+
+	b, start, end := tagNamesFixture(t)
+	q := b.Traces()
+	ctx := context.Background()
+
+	for _, scope := range []traceql.AttributeScope{
+		traceql.ScopeNone,
+		traceql.ScopeResource,
+		traceql.ScopeSpan,
+		traceql.ScopeInstrumentation,
+	} {
+		t.Run(scope.String(), func(t *testing.T) {
+			opts := tracestorage.TagNamesOptions{Scope: scope, Start: start, End: end}
+
+			want, err := q.legacyTagNames(ctx, opts)
+			require.NoError(t, err)
+			require.NotEmpty(t, want, "the oracle must actually find something")
+
+			got, err := q.TagNames(ctx, opts)
+			require.NoError(t, err)
+
+			assert.ElementsMatch(t, want, got)
+		})
+	}
+}
+
+// The scoped names the fixture pins, spelled out so a regression names the attribute it lost.
+func TestTraceTagNamesPerScope(t *testing.T) {
+	t.Parallel()
+
+	b, start, end := tagNamesFixture(t)
+	ctx := context.Background()
+
+	names := func(scope traceql.AttributeScope) []string {
+		t.Helper()
+
+		got, err := b.Traces().TagNames(ctx, tracestorage.TagNamesOptions{Scope: scope, Start: start, End: end})
+		require.NoError(t, err)
+
+		out := make([]string, 0, len(got))
+		for _, tn := range got {
+			require.Equal(t, scope, tn.Scope)
+			out = append(out, tn.Name)
+		}
+
+		return out
+	}
+
+	assert.ElementsMatch(t,
+		[]string{"service.name", "deployment.environment", "resource.only.frontend", "resource.only.cart"},
+		names(traceql.ScopeResource))
+	assert.ElementsMatch(t,
+		[]string{"library.tier", "scope.only.frontend", "scope.only.cart"},
+		names(traceql.ScopeInstrumentation))
+	assert.ElementsMatch(t,
+		[]string{"http.method", "span.only.frontend", "span.only.cart"},
+		names(traceql.ScopeSpan))
+}
+
+// The instrumentation scope name/version are intrinsics, not attributes. TraceKeys reports them as
+// scope-scoped keys, so answering the identity half from it instead of from TraceSeries would invent
+// tag names the scan never returned.
+func TestTraceTagNamesExcludesScopeIntrinsics(t *testing.T) {
+	t.Parallel()
+
+	b, start, end := tagNamesFixture(t)
+
+	got, err := b.Traces().TagNames(context.Background(), tracestorage.TagNamesOptions{Start: start, End: end})
+	require.NoError(t, err)
+
+	for _, tn := range got {
+		assert.NotEqual(t, "otel.scope.name", tn.Name)
+		assert.NotEqual(t, "otel.scope.version", tn.Name)
+	}
+}
+
+// noFetchSource fails the test if the traces read seam is opened at all: TagNames must be answered
+// from the key and stream enumerations, never by materializing spans.
+type noFetchSource struct {
+	Source
+
+	t *testing.T
+}
+
+func (s noFetchSource) TraceFetcher(...signal.TenantID) fetch.Fetcher {
+	s.t.Helper()
+	s.t.Error("TagNames materialized spans: it opened the traces fetcher")
+
+	return emptyFetcher{}
+}
+
+type emptyFetcher struct{}
+
+func (emptyFetcher) Fetch(context.Context, fetch.Request) (fetch.Iterator, error) {
+	return fetch.NewSliceIterator(nil), nil
+}
+
+// The regression this whole change exists for (oteldb#1335): the fetcher is never opened.
+func TestTraceTagNamesDoesNotScan(t *testing.T) {
+	t.Parallel()
+
+	b, start, end := tagNamesFixture(t)
+	guarded := NewQuery(noFetchSource{Source: b.src, t: t})
+
+	for _, scope := range []traceql.AttributeScope{
+		traceql.ScopeNone,
+		traceql.ScopeResource,
+		traceql.ScopeSpan,
+		traceql.ScopeInstrumentation,
+	} {
+		got, err := guarded.Traces().TagNames(context.Background(),
+			tracestorage.TagNamesOptions{Scope: scope, Start: start, End: end})
+		require.NoError(t, err)
+		assert.NotEmpty(t, got, "scope %s still enumerates names", scope)
+	}
+}


### PR DESCRIPTION
Fixes #1335.

> **Blocked on oteldb/storage#448.** This branch needs `Storage.TraceKeys`, which does not exist in
> storage v0.43.0. It was developed against a local `replace` that is **not** committed here, so
> `go build ./...` fails on this branch until #448 merges and `go get -u github.com/oteldb/storage`
> bumps the dependency. Bump first, then this is ready for review.

## Problem

`TraceQuerier.TagNames` called `scanSpans(ctx, opts.Start, opts.End, nil)` — a full-window
materialization of every span — and then read only each span's attribute *keys*. The answer is
O(distinct keys); the work was O(all spans). On a 3-node cluster with ~1 day of telemetry
`GET /api/v2/search/tags` 500s with `get tag names: fetch spans: ... context deadline exceeded`.

## Fix

Neither half scans, mirroring the split #1330 made for `TagValues`:

| scope | source | cost |
|---|---|---|
| span | `Source.TraceKeys` — the parts' attribute-key dictionaries (new, oteldb/storage#448) | O(distinct keys) |
| resource, instrumentation | `Source.TraceSeries` — the stream identities | O(streams) |
| none | both, unioned | both |

A scoped request only pays for the half it asks about.

The identity half deliberately does *not* use `TraceKeys`' resource/scope bits, even though it
reports them. `TraceKeys` derives them from the stream identity and also synthesizes the
`otel.scope.name`/`otel.scope.version` labels, which are TraceQL *intrinsics* here, not attributes —
enumerating them as tag names would invent names the scan never returned. `TraceSeries` carries
exactly the attribute maps the old per-span walk read.

Like every enumeration path here the result is a superset of the window (a part overlapping it
contributes its whole key dictionary) — the autocomplete tradeoff `TagValues` already documents.

Output is now sorted by (scope, name); it was map order before.

### `SearchTags` was not changed

The issue notes `SearchTags` has the same shape, but the fix does not fall out. It is a *search*: it
returns the spans matching a tag set and duration bounds, so it must materialize whatever it
returns. Its cost belongs to predicate pushdown (`fetch.Conditions` on the tag equalities and
`ColDuration`, the machinery `buildTracePushdown` already has for TraceQL), which is a separate
change with its own correctness surface. Left alone rather than forced in here.

## Also

`Source` gains `TraceKeys`, implemented by `*storage.Storage` and by `clusterquery.Source` (whose
`LogKeys` shard-union body is now shared as a signal-generic `keys`).

## Tests

`internal/storagebackend/traces_tagnames_internal_test.go` keeps the old scan-based implementation
verbatim as `legacyTagNames` and diffs the new answer against it per scope, plus a guard `Source`
whose `TraceFetcher` fails the test if it is ever opened.

Every test was negative-controlled by mutating the production code:

| mutation | tests that failed |
|---|---|
| revert `TagNames` to the old scan | `TestTraceTagNamesDoesNotScan` |
| drop the `TraceSeries` (identity) half | `...DoesNotScan`, `...PerScope`, `...MatchesScan/{none,resource,instrumentation}` |
| accept every `TraceKeys` scope as a span name | `...ExcludesScopeIntrinsics`, `...PerScope`, `...MatchesScan/{none,span}` |
| ignore the requested scope filter | `...PerScope`, `...MatchesScan/{resource,instrumentation}` |
| `clusterquery.TraceKeys` routing `signal.Log` | `TestTraceKeysEnumeratesTraceSignal` |

Note the equivalence test alone cannot detect a revert (reverted, new *is* old) — that is what the
`DoesNotScan` guard is for.

`go test ./...` passes (with the local `replace`); `golangci-lint run` clean on both touched
packages.