### PR TITLE
feat(odbbackup): backup and restore for the storage backend

### DIFF
--- a/cmd/odbbackup/main.go
+++ b/cmd/odbbackup/main.go
@@ -1,3 +1,11 @@
+// Command odbbackup writes an oteldb backup to a directory.
+//
+// It speaks two backends, selected with -backend: "clickhouse" (the default) dumps chstorage's
+// tables in ClickHouse Native format, and "storage" dumps the embedded storage engine through its
+// read seam. The two are separate formats — a backup restores into the backend it came from — but
+// they are one command so an operator has one tool to learn.
+//
+// See internal/storagebackup for the storage backend's layout and its fidelity contract.
 package main
 
 import (
@@ -6,18 +14,30 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/sdk/zctx"
 	"go.uber.org/zap"
 
 	"github.com/oteldb/oteldb/internal/chstorage"
+	"github.com/oteldb/oteldb/internal/storagebackup"
 )
 
 func run(ctx context.Context) error {
 	var (
-		path = flag.String("path", "./backup", "Backup destination directory")
-		dsn  = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL")
+		backend = flag.String("backend", "clickhouse", "Storage backend to back up: clickhouse or storage")
+		path    = flag.String("path", "./backup", "Backup destination directory")
+
+		dsn = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL (clickhouse backend)")
+
+		storageConfig = flag.String("storage-config", "", "oteldb config file whose storage block describes the engine (storage backend)")
+		storageDir    = flag.String("storage-dir", "", "Data directory of a single-node file backend, instead of -storage-config (storage backend)")
+		signals       = flag.String("signals", "", "Comma-separated signals to back up: log, trace, metric (default: all, storage backend)")
+		from          = flag.String("from", "", "Back up data at or after this time (RFC3339 or YYYY-MM-DD, UTC); empty starts at the oldest retained")
+		to            = flag.String("to", "", "Back up data before this time (RFC3339 or YYYY-MM-DD, UTC); empty ends at now minus -lag")
+		lag           = flag.Duration("lag", storagebackup.DefaultLag, "Keep the window this far behind the ingest edge, so the newest day is not scanned while it fills")
+		resume        = flag.Bool("resume", false, "Skip days already present in the destination, resuming an interrupted backup")
 	)
 	flag.Parse()
 
@@ -30,13 +50,74 @@ func run(ctx context.Context) error {
 	}()
 	ctx = zctx.Base(ctx, lg)
 
-	d, err := chstorage.Dial(ctx, *dsn, chstorage.DialOptions{})
-	if err != nil {
-		return errors.Wrap(err, "dial clickhouse")
-	}
-	backup := chstorage.NewBackup(d, chstorage.DefaultTables(), lg.Named("backup"))
+	switch *backend {
+	case "clickhouse":
+		d, err := chstorage.Dial(ctx, *dsn, chstorage.DialOptions{})
+		if err != nil {
+			return errors.Wrap(err, "dial clickhouse")
+		}
+		backup := chstorage.NewBackup(d, chstorage.DefaultTables(), lg.Named("backup"))
 
-	return backup.Create(ctx, *path)
+		return backup.Create(ctx, *path)
+	case "storage":
+		opts := storagebackup.BackupOptions{Lag: *lag, Resume: *resume}
+		if opts.Signals, err = storagebackup.ParseSignals(*signals); err != nil {
+			return err
+		}
+		if opts.From, err = parseTime("from", *from); err != nil {
+			return err
+		}
+		if opts.To, err = parseTime("to", *to); err != nil {
+			return err
+		}
+		if !opts.From.IsZero() && !opts.To.IsZero() && !opts.From.Before(opts.To) {
+			return errors.Errorf("-from %s must be before -to %s", opts.From, opts.To)
+		}
+
+		back, stop, err := storagebackup.OpenEngine(ctx, storagebackup.EngineConfig{
+			Path: *storageConfig,
+			Dir:  *storageDir,
+		}, lg)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = stop(ctx)
+		}()
+
+		store := back.Store()
+		if store == nil {
+			return errors.New("configured storage backend has no local engine to back up")
+		}
+
+		stats, err := storagebackup.NewBackup(store, lg.Named("backup"), opts).Create(ctx, *path)
+		if err != nil {
+			return errors.Wrap(err, "back up storage")
+		}
+		lg.Info("Backed up storage",
+			zap.Int("files", stats.Files),
+			zap.Int("skipped", stats.Skipped),
+			zap.Int("streams", stats.Streams),
+			zap.Int("rows", stats.Rows),
+		)
+		return nil
+	default:
+		return errors.Errorf("unknown backend %q", *backend)
+	}
+}
+
+// parseTime accepts a bare UTC date alongside a full timestamp, since a day-granular window is the
+// common case.
+func parseTime(name, v string) (time.Time, error) {
+	if v == "" {
+		return time.Time{}, nil
+	}
+	for _, layout := range []string{time.RFC3339, time.DateTime, time.DateOnly} {
+		if t, err := time.ParseInLocation(layout, v, time.UTC); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, errors.Errorf("parse -%s %q: want RFC3339 or YYYY-MM-DD", name, v)
 }
 
 func main() {

--- a/cmd/odbbackup/main.go
+++ b/cmd/odbbackup/main.go
@@ -98,6 +98,7 @@ func run(ctx context.Context) error {
 			zap.Int("files", stats.Files),
 			zap.Int("skipped", stats.Skipped),
 			zap.Int("streams", stats.Streams),
+			zap.Int("chunks", stats.Chunks),
 			zap.Int("rows", stats.Rows),
 		)
 		return nil

--- a/cmd/odbbackup/main.go
+++ b/cmd/odbbackup/main.go
@@ -5,6 +5,11 @@
 // read seam. The two are separate formats — a backup restores into the backend it came from — but
 // they are one command so an operator has one tool to learn.
 //
+// The storage backend is opened read-only: no WAL recovery, no flush, no merges, no retention and
+// no cluster membership, so backing up a data directory does not modify it. The cost is that data
+// still in the unflushed head (the WAL) is not backed up; keep -lag at or above the engine's flush
+// interval so the window ends behind whatever the head holds.
+//
 // See internal/storagebackup for the storage backend's layout and its fidelity contract.
 package main
 
@@ -32,7 +37,7 @@ func run(ctx context.Context) error {
 		dsn = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL (clickhouse backend)")
 
 		storageConfig = flag.String("storage-config", "", "oteldb config file whose storage block describes the engine (storage backend)")
-		storageDir    = flag.String("storage-dir", "", "Data directory of a single-node file backend, instead of -storage-config (storage backend)")
+		storageDir    = flag.String("storage-dir", "", "Data directory of a single-node file backend, instead of -storage-config; opened read-only (storage backend)")
 		signals       = flag.String("signals", "", "Comma-separated signals to back up: log, trace, metric (default: all, storage backend)")
 		from          = flag.String("from", "", "Back up data at or after this time (RFC3339 or YYYY-MM-DD, UTC); empty starts at the oldest retained")
 		to            = flag.String("to", "", "Back up data before this time (RFC3339 or YYYY-MM-DD, UTC); empty ends at now minus -lag")
@@ -75,8 +80,9 @@ func run(ctx context.Context) error {
 		}
 
 		back, stop, err := storagebackup.OpenEngine(ctx, storagebackup.EngineConfig{
-			Path: *storageConfig,
-			Dir:  *storageDir,
+			Path:     *storageConfig,
+			Dir:      *storageDir,
+			ReadOnly: true,
 		}, lg)
 		if err != nil {
 			return err

--- a/cmd/odbbackup/main.go
+++ b/cmd/odbbackup/main.go
@@ -37,7 +37,7 @@ func run(ctx context.Context) error {
 		dsn = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL (clickhouse backend)")
 
 		storageConfig = flag.String("storage-config", "", "oteldb config file whose storage block describes the engine (storage backend)")
-		storageDir    = flag.String("storage-dir", "", "Data directory of a single-node file backend, instead of -storage-config; opened read-only (storage backend)")
+		storageDir    = flag.String("storage-dir", "", "Data directory of a single-node file backend, instead of -storage-config; must not be a running node's — the open sweeps orphaned part objects (storage backend)")
 		signals       = flag.String("signals", "", "Comma-separated signals to back up: log, trace, metric (default: all, storage backend)")
 		from          = flag.String("from", "", "Back up data at or after this time (RFC3339 or YYYY-MM-DD, UTC); empty starts at the oldest retained")
 		to            = flag.String("to", "", "Back up data before this time (RFC3339 or YYYY-MM-DD, UTC); empty ends at now minus -lag")

--- a/cmd/odbrestore/main.go
+++ b/cmd/odbrestore/main.go
@@ -7,6 +7,10 @@
 // the *destination's* configuration, so the same tool covers disaster recovery, a
 // shards_per_tenant change, and moving a tenant between clusters.
 //
+// A restore writes: it needs the destination engine to itself, and must not be pointed at the data
+// directory of a running node, which would put two writers on one backend. Restore into a stopped
+// node (or a fresh directory) and start it afterwards.
+//
 // See internal/storagebackup for the layout and the fidelity contract.
 package main
 
@@ -35,7 +39,7 @@ func run(ctx context.Context) error {
 		dsn = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL (clickhouse backend)")
 
 		storageConfig = flag.String("storage-config", "", "oteldb config file whose storage block describes the destination engine (storage backend)")
-		storageDir    = flag.String("storage-dir", "", "Data directory of a single-node file backend, instead of -storage-config (storage backend)")
+		storageDir    = flag.String("storage-dir", "", "Data directory of a single-node file backend, instead of -storage-config; must not be a running node's (storage backend)")
 		signals       = flag.String("signals", "", "Comma-separated signals to restore: log, trace, metric (default: all, storage backend)")
 		tenant        = flag.String("tenant", "", "Restore only this logical tenant from the backup (default: all)")
 		batch         = flag.Int("batch", storagebackup.DefaultRestoreBatchSize, "Records, spans or samples buffered per write")

--- a/cmd/odbrestore/main.go
+++ b/cmd/odbrestore/main.go
@@ -1,3 +1,13 @@
+// Command odbrestore restores an oteldb backup written by odbbackup.
+//
+// It speaks two backends, selected with -backend: "clickhouse" (the default) inserts chstorage's
+// Native dumps back into ClickHouse, and "storage" re-ingests a storage-engine backup through the
+// engine's ordinary write path. Going through the write path is the point of the storage restore:
+// tenant routing and, in cluster mode, the shard key and its ring placement are derived again from
+// the *destination's* configuration, so the same tool covers disaster recovery, a
+// shards_per_tenant change, and moving a tenant between clusters.
+//
+// See internal/storagebackup for the layout and the fidelity contract.
 package main
 
 import (
@@ -11,13 +21,24 @@ import (
 	"github.com/go-faster/sdk/zctx"
 	"go.uber.org/zap"
 
+	sigstorage "github.com/oteldb/storage/signal"
+
 	"github.com/oteldb/oteldb/internal/chstorage"
+	"github.com/oteldb/oteldb/internal/storagebackup"
 )
 
 func run(ctx context.Context) error {
 	var (
-		path = flag.String("path", "./restore", "Backup directory")
-		dsn  = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL")
+		backend = flag.String("backend", "clickhouse", "Storage backend to restore into: clickhouse or storage")
+		path    = flag.String("path", "./restore", "Backup directory")
+
+		dsn = flag.String("dsn", "clickhouse://localhost:9000", "Clickhouse connection URL (clickhouse backend)")
+
+		storageConfig = flag.String("storage-config", "", "oteldb config file whose storage block describes the destination engine (storage backend)")
+		storageDir    = flag.String("storage-dir", "", "Data directory of a single-node file backend, instead of -storage-config (storage backend)")
+		signals       = flag.String("signals", "", "Comma-separated signals to restore: log, trace, metric (default: all, storage backend)")
+		tenant        = flag.String("tenant", "", "Restore only this logical tenant from the backup (default: all)")
+		batch         = flag.Int("batch", storagebackup.DefaultRestoreBatchSize, "Records, spans or samples buffered per write")
 	)
 	flag.Parse()
 
@@ -30,13 +51,49 @@ func run(ctx context.Context) error {
 	}()
 	ctx = zctx.Base(ctx, lg)
 
-	d, err := chstorage.Dial(ctx, *dsn, chstorage.DialOptions{})
-	if err != nil {
-		return errors.Wrap(err, "dial clickhouse")
-	}
-	restore := chstorage.NewRestore(d, chstorage.DefaultTables(), lg.Named("restore"))
+	switch *backend {
+	case "clickhouse":
+		d, err := chstorage.Dial(ctx, *dsn, chstorage.DialOptions{})
+		if err != nil {
+			return errors.Wrap(err, "dial clickhouse")
+		}
+		restore := chstorage.NewRestore(d, chstorage.DefaultTables(), lg.Named("restore"))
 
-	return restore.Restore(ctx, *path)
+		return restore.Restore(ctx, *path)
+	case "storage":
+		opts := storagebackup.RestoreOptions{
+			Tenant:    sigstorage.TenantID(*tenant),
+			BatchSize: *batch,
+		}
+		if opts.Signals, err = storagebackup.ParseSignals(*signals); err != nil {
+			return err
+		}
+
+		back, stop, err := storagebackup.OpenEngine(ctx, storagebackup.EngineConfig{
+			Path: *storageConfig,
+			Dir:  *storageDir,
+		}, lg)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_ = stop(ctx)
+		}()
+
+		stats, err := storagebackup.NewRestore(back, lg.Named("restore"), opts).Restore(ctx, *path)
+		if err != nil {
+			return errors.Wrap(err, "restore storage")
+		}
+		lg.Info("Restored storage",
+			zap.Int("files", stats.Files),
+			zap.Int("streams", stats.Streams),
+			zap.Int("rows", stats.Rows),
+			zap.Int("batches", stats.Batches),
+		)
+		return nil
+	default:
+		return errors.Errorf("unknown backend %q", *backend)
+	}
 }
 
 func main() {

--- a/internal/storagebackend/config.go
+++ b/internal/storagebackend/config.go
@@ -68,6 +68,12 @@ type Config struct {
 	// Policy configures the per-tenant merge-time storage policy: age-tiered lossy float precision,
 	// downsampling, and cold-data recompression. Empty ⇒ the library default (lossless, no rollup).
 	Policy *PolicyConfig `json:"policy" yaml:"policy"`
+	// ReadOnly opens the engine for reading only: no WAL (so no recovery of an unflushed head, and
+	// no checkpoint that discards segments), no maintenance loop (so no flush, merge or retention),
+	// and no cluster membership. It is set by a tool, never by a config file, which is why it has no
+	// serialized name: odbbackup opens the data directory this way so that reading a node's data
+	// does not write to it.
+	ReadOnly bool `json:"-" yaml:"-"`
 	// Cluster, when set with a non-empty Etcd endpoint list, joins this node to a storage cluster:
 	// nodes coordinate through etcd, form a rendezvous-hash ring, and replicate writes across each
 	// other's local backends. Unset (or empty Etcd) ⇒ a single-node engine.

--- a/internal/storagebackend/open.go
+++ b/internal/storagebackend/open.go
@@ -3,6 +3,7 @@ package storagebackend
 import (
 	"cmp"
 	"context"
+	"io/fs"
 	"math"
 	"net"
 	"os"
@@ -54,12 +55,15 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "open file backend")
 		}
+		opts = append(opts, storage.WithBackend(fb))
 		// Keep the WAL alongside the parts so the unflushed head survives a restart, not just the
 		// flushed parts.
-		opts = append(opts,
-			storage.WithBackend(fb),
-			storage.WithWALDir(filepath.Join(cfg.Dir, "wal")),
-		)
+		walDir := filepath.Join(cfg.Dir, "wal")
+		if cfg.ReadOnly {
+			warnUnflushedWAL(walDir, lg)
+		} else {
+			opts = append(opts, storage.WithWALDir(walDir))
+		}
 		if cfg.FlushInterval > 0 {
 			opts = append(opts, storage.WithFlushInterval(int64(cfg.FlushInterval)))
 		}
@@ -72,13 +76,29 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 		// The object store is stateless; keep an optional local WAL so the unflushed head survives a
 		// restart rather than only the flushed objects.
 		if cfg.WALDir != "" {
-			opts = append(opts, storage.WithWALDir(cfg.WALDir))
+			if cfg.ReadOnly {
+				warnUnflushedWAL(cfg.WALDir, lg)
+			} else {
+				opts = append(opts, storage.WithWALDir(cfg.WALDir))
+			}
 		}
 		if cfg.FlushInterval > 0 {
 			opts = append(opts, storage.WithFlushInterval(int64(cfg.FlushInterval)))
 		}
 	default:
 		return nil, nil, errors.Errorf("unknown storage backend %q", cfg.Backend)
+	}
+
+	if cfg.ReadOnly {
+		// A durable store with no explicit interval flushes periodically by default, and the loop
+		// that does it also merges parts and applies retention. A negative interval opts out, which
+		// is what read-only means here: the engine only reads.
+		opts = append(opts, storage.WithFlushInterval(-1))
+		if cfg.Cluster != nil && len(cfg.Cluster.Etcd) > 0 {
+			lg.Warn("Not joining the storage cluster: the engine is open read-only, " +
+				"so it serves only the data this node holds locally")
+			cfg.Cluster = nil
+		}
 	}
 
 	if clusterOpt, err := clusterOption(cfg.Cluster, lg); err != nil {
@@ -112,6 +132,7 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 
 	lg.Info("Using embedded storage engine for metrics",
 		zap.String("backend", cmp.Or(cfg.Backend, "memory")),
+		zap.Bool("read_only", cfg.ReadOnly),
 		zap.Int("log_query_parallelism", cfg.LogQueryParallelism),
 		zap.Int64("read_cache_bytes", caches.ReadCache),
 		zap.Int64("decode_cache_bytes", caches.DecodeCache),
@@ -123,6 +144,37 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 		WithLogParallelism(cfg.LogQueryParallelism),
 	)
 	return b, store.Close, nil
+}
+
+// warnUnflushedWAL reports the one thing a read-only open gives up: whatever the engine has
+// ingested but not yet flushed lives in the WAL, and replaying it is a write — it re-attaches a
+// writable WAL, and the close that follows flushes the recovered head into a new part and
+// checkpoints the segments away, out from under the node that owns them. So a read-only open skips
+// it, and reads the flushed parts only.
+func warnUnflushedWAL(dir string, lg *zap.Logger) {
+	if !hasFiles(dir) {
+		return
+	}
+	lg.Warn("Read-only engine: the write-ahead log is not replayed, so unflushed data is not visible",
+		zap.String("wal_dir", dir),
+	)
+}
+
+// hasFiles reports whether dir holds any regular file, at any depth. An unreadable or absent tree
+// answers false: this only decides whether to warn.
+func hasFiles(dir string) bool {
+	found := false
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			return nil
+		case d.IsDir():
+			return nil
+		}
+		found = true
+		return fs.SkipAll
+	})
+	return found
 }
 
 // clusterOption builds the storage cluster option from the config, or returns (nil, nil) when

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -116,6 +116,12 @@ func NewQuery(src Source, opts ...Option) *Backend {
 	return b
 }
 
+// Store returns the local storage engine, or nil when this Backend was built with [NewQuery] over a
+// bare [Source] and has none. It is the escape hatch for the few tools that need the engine itself
+// rather than a query API — the backup driver enumerates tenants and reads through the raw fetch
+// seam, which no query interface exposes.
+func (b *Backend) Store() *storage.Storage { return b.store }
+
 // Inspect returns an in-memory snapshot of engine statistics (tenants, per-signal series/parts/head
 // and WAL state, caches, and cluster membership when clustered). It performs no backend I/O and is
 // safe to poll at a seconds cadence; it is the admin panel's primary storage view.

--- a/internal/storagebackup/backup.go
+++ b/internal/storagebackup/backup.go
@@ -49,6 +49,9 @@ type BackupOptions struct {
 	// Resume skips a (tenant, signal, day) whose file already exists, making an interrupted run
 	// restartable. Off by default so a plain re-run rewrites the window.
 	Resume bool
+	// MaxChunkBytes is the size a fetch batch is split at, bounding the encoder's buffer. Zero ⇒
+	// [DefaultMaxChunkBytes]; a larger value than a reader accepts is clamped down to it.
+	MaxChunkBytes int
 	// Now overrides the clock, for tests.
 	Now func() time.Time
 }
@@ -61,6 +64,7 @@ type BackupStats struct {
 	Files   int
 	Skipped int
 	Streams int
+	Chunks  int
 	Rows    int
 }
 
@@ -83,6 +87,7 @@ func NewBackup(store Store, lg *zap.Logger, opts BackupOptions) *Backup {
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
+	opts.MaxChunkBytes = clampChunkLimit(opts.MaxChunkBytes)
 	return &Backup{store: store, lg: lg, opts: opts}
 }
 
@@ -135,6 +140,7 @@ func (b *Backup) Create(ctx context.Context, dir string) (BackupStats, error) {
 				manifest.Files = append(manifest.Files, *info)
 				stats.Files++
 				stats.Streams += info.Streams
+				stats.Chunks += info.Chunks
 				stats.Rows += info.Rows
 			}
 		}
@@ -175,7 +181,7 @@ func (b *Backup) day(
 		Day:     day.Format(dayLayout),
 		Start:   start,
 		End:     end,
-	})
+	}, b.opts.MaxChunkBytes)
 	if err != nil {
 		return nil, false, err
 	}
@@ -205,6 +211,7 @@ func (b *Backup) day(
 		Tenant:  string(tenant),
 		Day:     day.Format(dayLayout),
 		Streams: w.streams,
+		Chunks:  w.chunks,
 		Rows:    w.rows,
 	}
 	if err := w.Close(); err != nil {
@@ -215,6 +222,7 @@ func (b *Backup) day(
 		zap.String("tenant", string(tenant)),
 		zap.String("day", info.Day),
 		zap.Int("streams", info.Streams),
+		zap.Int("chunks", info.Chunks),
 		zap.Int("rows", info.Rows),
 	)
 	return info, false, nil

--- a/internal/storagebackup/backup.go
+++ b/internal/storagebackup/backup.go
@@ -1,0 +1,375 @@
+package storagebackup
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/cluster"
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+)
+
+// Store is the read seam a backup needs: the per-signal fetchers, the query budget, and the
+// in-memory snapshot that enumerates tenants and their retained window. *[storage.Storage]
+// implements it.
+type Store interface {
+	Fetcher(tenants ...signal.TenantID) fetch.Fetcher
+	LogFetcher(tenants ...signal.TenantID) fetch.Fetcher
+	TraceFetcher(tenants ...signal.TenantID) fetch.Fetcher
+	WithQueryBudget(ctx context.Context) context.Context
+	Inspect() storage.StoreStats
+}
+
+var _ Store = (*storage.Storage)(nil)
+
+// BackupSignals are the signals a backup covers, in a stable order. Profiles are excluded; see the
+// package documentation.
+var BackupSignals = []signal.Signal{signal.Log, signal.Trace, signal.Metric}
+
+// BackupOptions configures a [Backup].
+type BackupOptions struct {
+	// Signals selects what to back up. Empty ⇒ [BackupSignals].
+	Signals []signal.Signal
+	// From and To bound the scan (To exclusive). A zero From starts at the oldest retained data; a
+	// zero To ends at now minus Lag.
+	From, To time.Time
+	// Lag keeps the window behind the ingest edge, so the newest day is not scanned while it is
+	// still filling. Ignored when To is set. Zero ⇒ [DefaultLag].
+	Lag time.Duration
+	// Resume skips a (tenant, signal, day) whose file already exists, making an interrupted run
+	// restartable. Off by default so a plain re-run rewrites the window.
+	Resume bool
+	// Now overrides the clock, for tests.
+	Now func() time.Time
+}
+
+// DefaultLag is the default [BackupOptions.Lag]: an hour behind the ingest edge.
+const DefaultLag = time.Hour
+
+// BackupStats counts what a backup wrote.
+type BackupStats struct {
+	Files   int
+	Skipped int
+	Streams int
+	Rows    int
+}
+
+// Backup copies a storage engine's data into a backup directory. See the package documentation for
+// the layout and the fidelity contract.
+type Backup struct {
+	store Store
+	lg    *zap.Logger
+	opts  BackupOptions
+}
+
+// NewBackup creates a [Backup] over store.
+func NewBackup(store Store, lg *zap.Logger, opts BackupOptions) *Backup {
+	if len(opts.Signals) == 0 {
+		opts.Signals = BackupSignals
+	}
+	if opts.Lag == 0 {
+		opts.Lag = DefaultLag
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	return &Backup{store: store, lg: lg, opts: opts}
+}
+
+// tenantWindow is one logical tenant's shard keys and retained window for one signal.
+type tenantWindow struct {
+	shards     []signal.TenantID
+	mint, maxt int64
+}
+
+// Create writes the backup into dir.
+func (b *Backup) Create(ctx context.Context, dir string) (BackupStats, error) {
+	var stats BackupStats
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return stats, errors.Wrap(err, "create backup directory")
+	}
+
+	manifest := Manifest{Version: FormatVersion, CreatedAt: b.opts.Now().UTC()}
+	for _, sig := range b.opts.Signals {
+		tenants := b.tenants(sig)
+		for _, tenant := range slices.Sorted(maps.Keys(tenants)) {
+			w := tenants[tenant]
+			from, to, ok := b.window(w)
+			if !ok {
+				b.lg.Info("Nothing to back up",
+					zap.String("signal", sig.String()),
+					zap.String("tenant", string(tenant)),
+				)
+				continue
+			}
+			if manifest.Start.IsZero() || from.Before(manifest.Start) {
+				manifest.Start = from
+			}
+			if to.After(manifest.End) {
+				manifest.End = to
+			}
+
+			for day := from; day.Before(to); day = day.AddDate(0, 0, 1) {
+				info, skipped, err := b.day(ctx, dir, sig, tenant, w.shards, day)
+				if err != nil {
+					return stats, errors.Wrapf(err, "back up %s/%s %s", sig, tenant, day.Format(dayLayout))
+				}
+				if skipped {
+					stats.Skipped++
+					continue
+				}
+				if info == nil {
+					continue
+				}
+				manifest.Files = append(manifest.Files, *info)
+				stats.Files++
+				stats.Streams += info.Streams
+				stats.Rows += info.Rows
+			}
+		}
+	}
+
+	if err := writeManifest(dir, manifest); err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+// day writes one (tenant, signal, UTC day) file, returning nil when the day held no data. The
+// second result reports a day skipped because its file already exists.
+func (b *Backup) day(
+	ctx context.Context,
+	dir string,
+	sig signal.Signal,
+	tenant signal.TenantID,
+	shards []signal.TenantID,
+	day time.Time,
+) (_ *FileInfo, skipped bool, rerr error) {
+	rel := filePath(sig, tenant, day.Format(dayLayout))
+	if b.opts.Resume {
+		if _, err := os.Stat(filepath.Join(dir, filepath.FromSlash(rel))); err == nil {
+			return nil, true, nil
+		}
+	}
+
+	// The window is inclusive on both ends at the fetch seam, so the day ends one nanosecond
+	// before midnight — otherwise a record exactly at midnight lands in two adjacent files.
+	start := day.UnixNano()
+	end := day.AddDate(0, 0, 1).UnixNano() - 1
+
+	w, err := createChunkWriter(dir, rel, FileHeader{
+		Version: FormatVersion,
+		Signal:  sig.String(),
+		Tenant:  string(tenant),
+		Day:     day.Format(dayLayout),
+		Start:   start,
+		End:     end,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() {
+		if rerr != nil {
+			w.Abort()
+		}
+	}()
+
+	ctx = b.store.WithQueryBudget(ctx)
+	for _, shard := range shards {
+		if err := b.scan(ctx, w, sig, shard, start, end); err != nil {
+			return nil, false, errors.Wrapf(err, "scan shard %q", shard)
+		}
+	}
+
+	// An empty day is not worth a file: it would only make a resumed run believe it had already
+	// done work it had not, and it clutters the tree for a sparse tenant.
+	if w.rows == 0 {
+		w.Abort()
+		return nil, false, nil
+	}
+
+	info := &FileInfo{
+		Path:    rel,
+		Signal:  sig.String(),
+		Tenant:  string(tenant),
+		Day:     day.Format(dayLayout),
+		Streams: w.streams,
+		Rows:    w.rows,
+	}
+	if err := w.Close(); err != nil {
+		return nil, false, err
+	}
+	b.lg.Info("Backed up",
+		zap.String("signal", sig.String()),
+		zap.String("tenant", string(tenant)),
+		zap.String("day", info.Day),
+		zap.Int("streams", info.Streams),
+		zap.Int("rows", info.Rows),
+	)
+	return info, false, nil
+}
+
+// scan fetches every stream of one shard key in the window and writes it as chunks.
+func (b *Backup) scan(
+	ctx context.Context,
+	w *chunkWriter,
+	sig signal.Signal,
+	shard signal.TenantID,
+	start, end int64,
+) error {
+	// No matchers, no conditions and no projection: the fetch seam reads that as every stream, every
+	// record and every column of the signal's schema.
+	req := fetch.Request{
+		Tenant: shard,
+		Signal: sig,
+		Start:  start,
+		End:    end,
+		Scope:  fetch.NewScope(),
+	}
+
+	var fetcher fetch.Fetcher
+	switch sig {
+	case signal.Log:
+		fetcher = b.store.LogFetcher(shard)
+	case signal.Trace:
+		fetcher = b.store.TraceFetcher(shard)
+	case signal.Metric:
+		fetcher = b.store.Fetcher(shard)
+	default:
+		return errors.Errorf("signal %s is not backed up", sig)
+	}
+
+	it, err := fetcher.Fetch(ctx, req)
+	if err != nil {
+		return errors.Wrap(err, "fetch")
+	}
+	defer func() {
+		_ = it.Close()
+	}()
+
+	var weighted int
+	for {
+		batch, err := it.Next(ctx)
+		switch {
+		case errors.Is(err, io.EOF):
+			if weighted > 0 {
+				// The ingest model has no field for a sample's lossy-sampling weight, so a restore
+				// of these samples under-counts. Say so rather than let it pass silently.
+				b.lg.Warn("Lossy-sampling scale factors are not preserved by a backup",
+					zap.String("tenant", string(shard)),
+					zap.Int("series", weighted),
+				)
+			}
+			return nil
+		case err != nil:
+			return errors.Wrap(err, "next batch")
+		}
+		if len(batch.Timestamps) == 0 {
+			continue
+		}
+		if batch.ScaleFactors != nil {
+			weighted++
+		}
+		if err := w.Write(&Chunk{
+			Series:     batch.Series,
+			Timestamps: batch.Timestamps,
+			Values:     batch.Values,
+			Columns:    batch.Columns,
+		}); err != nil {
+			return errors.Wrap(err, "write chunk")
+		}
+	}
+}
+
+// tenants groups the store's tenants for one signal by their *logical* tenant, folding a cluster's
+// shard keys ("default/_s0") back into the tenant they split ("default").
+//
+// This is the step that makes a backup re-shardable: the shard key is a function of the source
+// cluster's shards_per_tenant, so recording it would pin the data to a cluster of that exact shape.
+// Recording the logical tenant instead lets the destination's write path derive its own.
+func (b *Backup) tenants(sig signal.Signal) map[signal.TenantID]*tenantWindow {
+	out := map[signal.TenantID]*tenantWindow{}
+	for _, t := range b.store.Inspect().Tenants {
+		for _, s := range t.Signals {
+			if s.Signal != sig {
+				continue
+			}
+			if s.HasReadGap {
+				b.lg.Warn("Tenant has a read gap; the backup will be incomplete over it",
+					zap.String("tenant", string(t.Tenant)),
+					zap.String("signal", sig.String()),
+					zap.Int64("gap_after_unix_nano", s.ReadGapAfterUnixNano),
+				)
+			}
+
+			logical := cluster.TenantOfShard(t.Tenant)
+			w, ok := out[logical]
+			if !ok {
+				w = &tenantWindow{mint: s.MinTimeUnixNano, maxt: s.MaxTimeUnixNano}
+				out[logical] = w
+			}
+			w.shards = append(w.shards, t.Tenant)
+			if s.MinTimeUnixNano != 0 && (w.mint == 0 || s.MinTimeUnixNano < w.mint) {
+				w.mint = s.MinTimeUnixNano
+			}
+			if s.MaxTimeUnixNano > w.maxt {
+				w.maxt = s.MaxTimeUnixNano
+			}
+		}
+	}
+	for _, w := range out {
+		slices.Sort(w.shards)
+	}
+	return out
+}
+
+// window resolves the UTC-day-aligned scan window for a tenant, intersecting its retained range
+// with the configured bounds. It reports false when nothing is left to scan.
+func (b *Backup) window(w *tenantWindow) (from, to time.Time, ok bool) {
+	if w.maxt == 0 {
+		return time.Time{}, time.Time{}, false
+	}
+
+	first := time.Unix(0, w.mint).UTC()
+	if !b.opts.From.IsZero() && b.opts.From.After(first) {
+		first = b.opts.From.UTC()
+	}
+
+	// The bounds below are inclusive instants, day-aligned only at the end: a To of exactly
+	// midnight is exclusive, so it must not pull the following day into the scan.
+	last := time.Unix(0, w.maxt).UTC()
+	limit := b.opts.To.UTC()
+	if b.opts.To.IsZero() {
+		limit = b.opts.Now().UTC().Add(-b.opts.Lag)
+	}
+	if limit = limit.Add(-time.Nanosecond); limit.Before(last) {
+		last = limit
+	}
+
+	if last.Before(first) {
+		return time.Time{}, time.Time{}, false
+	}
+	return first.Truncate(24 * time.Hour), last.Truncate(24*time.Hour).AddDate(0, 0, 1), true
+}
+
+func writeManifest(dir string, m Manifest) error {
+	raw, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "encode manifest")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), append(raw, '\n'), 0o600); err != nil {
+		return errors.Wrap(err, "write manifest")
+	}
+	return nil
+}

--- a/internal/storagebackup/convert.go
+++ b/internal/storagebackup/convert.go
@@ -1,0 +1,220 @@
+package storagebackup
+
+import (
+	"bytes"
+
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+)
+
+// Everything below deep-copies out of the chunk. A chunk read from a file aliases the reader's
+// frame buffer, which the next chunk overwrites, while the batch being built outlives many chunks.
+
+// appendLogs converts one chunk into a log stream appended to dst, returning the record count.
+func appendLogs(dst *siglog.Logs, c *Chunk) int {
+	cols := recordColumns(c)
+
+	sl := addStream(dst.AddResource(), c.Series)
+	for i := range c.Timestamps {
+		r := sl.AddRecord()
+		r.Timestamp = c.Timestamps[i]
+		r.ObservedTimestamp = cols.int(siglog.ColObserved, i)
+		r.SeverityNumber = int32(cols.int(siglog.ColSeverity, i))
+		r.Flags = uint32(cols.int(siglog.ColFlags, i))
+		r.Dropped = uint32(cols.int(siglog.ColDropped, i))
+		r.SeverityText = cols.bytes(siglog.ColSeverityText, i)
+		r.Body = cols.bytes(siglog.ColBody, i)
+		r.TraceID = cols.bytes(siglog.ColTraceID, i)
+		r.SpanID = cols.bytes(siglog.ColSpanID, i)
+		r.Attributes = cols.attrs(siglog.ColAttrs, i)
+	}
+	return len(c.Timestamps)
+}
+
+// appendTraces converts one chunk into a span stream appended to dst, returning the span count.
+//
+// The nested-set columns are not restored: they are derived per write batch by the traces
+// projector, so writing them back would be writing a value the destination is about to recompute.
+func appendTraces(dst *sigtrace.Traces, c *Chunk) int {
+	cols := recordColumns(c)
+
+	ss := addSpanStream(dst.AddResource(), c.Series)
+	for i := range c.Timestamps {
+		sp := ss.AddSpan()
+		sp.Start = c.Timestamps[i]
+		sp.End = sp.Start + cols.int(sigtrace.ColDuration, i)
+		sp.Kind = int32(cols.int(sigtrace.ColKind, i))
+		sp.StatusCode = int32(cols.int(sigtrace.ColStatusCode, i))
+		sp.TraceID = cols.bytes(sigtrace.ColTraceID, i)
+		sp.SpanID = cols.bytes(sigtrace.ColSpanID, i)
+		sp.ParentSpanID = cols.bytes(sigtrace.ColParentSpanID, i)
+		sp.Name = cols.bytes(sigtrace.ColName, i)
+		sp.StatusMessage = cols.bytes(sigtrace.ColStatusMsg, i)
+		sp.Attributes = cols.attrs(sigtrace.ColAttrs, i)
+
+		if raw := cols.raw(sigtrace.ColEvents, i); len(raw) > 0 {
+			if evs, err := sigtrace.DecodeEvents(raw); err == nil {
+				for _, ev := range evs {
+					e := sp.AddEvent()
+					e.Time = ev.Time
+					e.Name = bytes.Clone(ev.Name)
+					e.Dropped = ev.Dropped
+					e.Attributes = ev.Attributes.Clone()
+				}
+			}
+		}
+		if raw := cols.raw(sigtrace.ColLinks, i); len(raw) > 0 {
+			if links, err := sigtrace.DecodeLinks(raw); err == nil {
+				for _, ln := range links {
+					l := sp.AddLink()
+					l.TraceID = bytes.Clone(ln.TraceID)
+					l.SpanID = bytes.Clone(ln.SpanID)
+					l.TraceState = bytes.Clone(ln.TraceState)
+					l.Dropped = ln.Dropped
+					l.Attributes = ln.Attributes.Clone()
+				}
+			}
+		}
+	}
+	return len(c.Timestamps)
+}
+
+// appendMetrics converts one chunk into a metric series appended to dst, returning the sample
+// count. The chunk's identity carries the metric-specific fields as reserved labels, which
+// [splitMetricIdentity] folds back out; sample start timestamps are not stored by the engine and
+// restore as zero.
+func appendMetrics(dst *sigmetric.Metrics, c *Chunk) (int, error) {
+	id, err := splitMetricIdentity(c.Series)
+	if err != nil {
+		return 0, err
+	}
+	if len(c.Values) != len(c.Timestamps) {
+		return 0, errors.Errorf("metric series has %d timestamps but %d values", len(c.Timestamps), len(c.Values))
+	}
+
+	rm := dst.AddResource()
+	rm.Resource = id.Series.Resource.Clone()
+	sm := rm.AddScope()
+	sm.Scope = id.Series.Scope.Clone()
+
+	mt := sm.AddMetric()
+	mt.Name = bytes.Clone(id.Name)
+	mt.Unit = bytes.Clone(id.Unit)
+	mt.Kind = id.Kind
+	mt.Temporality = id.Temporality
+	mt.Monotonic = id.Monotonic
+
+	attrs := id.Series.Attributes.Clone()
+	for i := range c.Timestamps {
+		p := mt.AddPoint()
+		p.Attributes = attrs
+		p.Ts = c.Timestamps[i]
+		p.Value = c.Values[i]
+	}
+	return len(c.Timestamps), nil
+}
+
+// splitMetricIdentity is the inverse of [sigmetric.Identity.ToSeries]: it lifts the reserved
+// __name__/__unit__/__kind__/__temporality__/__monotonic__ labels back out of the stored series
+// attributes, leaving the data-point attributes behind.
+func splitMetricIdentity(s signal.Series) (sigmetric.Identity, error) {
+	id := sigmetric.Identity{Series: signal.Series{Resource: s.Resource, Scope: s.Scope}}
+
+	points := make(signal.Attributes, 0, len(s.Attributes))
+	var seenName bool
+	for _, kv := range s.Attributes {
+		switch {
+		case bytes.Equal(kv.Key, sigmetric.LabelName):
+			id.Name = kv.Value.Str()
+			seenName = true
+		case bytes.Equal(kv.Key, sigmetric.LabelUnit):
+			id.Unit = kv.Value.Str()
+		case bytes.Equal(kv.Key, sigmetric.LabelKind):
+			id.Kind = sigmetric.PointKind(kv.Value.Int())
+		case bytes.Equal(kv.Key, sigmetric.LabelTemporality):
+			id.Temporality = sigmetric.Temporality(kv.Value.Int())
+		case bytes.Equal(kv.Key, sigmetric.LabelMonotonic):
+			id.Monotonic = kv.Value.Bool()
+		default:
+			points = append(points, kv)
+		}
+	}
+	if !seenName {
+		return id, errors.Errorf("metric series carries no %q label", sigmetric.LabelName)
+	}
+
+	id.Series.Attributes = points
+	return id, nil
+}
+
+// addStream appends a (resource, scope) log stream to rl and returns it.
+func addStream(rl *siglog.ResourceLogs, s signal.Series) *siglog.ScopeLogs {
+	rl.Resource = s.Resource.Clone()
+	sl := rl.AddScope()
+	sl.Scope = s.Scope.Clone()
+	return sl
+}
+
+// addSpanStream appends a (resource, scope) span stream to rs and returns it.
+func addSpanStream(rs *sigtrace.ResourceSpans, s signal.Series) *sigtrace.ScopeSpans {
+	rs.Resource = s.Resource.Clone()
+	ss := rs.AddScope()
+	ss.Scope = s.Scope.Clone()
+	return ss
+}
+
+// recordCols indexes a chunk's columns by name so a per-row read is a map lookup rather than a
+// linear scan of the column list.
+type recordCols map[string]*fetch.NamedColumn
+
+func recordColumns(c *Chunk) recordCols {
+	cols := make(recordCols, len(c.Columns))
+	for i := range c.Columns {
+		cols[c.Columns[i].Name] = &c.Columns[i]
+	}
+	return cols
+}
+
+// int reads row i of an integer column, defaulting to zero when the column is absent or short (a
+// backup taken by an older build simply has fewer columns).
+func (c recordCols) int(name string, i int) int64 {
+	col, ok := c[name]
+	if !ok || i >= len(col.Int64) {
+		return 0
+	}
+	return col.Int64[i]
+}
+
+// raw reads row i of a bytes column without copying.
+func (c recordCols) raw(name string, i int) []byte {
+	col, ok := c[name]
+	if !ok || i >= len(col.Bytes) {
+		return nil
+	}
+	return col.Bytes[i]
+}
+
+// bytes reads row i of a bytes column into owned memory.
+func (c recordCols) bytes(name string, i int) []byte {
+	return bytes.Clone(c.raw(name, i))
+}
+
+// attrs decodes row i of a serialized attributes column. A row whose blob does not decode is
+// restored without attributes rather than failing the whole file, matching how the query path
+// treats an undecodable attribute blob.
+func (c recordCols) attrs(name string, i int) signal.Attributes {
+	raw := c.raw(name, i)
+	if len(raw) == 0 {
+		return nil
+	}
+	attrs, _, err := signal.DecodeAttributes(raw)
+	if err != nil {
+		return nil
+	}
+	return attrs.Clone()
+}

--- a/internal/storagebackup/doc.go
+++ b/internal/storagebackup/doc.go
@@ -1,0 +1,100 @@
+// Package storagebackup implements backup and restore for the embedded storage engine
+// ([github.com/oteldb/storage]), the backend that replaces chstorage.
+//
+// # Why restore goes through the write path
+//
+// A backup is a stream of logical telemetry — streams, records, series and samples — not a copy of
+// the engine's part files. Restore rebuilds the data by calling the engine's ordinary Write* entry
+// points, so every write-time decision is taken again against the *destination's* configuration:
+// tenant routing, and, in cluster mode, the shard key and its ring placement. That is what makes
+// one tool cover three jobs instead of only the first:
+//
+//   - disaster recovery,
+//   - re-sharding: raising cluster.shards_per_tenant re-keys every shard
+//     ([github.com/oteldb/storage/cluster.ShardKeyOf] turns tenant "default" into "default/_s0" …
+//     "default/_sN-1"), which strands data written under the old keys. A backup taken before the
+//     change and restored after it lands under the new keys.
+//   - moving a tenant between clusters.
+//
+// A byte-for-byte part copy would solve only disaster recovery, and only into an identically
+// shaped cluster.
+//
+// # On-disk layout
+//
+//	<dir>/manifest.json
+//	<dir>/<signal>/<tenant>/<YYYY-MM-DD>.obk.zst
+//
+// Signal is the stable [github.com/oteldb/storage/signal.Signal] name ("log", "trace", "metric").
+// The tenant path element is percent-escaped; the authoritative tenant id is the one in each
+// file's header, not the one in the path. One file holds one UTC day of one (tenant, signal),
+// which is the same day-at-a-time slicing chstorage's backup uses.
+//
+// A file is a zstd stream of: the magic, a JSON header, then length-delimited chunks. One chunk is
+// one fetch batch: a stream (or metric series) identity plus its rows. See [Chunk].
+//
+// manifest.json is written last and is informational — it records the window, the files and their
+// row counts for an operator. Restore walks the tree and trusts each file's own header, so a
+// backup whose manifest is missing still restores.
+//
+// # Backup is restartable, and does not require stopping ingest
+//
+// A day file is written to "<name>.tmp" and renamed into place only after its last chunk is
+// flushed, so a file that exists is complete. With [BackupOptions.Resume] an existing file is
+// skipped, which makes an interrupted run restartable at (tenant, signal, day) granularity — the
+// same granularity ch2storagebackend's checkpoint journal uses. There is no mid-file resume.
+//
+// The scan reads the head and the flushed parts through the ordinary fetch seam, so concurrent
+// ingest is safe and no flush or downtime is needed. It does mean the newest day is a moving
+// target: records that arrive after that day was scanned are not in the backup. Use
+// [BackupOptions.Lag] (or an explicit To) to keep the window behind the ingest edge.
+//
+// # Fidelity contract
+//
+// A backup can only carry what the engine stores. What the engine drops at ingest is already gone
+// before a backup runs; the contract below is stated against the engine's stored state, and is
+// exercised by the round-trip test.
+//
+// Round-trips exactly:
+//
+//   - Stream identity: resource (attributes and schema URL), instrumentation scope (name, version,
+//     schema URL, attributes), with attribute types preserved.
+//   - Logs: every column of [github.com/oteldb/storage/signal/log.Schema] — timestamp, observed
+//     timestamp, severity number and text, body, trace and span id, flags, dropped count, and the
+//     record attributes.
+//   - Traces: timestamp (span start), duration (hence end), kind, status code and message, trace,
+//     span and parent span ids, name, span attributes, events and links.
+//   - Metrics: series identity including the reserved __name__/__unit__/__kind__/
+//     __temporality__/__monotonic__ labels and the data-point attributes, plus every (timestamp,
+//     value) sample. Histograms are already decomposed into _count/_sum/_bucket{le} series at
+//     ingest, so they restore as the same decomposed series.
+//
+// Approximated:
+//
+//   - Span structural ids (nested_set_left/right, parent_id) are derived per write batch, not
+//     stored as source data. Restore recomputes them from the spans in each restored batch, so a
+//     trace whose spans fall in different batches is reconstructed per batch. This is the same
+//     approximation live ingest already makes when a trace's spans arrive in separate exports.
+//   - Data lands in the destination's tenant, which oteldb derives from its own configuration
+//     rather than from the backup. Backing up a cluster's shard keys ("default/_s0") records the
+//     logical tenant ("default"); restoring several logical tenants into a single-tenant
+//     destination merges them, and [RestoreOptions.Tenant] is the way to avoid that.
+//
+// Lost:
+//
+//   - Metric sample start timestamps. The engine has a StartTs field on the ingest model but never
+//     persists it, so it is not readable and is restored as zero.
+//   - Lossy-sampling scale factors. A sample kept by budgeted sampling carries the weight of the
+//     samples it stands for; the ingest model has no field for that weight, so a restored sample
+//     weighs one. Backup logs a warning when it sees weighted samples.
+//   - Span trace state, flags and dropped-attribute counts, and any field outside the engine's
+//     schemas. These are dropped at ingest, before any backup sees them.
+//
+// # Not covered
+//
+// Profiles are not backed up. A profile row stores only a content-addressed stack id into a
+// per-tenant symbol side store; rebuilding an ingestible
+// [github.com/oteldb/storage/signal/profile.Profiles] means re-interning a dictionary out of
+// resolved frames, which loses mappings, addresses and the original string table. That deserves
+// its own export rather than a lossy approximation folded in here. The format is keyed by signal
+// name, so adding "profile" later needs no format change.
+package storagebackup

--- a/internal/storagebackup/doc.go
+++ b/internal/storagebackup/doc.go
@@ -54,6 +54,23 @@
 // that day was scanned are not in the backup. Use [BackupOptions.Lag] (or an explicit To) to keep
 // the window behind the ingest edge.
 //
+// # Backup does not write to the data directory
+//
+// [EngineConfig.ReadOnly] — which odbbackup always sets — opens the engine with everything that
+// writes turned off: no WAL recovery, no flush, no merges, no retention, and no cluster membership.
+// Without it, opening a data directory is a write: recovery replays the WAL into a head, the close
+// that follows flushes that head into a new part, and the WAL is checkpointed, discarding
+// segments. Against a running node that makes the backup a second writer, discarding segments the
+// node still owns — "back up" would mean "modify".
+//
+// The cost is the unflushed head: a read-only open sees the flushed parts only, and whatever the
+// engine has ingested but not yet flushed is not backed up (it logs a warning when the WAL is
+// non-empty). With the default [BackupOptions.Lag] that data is outside the window anyway, since
+// the head holds the newest writes; keep Lag at or above the engine's flush interval.
+//
+// A restore is the other way round: it writes, so it needs the destination to itself. Do not point
+// odbrestore at a running node's data directory — restore into a stopped node, then start it.
+//
 // # Fidelity contract
 //
 // A backup can only carry what the engine stores. What the engine drops at ingest is already gone

--- a/internal/storagebackup/doc.go
+++ b/internal/storagebackup/doc.go
@@ -29,8 +29,14 @@
 // file's header, not the one in the path. One file holds one UTC day of one (tenant, signal),
 // which is the same day-at-a-time slicing chstorage's backup uses.
 //
-// A file is a zstd stream of: the magic, a JSON header, then length-delimited chunks. One chunk is
-// one fetch batch: a stream (or metric series) identity plus its rows. See [Chunk].
+// A file is a zstd stream of: the magic, a JSON header, then length-delimited chunks. See [Chunk].
+//
+// A chunk is a stream (or metric series) identity plus a run of its rows. A fetch batch is one
+// stream's whole day, which on a busy tenant is hundreds of megabytes, so a batch larger than
+// [BackupOptions.MaxChunkBytes] is split by row over as many chunks as it needs, each repeating
+// the identity. Every chunk therefore decodes on its own, and restore sees a split batch as
+// several writes of the same stream — the shape live ingest already produces when one stream's
+// records arrive in more than one export.
 //
 // manifest.json is written last and is informational — it records the window, the files and their
 // row counts for an operator. Restore walks the tree and trusts each file's own header, so a
@@ -43,10 +49,10 @@
 // skipped, which makes an interrupted run restartable at (tenant, signal, day) granularity — the
 // same granularity ch2storagebackend's checkpoint journal uses. There is no mid-file resume.
 //
-// The scan reads the head and the flushed parts through the ordinary fetch seam, so concurrent
-// ingest is safe and no flush or downtime is needed. It does mean the newest day is a moving
-// target: records that arrive after that day was scanned are not in the backup. Use
-// [BackupOptions.Lag] (or an explicit To) to keep the window behind the ingest edge.
+// The scan reads through the ordinary fetch seam, so concurrent ingest is safe and no flush or
+// downtime is needed. It does mean the newest day is a moving target: records that arrive after
+// that day was scanned are not in the backup. Use [BackupOptions.Lag] (or an explicit To) to keep
+// the window behind the ingest edge.
 //
 // # Fidelity contract
 //

--- a/internal/storagebackup/doc.go
+++ b/internal/storagebackup/doc.go
@@ -54,10 +54,11 @@
 // that day was scanned are not in the backup. Use [BackupOptions.Lag] (or an explicit To) to keep
 // the window behind the ingest edge.
 //
-// # Backup does not write to the data directory
+// # Backup suppresses every write it can, but the open itself still sweeps
 //
 // [EngineConfig.ReadOnly] — which odbbackup always sets — opens the engine with everything that
-// writes turned off: no WAL recovery, no flush, no merges, no retention, and no cluster membership.
+// writes turned off *that the storage API exposes*: no WAL recovery, no flush, no merges, no
+// retention, and no cluster membership.
 // Without it, opening a data directory is a write: recovery replays the WAL into a head, the close
 // that follows flushes that head into a new part, and the WAL is checkpointed, discarding
 // segments. Against a running node that makes the backup a second writer, discarding segments the
@@ -67,6 +68,21 @@
 // engine has ingested but not yet flushed is not backed up (it logs a warning when the WAL is
 // non-empty). With the default [BackupOptions.Lag] that data is outside the window anyway, since
 // the head holds the newest writes; keep Lag at or above the engine's flush interval.
+//
+// One write is left, and it cannot be suppressed from here. Opening an engine sweeps the part
+// objects the bucket index does not name, and both load modes storage.Storage can select do it
+// (the mode that sweeps nothing is internal to the engine). So a backup of a directory holding
+// orphans — which a long-running node accumulates, since that sweep is the only thing that
+// reclaims them — deletes those objects as it opens.
+//
+// Measured against a real node's data directory: 87 objects across six orphaned parts, deleted on
+// the first open, deterministically. It is not data loss — two consecutive backups of the same
+// directory returned identical stream and row counts, because an orphan is by definition
+// unreferenced — and the tree is stable from the second open on. But it means a copy diverges from
+// its original the first time it is backed up, so a bit-for-bit comparison against the source will
+// not hold, and it is one more reason never to point this at a live node's directory.
+//
+// oteldb/storage#583 tracks exposing the read-only load that would close this.
 //
 // A restore is the other way round: it writes, so it needs the destination to itself. Do not point
 // odbrestore at a running node's data directory — restore into a stopped node, then start it.

--- a/internal/storagebackup/engine.go
+++ b/internal/storagebackup/engine.go
@@ -20,6 +20,10 @@ type EngineConfig struct {
 	// Dir is the shorthand for a single-node file backend rooted there, for an offline engine that
 	// needs no other configuration. Ignored when Path is set.
 	Dir string
+	// ReadOnly opens the engine without anything that writes: no WAL recovery (and so no checkpoint
+	// discarding segments), no flush, no merges, no retention, no cluster membership. A backup sets
+	// it, because "back up" must not mean "modify". See the package documentation.
+	ReadOnly bool
 }
 
 // engineFile is the "storage" block of an oteldb config file.
@@ -45,6 +49,7 @@ func OpenEngine(
 		return nil, nil, errors.New("one of -storage-config or -storage-dir is required")
 	}
 	scfg.SetDefaults()
+	scfg.ReadOnly = cfg.ReadOnly
 
 	// The telemetry is only a provider holder here; its zero value falls back to the global
 	// providers, which a one-shot command has no reason to configure.

--- a/internal/storagebackup/engine.go
+++ b/internal/storagebackup/engine.go
@@ -1,0 +1,56 @@
+package storagebackup
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+	"github.com/go-faster/sdk/app"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/oteldb/internal/config"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// EngineConfig selects the storage engine odbbackup reads from, or odbrestore writes to.
+type EngineConfig struct {
+	// Path is an oteldb config file; its "storage" block configures the engine. It is the way to
+	// reach a clustered engine, which is the case that matters: joining the destination cluster is
+	// what lets a restore's writes be routed and sharded by the ring rather than landing locally.
+	Path string
+	// Dir is the shorthand for a single-node file backend rooted there, for an offline engine that
+	// needs no other configuration. Ignored when Path is set.
+	Dir string
+}
+
+// engineFile is the "storage" block of an oteldb config file.
+type engineFile struct {
+	Storage storagebackend.Config `json:"storage" yaml:"storage"`
+}
+
+// OpenEngine opens the engine described by cfg. The returned func stops and flushes it.
+func OpenEngine(
+	ctx context.Context, cfg EngineConfig, lg *zap.Logger,
+) (*storagebackend.Backend, func(context.Context) error, error) {
+	var scfg storagebackend.Config
+	switch {
+	case cfg.Path != "":
+		file, err := config.Load[engineFile](cfg.Path, config.LoadOptions{})
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "load config")
+		}
+		scfg = file.Storage
+	case cfg.Dir != "":
+		scfg = storagebackend.Config{Backend: "file", Dir: cfg.Dir}
+	default:
+		return nil, nil, errors.New("one of -storage-config or -storage-dir is required")
+	}
+	scfg.SetDefaults()
+
+	// The telemetry is only a provider holder here; its zero value falls back to the global
+	// providers, which a one-shot command has no reason to configure.
+	back, stop, err := storagebackend.Open(ctx, scfg, lg, &app.Telemetry{})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "open storage engine")
+	}
+	return back, stop, nil
+}

--- a/internal/storagebackup/file.go
+++ b/internal/storagebackup/file.go
@@ -17,8 +17,15 @@ import (
 )
 
 // maxChunkBytes bounds one decoded chunk. A corrupt or hostile length prefix would otherwise ask
-// for an arbitrary allocation before anything has been validated.
+// for an arbitrary allocation before anything has been validated. It is the reader's hard bound,
+// and the ceiling on what a writer may be configured to emit.
 const maxChunkBytes = 512 << 20
+
+// DefaultMaxChunkBytes is the default size a backup splits a fetch batch at. A batch is whatever
+// the fetch seam returns for one stream over one day, which on a busy tenant runs to hundreds of
+// megabytes; splitting keeps the encoder's buffer bounded rather than proportional to the busiest
+// day. It is well under [maxChunkBytes] so a file stays readable by any build.
+const DefaultMaxChunkBytes = 64 << 20
 
 // filePath returns a chunk file's path relative to the backup root. The tenant element is escaped
 // because a cluster shard key contains a slash and a tenant id is otherwise unconstrained; the
@@ -36,12 +43,14 @@ type chunkWriter struct {
 	tmp   string
 	final string
 	buf   []byte
+	limit int
 
 	streams int
+	chunks  int
 	rows    int
 }
 
-func createChunkWriter(root, rel string, h FileHeader) (_ *chunkWriter, rerr error) {
+func createChunkWriter(root, rel string, h FileHeader, limit int) (_ *chunkWriter, rerr error) {
 	final := filepath.Join(root, filepath.FromSlash(rel))
 	if err := os.MkdirAll(filepath.Dir(final), 0o750); err != nil {
 		return nil, errors.Wrap(err, "create backup directory")
@@ -80,14 +89,61 @@ func createChunkWriter(root, rel string, h FileHeader) (_ *chunkWriter, rerr err
 		return nil, errors.Wrap(err, "write header")
 	}
 
-	return &chunkWriter{f: f, enc: enc, tmp: tmp, final: final}, nil
+	return &chunkWriter{f: f, enc: enc, tmp: tmp, final: final, limit: clampChunkLimit(limit)}, nil
 }
 
-// Write appends one chunk.
+// clampChunkLimit resolves a writer's chunk size: unset takes [DefaultMaxChunkBytes], and no
+// setting may exceed [maxChunkBytes], which is what a reader will accept.
+func clampChunkLimit(limit int) int {
+	if limit <= 0 {
+		limit = DefaultMaxChunkBytes
+	}
+	return min(limit, maxChunkBytes)
+}
+
+// Write appends one fetch batch, splitting it over as many chunks as its size needs.
+//
+// The split is by row, and every chunk repeats the batch's stream identity, so each one stays
+// independently decodable — the reader needs no notion of a continuation, and restore sees a split
+// batch as several writes of the same stream. That is a shape live ingest already produces, when
+// one stream's records arrive in more than one export, and the per-batch approximations (span
+// structural ids) are the same either way.
 func (w *chunkWriter) Write(c *Chunk) error {
-	w.buf = appendChunk(w.buf[:0], c)
-	if len(w.buf) > maxChunkBytes {
-		return errors.Errorf("chunk of %d bytes exceeds the %d byte limit", len(w.buf), maxChunkBytes)
+	w.streams++
+	w.rows += len(c.Timestamps)
+
+	rows := len(c.Timestamps)
+	if rows == 0 {
+		// An identity-only batch still carries its columns' shape; write it whole.
+		return w.writeRange(c, 0, 0)
+	}
+
+	budget := w.limit - chunkOverhead(c)
+	for i := 0; i < rows; {
+		j := min(i+rowsFitting(c, i, budget), rows)
+		if err := w.writeRange(c, i, j); err != nil {
+			return err
+		}
+		i = j
+	}
+	return nil
+}
+
+// writeRange writes rows [i, j) of c as one chunk, halving the range if the size estimate that
+// chose it turned out to be optimistic.
+func (w *chunkWriter) writeRange(c *Chunk, i, j int) error {
+	part := sliceChunk(c, i, j)
+	w.buf = appendChunk(w.buf[:0], &part)
+	if len(w.buf) > w.limit {
+		if j-i <= 1 {
+			return errors.Errorf("chunk of %d bytes exceeds the %d byte limit and holds a single row",
+				len(w.buf), w.limit)
+		}
+		mid := i + (j-i)/2
+		if err := w.writeRange(c, i, mid); err != nil {
+			return err
+		}
+		return w.writeRange(c, mid, j)
 	}
 
 	var frame [binary.MaxVarintLen64]byte
@@ -98,9 +154,7 @@ func (w *chunkWriter) Write(c *Chunk) error {
 	if _, err := w.enc.Write(w.buf); err != nil {
 		return errors.Wrap(err, "write chunk")
 	}
-
-	w.streams++
-	w.rows += len(c.Timestamps)
+	w.chunks++
 	return nil
 }
 

--- a/internal/storagebackup/file.go
+++ b/internal/storagebackup/file.go
@@ -1,0 +1,233 @@
+package storagebackup
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/go-faster/errors"
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/oteldb/storage/signal"
+)
+
+// maxChunkBytes bounds one decoded chunk. A corrupt or hostile length prefix would otherwise ask
+// for an arbitrary allocation before anything has been validated.
+const maxChunkBytes = 512 << 20
+
+// filePath returns a chunk file's path relative to the backup root. The tenant element is escaped
+// because a cluster shard key contains a slash and a tenant id is otherwise unconstrained; the
+// tenant recorded in the file's header stays authoritative.
+func filePath(sig signal.Signal, tenant signal.TenantID, day string) string {
+	return path.Join(sig.String(), url.PathEscape(string(tenant)), day+fileExt)
+}
+
+// chunkWriter writes one chunk file. It writes to a temporary name and renames on Close, so a file
+// present under its final name is complete — which is what makes an interrupted backup restartable
+// by skipping the days it already finished.
+type chunkWriter struct {
+	f     *os.File
+	enc   *zstd.Encoder
+	tmp   string
+	final string
+	buf   []byte
+
+	streams int
+	rows    int
+}
+
+func createChunkWriter(root, rel string, h FileHeader) (_ *chunkWriter, rerr error) {
+	final := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(final), 0o750); err != nil {
+		return nil, errors.Wrap(err, "create backup directory")
+	}
+
+	tmp := final + ".tmp"
+	f, err := os.Create(filepath.Clean(tmp))
+	if err != nil {
+		return nil, errors.Wrap(err, "create chunk file")
+	}
+	defer func() {
+		if rerr != nil {
+			_ = f.Close()
+			_ = os.Remove(tmp)
+		}
+	}()
+
+	enc, err := zstd.NewWriter(f)
+	if err != nil {
+		return nil, errors.Wrap(err, "make zstd encoder")
+	}
+	defer func() {
+		if rerr != nil {
+			_ = enc.Close()
+		}
+	}()
+
+	if _, err := enc.Write([]byte(fileMagic)); err != nil {
+		return nil, errors.Wrap(err, "write magic")
+	}
+	raw, err := json.Marshal(h)
+	if err != nil {
+		return nil, errors.Wrap(err, "encode header")
+	}
+	if _, err := enc.Write(appendBlob(nil, raw)); err != nil {
+		return nil, errors.Wrap(err, "write header")
+	}
+
+	return &chunkWriter{f: f, enc: enc, tmp: tmp, final: final}, nil
+}
+
+// Write appends one chunk.
+func (w *chunkWriter) Write(c *Chunk) error {
+	w.buf = appendChunk(w.buf[:0], c)
+	if len(w.buf) > maxChunkBytes {
+		return errors.Errorf("chunk of %d bytes exceeds the %d byte limit", len(w.buf), maxChunkBytes)
+	}
+
+	var frame [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(frame[:], uint64(len(w.buf)))
+	if _, err := w.enc.Write(frame[:n]); err != nil {
+		return errors.Wrap(err, "write chunk length")
+	}
+	if _, err := w.enc.Write(w.buf); err != nil {
+		return errors.Wrap(err, "write chunk")
+	}
+
+	w.streams++
+	w.rows += len(c.Timestamps)
+	return nil
+}
+
+// Close flushes the file and publishes it under its final name.
+func (w *chunkWriter) Close() error {
+	if err := w.enc.Close(); err != nil {
+		_ = w.f.Close()
+		return errors.Wrap(err, "close zstd encoder")
+	}
+	// Sync before the rename: the rename is what marks the file complete, so a crash must not be
+	// able to publish a name whose contents have not reached the disk.
+	if err := w.f.Sync(); err != nil {
+		_ = w.f.Close()
+		return errors.Wrap(err, "sync chunk file")
+	}
+	if err := w.f.Close(); err != nil {
+		return errors.Wrap(err, "close chunk file")
+	}
+	if err := os.Rename(w.tmp, w.final); err != nil {
+		return errors.Wrap(err, "publish chunk file")
+	}
+	return nil
+}
+
+// Abort discards a partially written file.
+func (w *chunkWriter) Abort() {
+	_ = w.enc.Close()
+	_ = w.f.Close()
+	_ = os.Remove(w.tmp)
+}
+
+// chunkReader reads a chunk file written by [chunkWriter].
+type chunkReader struct {
+	f   *os.File
+	dec *zstd.Decoder
+	r   *bufio.Reader
+	buf []byte
+}
+
+func openChunkReader(name string) (_ *chunkReader, _ FileHeader, rerr error) {
+	var h FileHeader
+
+	f, err := os.Open(filepath.Clean(name))
+	if err != nil {
+		return nil, h, errors.Wrap(err, "open chunk file")
+	}
+	defer func() {
+		if rerr != nil {
+			_ = f.Close()
+		}
+	}()
+
+	dec, err := zstd.NewReader(f)
+	if err != nil {
+		return nil, h, errors.Wrap(err, "make zstd decoder")
+	}
+	defer func() {
+		if rerr != nil {
+			dec.Close()
+		}
+	}()
+
+	r := bufio.NewReader(dec)
+	magic := make([]byte, len(fileMagic))
+	if _, err := io.ReadFull(r, magic); err != nil {
+		return nil, h, errors.Wrap(err, "read magic")
+	}
+	if string(magic) != fileMagic {
+		return nil, h, errors.New("not an oteldb storage backup file")
+	}
+
+	cr := &chunkReader{f: f, dec: dec, r: r}
+	raw, err := cr.readFrame()
+	if err != nil {
+		return nil, h, errors.Wrap(err, "read header")
+	}
+	if err := json.Unmarshal(raw, &h); err != nil {
+		return nil, h, errors.Wrap(err, "decode header")
+	}
+	if err := h.Validate(); err != nil {
+		return nil, h, err
+	}
+	return cr, h, nil
+}
+
+// Next decodes the next chunk, returning [io.EOF] at the end of the file. The returned chunk
+// aliases an internal buffer that the following call overwrites.
+func (r *chunkReader) Next() (Chunk, error) {
+	raw, err := r.readFrame()
+	if err != nil {
+		return Chunk{}, err
+	}
+	c, err := decodeChunk(raw)
+	if err != nil {
+		return Chunk{}, errors.Wrap(err, "decode chunk")
+	}
+	return c, nil
+}
+
+// readFrame reads one length-delimited frame into the reader's buffer.
+func (r *chunkReader) readFrame() ([]byte, error) {
+	n, err := binary.ReadUvarint(r.r)
+	switch {
+	case errors.Is(err, io.EOF):
+		return nil, io.EOF
+	case err != nil:
+		return nil, errors.Wrap(err, "read frame length")
+	}
+	if n > maxChunkBytes {
+		return nil, errors.Errorf("frame of %d bytes exceeds the %d byte limit", n, maxChunkBytes)
+	}
+
+	if uint64(cap(r.buf)) < n {
+		r.buf = make([]byte, n)
+	}
+	r.buf = r.buf[:n]
+	if _, err := io.ReadFull(r.r, r.buf); err != nil {
+		return nil, errors.Wrap(err, "read frame")
+	}
+	return r.buf, nil
+}
+
+// Close releases the file.
+func (r *chunkReader) Close() error {
+	r.dec.Close()
+	if err := r.f.Close(); err != nil {
+		return errors.Wrap(err, "close chunk file")
+	}
+	return nil
+}

--- a/internal/storagebackup/file.go
+++ b/internal/storagebackup/file.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 
 	"github.com/go-faster/errors"
 	"github.com/klauspost/compress/zstd"
@@ -26,6 +27,10 @@ const maxChunkBytes = 512 << 20
 // megabytes; splitting keeps the encoder's buffer bounded rather than proportional to the busiest
 // day. It is well under [maxChunkBytes] so a file stays readable by any build.
 const DefaultMaxChunkBytes = 64 << 20
+
+// frameReadStep bounds how much of a frame is allocated before any of it has been read, so the
+// buffer tracks bytes actually delivered rather than the length the stream claims.
+const frameReadStep = 1 << 20
 
 // filePath returns a chunk file's path relative to the backup root. The tenant element is escaped
 // because a cluster shard key contains a slash and a tenant id is otherwise unconstrained; the
@@ -186,28 +191,21 @@ func (w *chunkWriter) Abort() {
 	_ = os.Remove(w.tmp)
 }
 
-// chunkReader reads a chunk file written by [chunkWriter].
+// chunkReader reads a chunk stream written by [chunkWriter].
 type chunkReader struct {
-	f   *os.File
-	dec *zstd.Decoder
-	r   *bufio.Reader
-	buf []byte
+	closer io.Closer
+	dec    *zstd.Decoder
+	r      *bufio.Reader
+	buf    []byte
 }
 
-func openChunkReader(name string) (_ *chunkReader, _ FileHeader, rerr error) {
+// newChunkReader reads the magic and header off rd and returns a reader positioned at the first
+// chunk. It takes an [io.Reader] rather than a name so the stream can come from somewhere other
+// than a file, which is what lets the tests drive it through short and failing reads.
+func newChunkReader(rd io.Reader) (_ *chunkReader, _ FileHeader, rerr error) {
 	var h FileHeader
 
-	f, err := os.Open(filepath.Clean(name))
-	if err != nil {
-		return nil, h, errors.Wrap(err, "open chunk file")
-	}
-	defer func() {
-		if rerr != nil {
-			_ = f.Close()
-		}
-	}()
-
-	dec, err := zstd.NewReader(f)
+	dec, err := zstd.NewReader(rd)
 	if err != nil {
 		return nil, h, errors.Wrap(err, "make zstd decoder")
 	}
@@ -226,7 +224,7 @@ func openChunkReader(name string) (_ *chunkReader, _ FileHeader, rerr error) {
 		return nil, h, errors.New("not an oteldb storage backup file")
 	}
 
-	cr := &chunkReader{f: f, dec: dec, r: r}
+	cr := &chunkReader{dec: dec, r: r}
 	raw, err := cr.readFrame()
 	if err != nil {
 		return nil, h, errors.Wrap(err, "read header")
@@ -237,6 +235,28 @@ func openChunkReader(name string) (_ *chunkReader, _ FileHeader, rerr error) {
 	if err := h.Validate(); err != nil {
 		return nil, h, err
 	}
+	return cr, h, nil
+}
+
+func openChunkReader(name string) (_ *chunkReader, _ FileHeader, rerr error) {
+	var h FileHeader
+
+	f, err := os.Open(filepath.Clean(name))
+	if err != nil {
+		return nil, h, errors.Wrap(err, "open chunk file")
+	}
+	defer func() {
+		if rerr != nil {
+			_ = f.Close()
+		}
+	}()
+
+	cr, h, err := newChunkReader(f)
+	if err != nil {
+		return nil, h, err
+	}
+	cr.closer = f
+
 	return cr, h, nil
 }
 
@@ -255,6 +275,11 @@ func (r *chunkReader) Next() (Chunk, error) {
 }
 
 // readFrame reads one length-delimited frame into the reader's buffer.
+//
+// The frame is read in bounded steps rather than allocating the announced length up front: the
+// length comes out of the decompressed stream, so a few bytes of a corrupt or hostile file can
+// announce a frame far larger than the file could hold, and a length that lies then costs only
+// what the stream actually delivers.
 func (r *chunkReader) readFrame() ([]byte, error) {
 	n, err := binary.ReadUvarint(r.r)
 	switch {
@@ -267,20 +292,33 @@ func (r *chunkReader) readFrame() ([]byte, error) {
 		return nil, errors.Errorf("frame of %d bytes exceeds the %d byte limit", n, maxChunkBytes)
 	}
 
-	if uint64(cap(r.buf)) < n {
-		r.buf = make([]byte, n)
-	}
-	r.buf = r.buf[:n]
-	if _, err := io.ReadFull(r.r, r.buf); err != nil {
-		return nil, errors.Wrap(err, "read frame")
+	r.buf = r.buf[:0]
+	for uint64(len(r.buf)) < n {
+		want := int(min(n-uint64(len(r.buf)), frameReadStep))
+		r.buf = slices.Grow(r.buf, want)
+		at := len(r.buf)
+		r.buf = r.buf[:at+want]
+		if _, err := io.ReadFull(r.r, r.buf[at:]); err != nil {
+			// A frame that ends early is a truncated file, not the end of one: [io.ReadFull]
+			// reports io.EOF when it read nothing at all, and passing that up would make restore
+			// stop and report success over however much of the file survived.
+			if errors.Is(err, io.EOF) {
+				err = io.ErrUnexpectedEOF
+			}
+			return nil, errors.Wrap(err, "read frame")
+		}
 	}
 	return r.buf, nil
 }
 
-// Close releases the file.
+// Close releases the underlying stream. A reader over a plain [io.Reader] has nothing to release
+// beyond the decoder.
 func (r *chunkReader) Close() error {
 	r.dec.Close()
-	if err := r.f.Close(); err != nil {
+	if r.closer == nil {
+		return nil
+	}
+	if err := r.closer.Close(); err != nil {
 		return errors.Wrap(err, "close chunk file")
 	}
 	return nil

--- a/internal/storagebackup/file.go
+++ b/internal/storagebackup/file.go
@@ -114,6 +114,10 @@ func clampChunkLimit(limit int) int {
 // one stream's records arrive in more than one export, and the per-batch approximations (span
 // structural ids) are the same either way.
 func (w *chunkWriter) Write(c *Chunk) error {
+	if err := validateColumns(c.Columns); err != nil {
+		return err
+	}
+
 	w.streams++
 	w.rows += len(c.Timestamps)
 

--- a/internal/storagebackup/format.go
+++ b/internal/storagebackup/format.go
@@ -66,7 +66,10 @@ type FileInfo struct {
 	Tenant  string `json:"tenant"`
 	Day     string `json:"day"`
 	Streams int    `json:"streams"`
-	Rows    int    `json:"rows"`
+	// Chunks is how many chunks the file holds: one per stream, plus one for each split an
+	// oversized batch needed.
+	Chunks int `json:"chunks"`
+	Rows   int `json:"rows"`
 }
 
 // Chunk is one fetch batch as stored: a stream (or metric series) identity plus its rows. It
@@ -119,6 +122,89 @@ func appendChunk(dst []byte, c *Chunk) []byte {
 		}
 	}
 	return dst
+}
+
+// chunkOverhead is an upper bound on what [appendChunk] writes for a chunk of c's shape before any
+// row: the stream identity and the per-slice and per-column counts.
+func chunkOverhead(c *Chunk) int {
+	// The identity is encoded rather than estimated: it is the one part with no size bound, and
+	// getting it wrong is what would let a chunk overrun the limit.
+	n := binary.MaxVarintLen64 + len(c.Series.AppendHashInput(nil))
+	n += 3 * binary.MaxVarintLen64
+	for i := range c.Columns {
+		n += binary.MaxVarintLen64 + len(c.Columns[i].Name) + 1 + binary.MaxVarintLen64
+	}
+	return n
+}
+
+// rowsFitting returns how many of c's rows from i on fit in budget bytes, at least one. It sums an
+// upper bound per row, so the range it picks encodes to no more than the caller's limit; a caller
+// that oversteps anyway (a zero or negative budget) falls back to halving the range.
+func rowsFitting(c *Chunk, i, budget int) int {
+	n := 0
+	for j := i; j < len(c.Timestamps); j++ {
+		if n > 0 && n+rowSize(c, j) > budget {
+			return j - i
+		}
+		n += rowSize(c, j)
+	}
+	return len(c.Timestamps) - i
+}
+
+// rowSize bounds the bytes row i of c contributes to its chunk.
+func rowSize(c *Chunk, i int) int {
+	n := binary.MaxVarintLen64
+	if i < len(c.Values) {
+		n += 8
+	}
+	for k := range c.Columns {
+		col := &c.Columns[k]
+		switch {
+		case col.Int64 != nil:
+			n += binary.MaxVarintLen64
+		case col.Float64 != nil:
+			n += 8
+		case col.Bytes != nil:
+			n++
+			if i < len(col.Bytes) {
+				n += binary.MaxVarintLen64 + len(col.Bytes[i])
+			}
+		}
+	}
+	return n
+}
+
+// sliceChunk returns c restricted to rows [i, j), keeping the identity and the columns' kinds.
+func sliceChunk(c *Chunk, i, j int) Chunk {
+	out := Chunk{
+		Series:     c.Series,
+		Timestamps: sliceRows(c.Timestamps, i, j),
+		Values:     sliceRows(c.Values, i, j),
+	}
+	if c.Columns == nil {
+		return out
+	}
+
+	out.Columns = make([]fetch.NamedColumn, len(c.Columns))
+	for k := range c.Columns {
+		col := &c.Columns[k]
+		out.Columns[k] = fetch.NamedColumn{
+			Name:    col.Name,
+			Int64:   sliceRows(col.Int64, i, j),
+			Float64: sliceRows(col.Float64, i, j),
+			Bytes:   sliceRows(col.Bytes, i, j),
+		}
+	}
+	return out
+}
+
+// sliceRows takes rows [i, j) of a column, tolerating a slice shorter than the batch claims and
+// keeping a nil slice nil — for a column an empty slice and an absent one encode differently.
+func sliceRows[T any](vs []T, i, j int) []T {
+	if vs == nil {
+		return nil
+	}
+	return vs[min(i, len(vs)):min(j, len(vs))]
 }
 
 // decodeChunk decodes a chunk payload. The returned chunk owns no memory from src beyond what

--- a/internal/storagebackup/format.go
+++ b/internal/storagebackup/format.go
@@ -1,0 +1,313 @@
+package storagebackup
+
+import (
+	"encoding/binary"
+	"math"
+	"time"
+
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+)
+
+// FormatVersion is the backup format version. Restore refuses a file it does not know how to read
+// rather than guessing at its layout.
+const FormatVersion = 1
+
+// fileMagic prefixes every chunk file, so a truncated or unrelated file is rejected before its
+// bytes are interpreted as a length.
+const fileMagic = "ODBBK1\n"
+
+// fileExt is the extension of a chunk file. The ".zst" tail is honest: the whole file, magic
+// included, is one zstd stream.
+const fileExt = ".obk.zst"
+
+// dayLayout formats the UTC day a chunk file covers, and names the file.
+const dayLayout = "2006-01-02"
+
+// FileHeader is the JSON header of a chunk file. It is authoritative for the file's identity: the
+// path is only a convenience, since a tenant id has to be escaped to fit in one.
+type FileHeader struct {
+	Version int    `json:"version"`
+	Signal  string `json:"signal"`
+	Tenant  string `json:"tenant"`
+	Day     string `json:"day"`
+	// Start and End are the inclusive unix-nanosecond bounds the file's fetch used.
+	Start int64 `json:"start"`
+	End   int64 `json:"end"`
+}
+
+// Validate reports whether the header is one this build can restore.
+func (h FileHeader) Validate() error {
+	if h.Version != FormatVersion {
+		return errors.Errorf("unsupported backup format version %d (want %d)", h.Version, FormatVersion)
+	}
+	if _, err := signal.ParseSignal(h.Signal); err != nil {
+		return errors.Wrap(err, "header signal")
+	}
+	return nil
+}
+
+// Manifest is the operator-facing index of a backup directory. Restore does not need it: it walks
+// the tree and trusts each file's own header, so a backup that lost its manifest still restores.
+type Manifest struct {
+	Version   int        `json:"version"`
+	CreatedAt time.Time  `json:"created_at"`
+	Start     time.Time  `json:"start"`
+	End       time.Time  `json:"end"`
+	Files     []FileInfo `json:"files"`
+}
+
+// FileInfo describes one chunk file in a [Manifest].
+type FileInfo struct {
+	Path    string `json:"path"`
+	Signal  string `json:"signal"`
+	Tenant  string `json:"tenant"`
+	Day     string `json:"day"`
+	Streams int    `json:"streams"`
+	Rows    int    `json:"rows"`
+}
+
+// Chunk is one fetch batch as stored: a stream (or metric series) identity plus its rows. It
+// mirrors [fetch.Batch] minus the engine-internal bookkeeping, and is the unit restore converts
+// back into an ingestible batch.
+type Chunk struct {
+	Series     signal.Series
+	Timestamps []int64
+	// Values holds the samples of a metric series; nil for the record signals.
+	Values []float64
+	// Columns are the per-record columns of a record signal; nil for metrics.
+	Columns []fetch.NamedColumn
+}
+
+// Column kinds, as written into a chunk. They name which typed slice of a
+// [fetch.NamedColumn] is populated.
+const (
+	colEmpty   byte = 0
+	colInt64   byte = 1
+	colFloat64 byte = 2
+	colBytes   byte = 3
+)
+
+// appendChunk appends c's encoding to dst.
+//
+// The identity is written with [signal.Series.AppendHashInput], the engine's own reversible wire
+// form, so resource/scope/attribute types survive without a second encoding to keep in step with
+// the engine's.
+func appendChunk(dst []byte, c *Chunk) []byte {
+	dst = appendBlob(dst, c.Series.AppendHashInput(nil))
+	dst = appendInt64s(dst, c.Timestamps)
+	dst = appendFloat64s(dst, c.Values)
+
+	dst = binary.AppendUvarint(dst, uint64(len(c.Columns)))
+	for i := range c.Columns {
+		col := &c.Columns[i]
+		dst = appendBlob(dst, []byte(col.Name))
+		switch {
+		case col.Int64 != nil:
+			dst = append(dst, colInt64)
+			dst = appendInt64s(dst, col.Int64)
+		case col.Float64 != nil:
+			dst = append(dst, colFloat64)
+			dst = appendFloat64s(dst, col.Float64)
+		case col.Bytes != nil:
+			dst = append(dst, colBytes)
+			dst = appendBlobs(dst, col.Bytes)
+		default:
+			dst = append(dst, colEmpty)
+		}
+	}
+	return dst
+}
+
+// decodeChunk decodes a chunk payload. The returned chunk owns no memory from src beyond what
+// [signal.DecodeSeries] aliases, which the caller must copy before reusing the buffer.
+func decodeChunk(src []byte) (c Chunk, _ error) {
+	blob, off, err := readBlob(src)
+	if err != nil {
+		return c, errors.Wrap(err, "series blob")
+	}
+	if c.Series, _, err = signal.DecodeSeries(blob); err != nil {
+		return c, errors.Wrap(err, "decode series")
+	}
+
+	rest := src[off:]
+	if c.Timestamps, rest, err = readInt64s(rest); err != nil {
+		return c, errors.Wrap(err, "timestamps")
+	}
+	if c.Values, rest, err = readFloat64s(rest); err != nil {
+		return c, errors.Wrap(err, "values")
+	}
+
+	ncols, n := binary.Uvarint(rest)
+	if n <= 0 {
+		return c, errors.New("read column count")
+	}
+	rest = rest[n:]
+	if ncols > uint64(len(rest)) {
+		return c, errors.Errorf("column count %d exceeds remaining %d bytes", ncols, len(rest))
+	}
+
+	c.Columns = make([]fetch.NamedColumn, 0, ncols)
+	for range ncols {
+		name, off, err := readBlob(rest)
+		if err != nil {
+			return c, errors.Wrap(err, "column name")
+		}
+		rest = rest[off:]
+		if len(rest) == 0 {
+			return c, errors.New("truncated column kind")
+		}
+		kind := rest[0]
+		rest = rest[1:]
+
+		col := fetch.NamedColumn{Name: string(name)}
+		switch kind {
+		case colInt64:
+			if col.Int64, rest, err = readInt64s(rest); err != nil {
+				return c, errors.Wrapf(err, "column %q", col.Name)
+			}
+		case colFloat64:
+			if col.Float64, rest, err = readFloat64s(rest); err != nil {
+				return c, errors.Wrapf(err, "column %q", col.Name)
+			}
+		case colBytes:
+			if col.Bytes, rest, err = readBlobs(rest); err != nil {
+				return c, errors.Wrapf(err, "column %q", col.Name)
+			}
+		case colEmpty:
+		default:
+			return c, errors.Errorf("column %q: unknown kind %d", col.Name, kind)
+		}
+		c.Columns = append(c.Columns, col)
+	}
+	if len(rest) != 0 {
+		return c, errors.Errorf("%d trailing bytes", len(rest))
+	}
+	return c, nil
+}
+
+func appendBlob(dst, b []byte) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(b)))
+	return append(dst, b...)
+}
+
+func readBlob(src []byte) (blob []byte, read int, _ error) {
+	n, off := binary.Uvarint(src)
+	if off <= 0 {
+		return nil, 0, errors.New("read length")
+	}
+	if n > uint64(len(src)-off) {
+		return nil, 0, errors.Errorf("length %d exceeds remaining %d bytes", n, len(src)-off)
+	}
+	return src[off : off+int(n)], off + int(n), nil
+}
+
+func appendBlobs(dst []byte, bs [][]byte) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(bs)))
+	for _, b := range bs {
+		// A nil element is distinct from an empty one for a bytes column (an unset trace id versus
+		// an empty body), so nil is tagged rather than written as a zero-length blob.
+		if b == nil {
+			dst = append(dst, 0)
+			continue
+		}
+		dst = append(dst, 1)
+		dst = appendBlob(dst, b)
+	}
+	return dst
+}
+
+func readBlobs(src []byte) (blobs [][]byte, rest []byte, _ error) {
+	n, off := binary.Uvarint(src)
+	if off <= 0 {
+		return nil, nil, errors.New("read count")
+	}
+	src = src[off:]
+	if n > uint64(len(src)) {
+		return nil, nil, errors.Errorf("count %d exceeds remaining %d bytes", n, len(src))
+	}
+
+	out := make([][]byte, 0, n)
+	for range n {
+		if len(src) == 0 {
+			return nil, nil, errors.New("truncated element")
+		}
+		present := src[0]
+		src = src[1:]
+		if present == 0 {
+			out = append(out, nil)
+			continue
+		}
+		b, off, err := readBlob(src)
+		if err != nil {
+			return nil, nil, err
+		}
+		src = src[off:]
+		out = append(out, b)
+	}
+	return out, src, nil
+}
+
+func appendInt64s(dst []byte, vs []int64) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(vs)))
+	for _, v := range vs {
+		dst = binary.AppendVarint(dst, v)
+	}
+	return dst
+}
+
+func readInt64s(src []byte) (vs []int64, rest []byte, _ error) {
+	n, off := binary.Uvarint(src)
+	if off <= 0 {
+		return nil, nil, errors.New("read count")
+	}
+	src = src[off:]
+	if n > uint64(len(src)) {
+		return nil, nil, errors.Errorf("count %d exceeds remaining %d bytes", n, len(src))
+	}
+	if n == 0 {
+		return nil, src, nil
+	}
+
+	out := make([]int64, 0, n)
+	for range n {
+		v, off := binary.Varint(src)
+		if off <= 0 {
+			return nil, nil, errors.New("read value")
+		}
+		src = src[off:]
+		out = append(out, v)
+	}
+	return out, src, nil
+}
+
+func appendFloat64s(dst []byte, vs []float64) []byte {
+	dst = binary.AppendUvarint(dst, uint64(len(vs)))
+	for _, v := range vs {
+		dst = binary.LittleEndian.AppendUint64(dst, math.Float64bits(v))
+	}
+	return dst
+}
+
+func readFloat64s(src []byte) (vs []float64, rest []byte, _ error) {
+	n, off := binary.Uvarint(src)
+	if off <= 0 {
+		return nil, nil, errors.New("read count")
+	}
+	src = src[off:]
+	if n > uint64(len(src)/8) {
+		return nil, nil, errors.Errorf("count %d exceeds remaining %d bytes", n, len(src))
+	}
+	if n == 0 {
+		return nil, src, nil
+	}
+
+	out := make([]float64, 0, n)
+	for range n {
+		out = append(out, math.Float64frombits(binary.LittleEndian.Uint64(src)))
+		src = src[8:]
+	}
+	return out, src, nil
+}

--- a/internal/storagebackup/format.go
+++ b/internal/storagebackup/format.go
@@ -84,14 +84,37 @@ type Chunk struct {
 	Columns []fetch.NamedColumn
 }
 
-// Column kinds, as written into a chunk. They name which typed slice of a
-// [fetch.NamedColumn] is populated.
+// Column kinds, as written into a chunk. The values are the archive format and never change: a
+// backup written by an older build must still restore. They are mapped to and from
+// [fetch.ColumnKind] rather than being it, so an upstream renumbering cannot silently reinterpret
+// files already on disk.
+//
+// colEmpty is a column carrying no kind and no data. It is what an archive from before the engine
+// carried a kind holds, so it stays readable rather than becoming an error.
 const (
 	colEmpty   byte = 0
 	colInt64   byte = 1
 	colFloat64 byte = 2
 	colBytes   byte = 3
 )
+
+// validateColumns rejects a column whose kind does not account for the rows it carries. Writing it
+// would encode as colEmpty and lose those rows silently, which is the whole failure the engine's
+// kind exists to prevent — a backup is the wrong place to discover it.
+func validateColumns(cols []fetch.NamedColumn) error {
+	for i := range cols {
+		col := &cols[i]
+		if col.Kind.Valid() {
+			continue
+		}
+
+		if n := len(col.Int64) + len(col.Float64) + len(col.Bytes); n > 0 {
+			return errors.Errorf("column %q carries %d values with no column kind (%s)", col.Name, n, col.Kind)
+		}
+	}
+
+	return nil
+}
 
 // appendChunk appends c's encoding to dst.
 //
@@ -107,14 +130,18 @@ func appendChunk(dst []byte, c *Chunk) []byte {
 	for i := range c.Columns {
 		col := &c.Columns[i]
 		dst = appendBlob(dst, []byte(col.Name))
-		switch {
-		case col.Int64 != nil:
+		// The engine's own kind decides what is written, rather than which slice happens to be
+		// non-nil: a nil-check cannot tell an absent column from an empty one, and answers wrongly
+		// for a kind it has not been taught. [validateColumns] has already rejected the case where
+		// the two disagree.
+		switch col.Kind {
+		case fetch.KindInt64:
 			dst = append(dst, colInt64)
 			dst = appendInt64s(dst, col.Int64)
-		case col.Float64 != nil:
+		case fetch.KindFloat64:
 			dst = append(dst, colFloat64)
 			dst = appendFloat64s(dst, col.Float64)
-		case col.Bytes != nil:
+		case fetch.KindBytes:
 			dst = append(dst, colBytes)
 			dst = appendBlobs(dst, col.Bytes)
 		default:
@@ -190,6 +217,7 @@ func sliceChunk(c *Chunk, i, j int) Chunk {
 		col := &c.Columns[k]
 		out.Columns[k] = fetch.NamedColumn{
 			Name:    col.Name,
+			Kind:    col.Kind,
 			Int64:   sliceRows(col.Int64, i, j),
 			Float64: sliceRows(col.Float64, i, j),
 			Bytes:   sliceRows(col.Bytes, i, j),
@@ -251,14 +279,17 @@ func decodeChunk(src []byte) (c Chunk, _ error) {
 		col := fetch.NamedColumn{Name: string(name)}
 		switch kind {
 		case colInt64:
+			col.Kind = fetch.KindInt64
 			if col.Int64, rest, err = readInt64s(rest); err != nil {
 				return c, errors.Wrapf(err, "column %q", col.Name)
 			}
 		case colFloat64:
+			col.Kind = fetch.KindFloat64
 			if col.Float64, rest, err = readFloat64s(rest); err != nil {
 				return c, errors.Wrapf(err, "column %q", col.Name)
 			}
 		case colBytes:
+			col.Kind = fetch.KindBytes
 			if col.Bytes, rest, err = readBlobs(rest); err != nil {
 				return c, errors.Wrapf(err, "column %q", col.Name)
 			}

--- a/internal/storagebackup/format_internal_test.go
+++ b/internal/storagebackup/format_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -184,4 +185,29 @@ func FuzzDecodeChunk(f *testing.F) {
 		}
 		require.True(t, c.Series.Equal(again.Series))
 	})
+}
+
+// The chunk codec writes a column by asking which of [fetch.NamedColumn]'s typed slices is
+// populated, so a slice added upstream would fall through to colEmpty: the column would be backed
+// up as present-but-empty, silently, with nothing failing to build and no test noticing. This is
+// that notice. A failure here means the codec needs the new kind, not that this test needs the new
+// count.
+func TestNamedColumnKindsAreCovered(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		"Name":    "string",
+		"Int64":   "[]int64",
+		"Float64": "[]float64",
+		"Bytes":   "[][]uint8",
+	}
+
+	got := map[string]string{}
+	for f := range reflect.TypeFor[fetch.NamedColumn]().Fields() {
+		got[f.Name] = f.Type.String()
+	}
+
+	require.Equal(t, want, got,
+		"fetch.NamedColumn changed shape: teach appendChunk and decodeChunk the new column kind, "+
+			"and give it a byte in the colEmpty/colInt64/... block, before updating this test")
 }

--- a/internal/storagebackup/format_internal_test.go
+++ b/internal/storagebackup/format_internal_test.go
@@ -81,7 +81,7 @@ func TestChunkFile(t *testing.T) {
 	rel := "log/default/2024-01-02" + fileExt
 	header := FileHeader{Version: FormatVersion, Signal: "log", Tenant: "default", Day: "2024-01-02"}
 
-	w, err := createChunkWriter(dir, rel, header)
+	w, err := createChunkWriter(dir, rel, header, 0)
 	require.NoError(t, err)
 
 	want := testChunks()
@@ -117,7 +117,7 @@ func TestChunkFileAbort(t *testing.T) {
 	dir := t.TempDir()
 	rel := "log/default/2024-01-02" + fileExt
 
-	w, err := createChunkWriter(dir, rel, FileHeader{Version: FormatVersion, Signal: "log"})
+	w, err := createChunkWriter(dir, rel, FileHeader{Version: FormatVersion, Signal: "log"}, 0)
 	require.NoError(t, err)
 	c := testChunks()["Samples"]
 	require.NoError(t, w.Write(&c))
@@ -153,6 +153,13 @@ func requireSameFloats(tb testing.TB, want, got []float64) {
 func FuzzDecodeChunk(f *testing.F) {
 	for _, c := range testChunks() {
 		f.Add(appendChunk(nil, &c))
+	}
+	// The pieces an oversized batch is split into are ordinary chunks, so the split's boundary is
+	// in the corpus like any other shape.
+	big := bigChunk(4, 8)
+	for _, r := range [][2]int{{0, 0}, {0, 2}, {2, 4}} {
+		part := sliceChunk(&big, r[0], r[1])
+		f.Add(appendChunk(nil, &part))
 	}
 	f.Add([]byte{})
 	f.Add([]byte{0xff, 0xff, 0xff, 0xff})

--- a/internal/storagebackup/format_internal_test.go
+++ b/internal/storagebackup/format_internal_test.go
@@ -1,0 +1,180 @@
+package storagebackup
+
+import (
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+)
+
+func testChunks() map[string]Chunk {
+	return map[string]Chunk{
+		"Empty": {},
+		"IdentityOnly": {
+			Series: signal.Series{
+				Resource: signal.Resource{
+					SchemaURL:  []byte("https://schema"),
+					Attributes: signal.NewAttributes(signal.KeyValue{Key: []byte("k"), Value: signal.StringValue([]byte("v"))}),
+				},
+				Scope: signal.Scope{Name: []byte("scope"), Version: []byte("v1")},
+			},
+		},
+		"Samples": {
+			Series:     signal.Series{Resource: signal.Resource{Attributes: signal.NewAttributes(signal.KeyValue{Key: []byte("a"), Value: signal.IntValue(-3)})}},
+			Timestamps: []int64{-1, 0, 1 << 40},
+			Values:     []float64{0, -1.5, 1e308},
+		},
+		"Columns": {
+			Timestamps: []int64{1, 2},
+			Columns: []fetch.NamedColumn{
+				{Name: "severity", Int64: []int64{9, 17}},
+				// A nil element is not an empty one: an unset trace id must not come back as "".
+				{Name: "trace_id", Bytes: [][]byte{nil, []byte("x")}},
+				{Name: "ratio", Float64: []float64{0.25, 0.5}},
+				{Name: "absent"},
+			},
+		},
+	}
+}
+
+func TestChunkRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for name, c := range testChunks() {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := decodeChunk(appendChunk(nil, &c))
+			require.NoError(t, err)
+			require.True(t, c.Series.Equal(got.Series))
+			require.Equal(t, c.Timestamps, got.Timestamps)
+			require.Equal(t, c.Values, got.Values)
+			require.Len(t, got.Columns, len(c.Columns))
+			for i := range c.Columns {
+				require.Equal(t, c.Columns[i], got.Columns[i])
+			}
+		})
+	}
+}
+
+func TestChunkTruncated(t *testing.T) {
+	t.Parallel()
+
+	c := testChunks()["Columns"]
+	full := appendChunk(nil, &c)
+	for i := range len(full) {
+		_, err := decodeChunk(full[:i])
+		require.Error(t, err, "a %d-byte prefix must not decode", i)
+	}
+}
+
+func TestChunkFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rel := "log/default/2024-01-02" + fileExt
+	header := FileHeader{Version: FormatVersion, Signal: "log", Tenant: "default", Day: "2024-01-02"}
+
+	w, err := createChunkWriter(dir, rel, header)
+	require.NoError(t, err)
+
+	want := testChunks()
+	names := []string{"Columns", "IdentityOnly", "Samples"}
+	for _, name := range names {
+		c := want[name]
+		require.NoError(t, w.Write(&c))
+	}
+	require.NoError(t, w.Close())
+
+	// The file is published only on Close, so a name that exists is a complete file.
+	require.NoFileExists(t, filepath.Join(dir, filepath.FromSlash(rel))+".tmp")
+
+	r, got, err := openChunkReader(filepath.Join(dir, filepath.FromSlash(rel)))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, r.Close())
+	}()
+	require.Equal(t, header, got)
+
+	for _, name := range names {
+		c, err := r.Next()
+		require.NoError(t, err)
+		require.Equal(t, want[name].Timestamps, c.Timestamps)
+	}
+	_, err = r.Next()
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestChunkFileAbort(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rel := "log/default/2024-01-02" + fileExt
+
+	w, err := createChunkWriter(dir, rel, FileHeader{Version: FormatVersion, Signal: "log"})
+	require.NoError(t, err)
+	c := testChunks()["Samples"]
+	require.NoError(t, w.Write(&c))
+	w.Abort()
+
+	entries, err := os.ReadDir(filepath.Join(dir, "log", "default"))
+	require.NoError(t, err)
+	require.Empty(t, entries, "an aborted day leaves nothing behind for a resumed run to trust")
+}
+
+func TestOpenChunkReaderRejects(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	name := filepath.Join(dir, "bogus"+fileExt)
+	require.NoError(t, os.WriteFile(name, []byte("not zstd"), 0o600))
+
+	_, _, err := openChunkReader(name)
+	require.Error(t, err)
+}
+
+// requireSameFloats compares bit patterns rather than values, so a NaN that round-trips unchanged
+// is equal to itself.
+func requireSameFloats(tb testing.TB, want, got []float64) {
+	tb.Helper()
+
+	require.Len(tb, got, len(want))
+	for i := range want {
+		require.Equal(tb, math.Float64bits(want[i]), math.Float64bits(got[i]), "value %d", i)
+	}
+}
+
+func FuzzDecodeChunk(f *testing.F) {
+	for _, c := range testChunks() {
+		f.Add(appendChunk(nil, &c))
+	}
+	f.Add([]byte{})
+	f.Add([]byte{0xff, 0xff, 0xff, 0xff})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		c, err := decodeChunk(data)
+		if err != nil {
+			return
+		}
+		// Anything that decodes must re-encode and decode again to the same thing, so a malformed
+		// input cannot smuggle in a chunk the encoder could never have produced.
+		again, err := decodeChunk(appendChunk(nil, &c))
+		require.NoError(t, err)
+		require.Equal(t, c.Timestamps, again.Timestamps)
+		requireSameFloats(t, c.Values, again.Values)
+		require.Len(t, again.Columns, len(c.Columns))
+		for i := range c.Columns {
+			require.Equal(t, c.Columns[i].Name, again.Columns[i].Name)
+			require.Equal(t, c.Columns[i].Int64, again.Columns[i].Int64)
+			require.Equal(t, c.Columns[i].Bytes, again.Columns[i].Bytes)
+			requireSameFloats(t, c.Columns[i].Float64, again.Columns[i].Float64)
+		}
+		require.True(t, c.Series.Equal(again.Series))
+	})
+}

--- a/internal/storagebackup/format_internal_test.go
+++ b/internal/storagebackup/format_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oteldb/storage/query/fetch"
@@ -34,10 +35,12 @@ func testChunks() map[string]Chunk {
 		"Columns": {
 			Timestamps: []int64{1, 2},
 			Columns: []fetch.NamedColumn{
-				{Name: "severity", Int64: []int64{9, 17}},
+				fetch.Int64Column("severity", []int64{9, 17}),
 				// A nil element is not an empty one: an unset trace id must not come back as "".
-				{Name: "trace_id", Bytes: [][]byte{nil, []byte("x")}},
-				{Name: "ratio", Float64: []float64{0.25, 0.5}},
+				fetch.BytesColumn("trace_id", [][]byte{nil, []byte("x")}),
+				fetch.Float64Column("ratio", []float64{0.25, 0.5}),
+				// A column with neither kind nor rows: what an archive written before the engine
+				// carried a kind holds, and it must stay readable.
 				{Name: "absent"},
 			},
 		},
@@ -197,6 +200,7 @@ func TestNamedColumnKindsAreCovered(t *testing.T) {
 
 	want := map[string]string{
 		"Name":    "string",
+		"Kind":    "fetch.ColumnKind",
 		"Int64":   "[]int64",
 		"Float64": "[]float64",
 		"Bytes":   "[][]uint8",
@@ -209,5 +213,59 @@ func TestNamedColumnKindsAreCovered(t *testing.T) {
 
 	require.Equal(t, want, got,
 		"fetch.NamedColumn changed shape: teach appendChunk and decodeChunk the new column kind, "+
-			"and give it a byte in the colEmpty/colInt64/... block, before updating this test")
+			"and give it a byte in the colEmpty/colInt64/... block — the existing bytes are the archive "+
+			"format and must keep their meaning — before updating this test")
+}
+
+// The engine's column kind is what the codec writes, so it has to come back — a restored column
+// that lost its kind would be fed to the write path as kindless and rejected there instead.
+func TestChunkRoundTripKeepsColumnKind(t *testing.T) {
+	t.Parallel()
+
+	c := Chunk{
+		Timestamps: []int64{1, 2},
+		Columns: []fetch.NamedColumn{
+			fetch.Int64Column("severity", []int64{9, 17}),
+			fetch.Float64Column("ratio", []float64{0.25, 0.5}),
+			fetch.BytesColumn("trace_id", [][]byte{nil, []byte("x")}),
+			// Empty but kinded: distinguishable from absent only because the kind is carried.
+			fetch.BytesColumn("empty", nil),
+			{Name: "absent"},
+		},
+	}
+
+	got, err := decodeChunk(appendChunk(nil, &c))
+	require.NoError(t, err)
+	require.Len(t, got.Columns, len(c.Columns))
+
+	for i := range c.Columns {
+		assert.Equal(t, c.Columns[i].Kind, got.Columns[i].Kind, "column %q", c.Columns[i].Name)
+	}
+
+	assert.Equal(t, fetch.KindBytes, got.Columns[3].Kind, "an empty bytes column is still a bytes column")
+	assert.False(t, got.Columns[4].Kind.Valid(), "a column with no kind stays kindless")
+}
+
+// A column carrying rows under no kind is the silent-loss case the engine's kind exists to prevent:
+// the codec would write it as empty and the rows would be gone with nothing failing. A backup is a
+// bad place to find that out, so the writer refuses it.
+func TestWriteRejectsKindlessColumnWithRows(t *testing.T) {
+	t.Parallel()
+
+	w, err := createChunkWriter(t.TempDir(), "log/default/2024-01-02"+fileExt,
+		FileHeader{Version: FormatVersion, Signal: "log"}, 0)
+	require.NoError(t, err)
+	defer w.Abort()
+
+	err = w.Write(&Chunk{
+		Timestamps: []int64{1, 2},
+		Columns:    []fetch.NamedColumn{{Name: "severity", Int64: []int64{9, 17}}},
+	})
+	require.ErrorContains(t, err, "no column kind")
+
+	// An absent column carries nothing, so nothing is lost by writing it: it stays legal.
+	require.NoError(t, w.Write(&Chunk{
+		Timestamps: []int64{1},
+		Columns:    []fetch.NamedColumn{{Name: "absent"}},
+	}))
 }

--- a/internal/storagebackup/readonly_test.go
+++ b/internal/storagebackup/readonly_test.go
@@ -1,0 +1,107 @@
+package storagebackup_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/oteldb/storage"
+	backendfile "github.com/oteldb/storage/backend/file"
+
+	"github.com/oteldb/oteldb/internal/storagebackup"
+)
+
+// openFileStore opens a durable engine over dir, shaped like a node's: parts in dir, WAL beside
+// them, no maintenance loop so nothing happens on a timer.
+func openFileStore(tb testing.TB, dir string) *storage.Storage {
+	tb.Helper()
+
+	fb, err := backendfile.New(dir)
+	require.NoError(tb, err)
+
+	store, err := storage.Open(tb.Context(), storage.Options{},
+		storage.WithBackend(fb),
+		storage.WithWALDir(filepath.Join(dir, "wal")),
+		storage.WithFlushInterval(-1),
+	)
+	require.NoError(tb, err)
+	return store
+}
+
+// liveNodeDir builds a data directory in the state a running node's is in: some data flushed into
+// parts, and more of it still only in the write-ahead log, because the second store is abandoned
+// rather than closed — exactly what a copy taken from a live node holds.
+func liveNodeDir(tb testing.TB) string {
+	tb.Helper()
+
+	dir := tb.TempDir()
+
+	flushed := openFileStore(tb, dir)
+	writeSample(tb, flushed)
+	require.NoError(tb, flushed.Close(context.WithoutCancel(tb.Context())))
+
+	unflushed := openFileStore(tb, dir)
+	writeSample(tb, unflushed)
+
+	return dir
+}
+
+// treeState fingerprints every file under dir, so any write — a new part, a rewritten bucket index,
+// a WAL checkpoint — shows up as a difference.
+func treeState(tb testing.TB, dir string) map[string]string {
+	tb.Helper()
+
+	out := map[string]string{}
+	require.NoError(tb, filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(data)
+		out[filepath.ToSlash(rel)] = hex.EncodeToString(sum[:])
+		return nil
+	}))
+	return out
+}
+
+// TestBackupDoesNotWriteToDataDir pins that backing up a data directory does not modify it. Opening
+// it read-write recovers the WAL, flushes a head into a new part and checkpoints the segments away
+// — which, pointed at a running node, is a second writer discarding segments the node still owns.
+func TestBackupDoesNotWriteToDataDir(t *testing.T) {
+	t.Parallel()
+
+	lg := zaptest.NewLogger(t)
+	dir := liveNodeDir(t)
+	before := treeState(t, dir)
+	require.NotEmpty(t, before)
+
+	back, stop, err := storagebackup.OpenEngine(t.Context(), storagebackup.EngineConfig{
+		Dir:      dir,
+		ReadOnly: true,
+	}, lg)
+	require.NoError(t, err)
+
+	store := back.Store()
+	require.NotNil(t, store)
+
+	stats, err := storagebackup.NewBackup(store, lg, backupOptions()).Create(t.Context(), t.TempDir())
+	require.NoError(t, err)
+	require.Positive(t, stats.Rows, "the backup must have read the flushed parts")
+	require.NoError(t, stop(context.WithoutCancel(t.Context())))
+
+	require.Equal(t, before, treeState(t, dir), "a backup must not write to the data directory")
+}

--- a/internal/storagebackup/readonly_test.go
+++ b/internal/storagebackup/readonly_test.go
@@ -81,6 +81,9 @@ func treeState(tb testing.TB, dir string) map[string]string {
 // TestBackupDoesNotWriteToDataDir pins that backing up a data directory does not modify it. Opening
 // it read-write recovers the WAL, flushes a head into a new part and checkpoints the segments away
 // — which, pointed at a running node, is a second writer discarding segments the node still owns.
+//
+// It holds for a directory whose parts are all referenced. It does not hold for one carrying
+// orphans; see [TestBackupSweepsOrphanedObjects] for the write this cannot suppress.
 func TestBackupDoesNotWriteToDataDir(t *testing.T) {
 	t.Parallel()
 
@@ -104,4 +107,51 @@ func TestBackupDoesNotWriteToDataDir(t *testing.T) {
 	require.NoError(t, stop(context.WithoutCancel(t.Context())))
 
 	require.Equal(t, before, treeState(t, dir), "a backup must not write to the data directory")
+}
+
+// TestBackupSweepsOrphanedObjects pins the one write a read-only backup cannot suppress: opening an
+// engine deletes the part objects its bucket index does not name, and both load modes
+// storage.Storage can select do that — the mode that sweeps nothing is internal to the engine
+// (oteldb/storage#583).
+//
+// It is not data loss: an orphan is by definition unreferenced, so consecutive backups of the same
+// directory return identical rows. But a copy diverges from its original the first time it is
+// backed up, which is why this is pinned rather than left to be discovered — and why
+// [TestBackupDoesNotWriteToDataDir] passes only because its directory happens to have none.
+//
+// When #583 lands, this is the test that should fail, and its assertion inverts.
+func TestBackupSweepsOrphanedObjects(t *testing.T) {
+	t.Parallel()
+
+	lg := zaptest.NewLogger(t)
+	dir := liveNodeDir(t)
+
+	// An object no bucket index names, which is what a failed flush leaves behind. A long-running
+	// node accumulates them, since this sweep is the only thing that reclaims them.
+	orphan := filepath.Join(dir, "default", "logs", "01M1FGJ51CVRFV96490N2AD7AH", "c", "0")
+	require.NoError(t, os.MkdirAll(filepath.Dir(orphan), 0o750))
+	require.NoError(t, os.WriteFile(orphan, []byte("unreferenced"), 0o600))
+
+	before := treeState(t, dir)
+
+	back, stop, err := storagebackup.OpenEngine(t.Context(), storagebackup.EngineConfig{
+		Dir:      dir,
+		ReadOnly: true,
+	}, lg)
+	require.NoError(t, err)
+
+	stats, err := storagebackup.NewBackup(back.Store(), lg, backupOptions()).Create(t.Context(), t.TempDir())
+	require.NoError(t, err)
+	require.Positive(t, stats.Rows, "the committed data is still backed up")
+	require.NoError(t, stop(context.WithoutCancel(t.Context())))
+
+	rel := filepath.ToSlash(filepath.Join("default", "logs", "01M1FGJ51CVRFV96490N2AD7AH", "c", "0"))
+	after := treeState(t, dir)
+
+	if _, kept := after[rel]; kept {
+		t.Skip("the open no longer sweeps: storage exposes a read-only load, so invert this test")
+	}
+
+	delete(before, rel)
+	require.Equal(t, before, after, "the sweep takes the orphan and nothing else")
 }

--- a/internal/storagebackup/reshard_test.go
+++ b/internal/storagebackup/reshard_test.go
@@ -1,0 +1,141 @@
+package storagebackup_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/cluster"
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/storagebackup"
+)
+
+// baseTenant is the logical tenant the shard keys below split.
+const baseTenant signal.TenantID = "default"
+
+// shardRouter emulates a cluster's placement inside a single-node engine: it keys each stream by
+// the shard its identity hashes to, exactly as [cluster.ShardKeyOf] does on the write path. A real
+// cluster needs etcd, which a hermetic test cannot have; what it would do to the tenant key is
+// this.
+func shardRouter(n int) func(signal.Resource, signal.Scope) signal.TenantID {
+	return func(r signal.Resource, sc signal.Scope) signal.TenantID {
+		id := signal.Series{Resource: r, Scope: sc}.Hash()
+		return cluster.ShardKeyOf(baseTenant, cluster.ShardOf(id, n), n)
+	}
+}
+
+// writeSpread writes one log record per service, so the streams hash across several shards instead
+// of piling onto one.
+func writeSpread(tb testing.TB, store *storage.Storage) {
+	tb.Helper()
+
+	services := []string{"api", "worker", "cron", "gateway", "billing", "search", "auth", "cache"}
+	for i, svc := range services {
+		var logs siglog.Logs
+		rl := logs.AddResource()
+		rl.Resource = signal.Resource{Attributes: attrs(str("service.name", svc))}
+		sl := rl.AddScope()
+		sl.Scope = signal.Scope{Name: []byte("scope")}
+
+		r := sl.AddRecord()
+		r.Timestamp = at(4, i)
+		r.SeverityNumber = 9
+		r.Body = []byte("body-" + svc)
+		r.Attributes = attrs(str("service", svc))
+
+		acc, err := store.WriteLogs(tb.Context(), logs)
+		require.NoError(tb, err)
+		require.Zero(tb, acc.Rejected)
+	}
+}
+
+// occupiedShards reports which of a tenant's n shard keys hold log data.
+func occupiedShards(tb testing.TB, store *storage.Storage, n int) []signal.TenantID {
+	tb.Helper()
+
+	var out []signal.TenantID
+	for _, key := range cluster.ShardKeys(baseTenant, n) {
+		if len(collectLogs(tb, store, key)) > 0 {
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+// TestReshard is the property that justifies the design: a backup taken from a two-shard cluster
+// restores into a three-shard one and stays readable, because restore goes through the write path
+// and the destination re-derives every shard key.
+func TestReshard(t *testing.T) {
+	t.Parallel()
+
+	const (
+		srcShards = 2
+		dstShards = 3
+	)
+
+	lg := zaptest.NewLogger(t)
+	src := newStore(t, shardRouter(srcShards))
+	writeSpread(t, src)
+
+	srcKeys := occupiedShards(t, src, srcShards)
+	require.Len(t, srcKeys, srcShards, "the sample must actually span the source's shards")
+
+	dir := t.TempDir()
+	stats, err := storagebackup.NewBackup(src, lg, backupOptions()).Create(t.Context(), dir)
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Files, "both shards fold into one logical tenant's day file")
+
+	// The backup records the logical tenant, not the source's shard keys. Recording the keys would
+	// pin the data to a cluster with exactly srcShards shards, which is the whole problem.
+	tenants, err := os.ReadDir(filepath.Join(dir, "log"))
+	require.NoError(t, err)
+	require.Len(t, tenants, 1)
+	require.Equal(t, string(baseTenant), tenants[0].Name())
+
+	dst := newStore(t, shardRouter(dstShards))
+	_, err = storagebackup.NewRestore(storagebackend.New(dst), lg, storagebackup.RestoreOptions{}).
+		Restore(t.Context(), dir)
+	require.NoError(t, err)
+
+	dstKeys := occupiedShards(t, dst, dstShards)
+	require.Len(t, dstKeys, dstShards, "the restored data must spread over the destination's shards")
+	require.Contains(t, dstKeys, cluster.ShardKeyOf(baseTenant, 2, dstShards),
+		"a shard key that does not exist in the source's shape must now hold data")
+
+	require.Equal(t,
+		collectLogs(t, src, cluster.ShardKeys(baseTenant, srcShards)...),
+		collectLogs(t, dst, cluster.ShardKeys(baseTenant, dstShards)...),
+		"every record survives the re-keying",
+	)
+}
+
+// TestReshardToSingleShard covers the other direction: collapsing a sharded tenant back onto one
+// key, which is what an operator does when shards_per_tenant is lowered.
+func TestReshardToSingleShard(t *testing.T) {
+	t.Parallel()
+
+	lg := zaptest.NewLogger(t)
+	src := newStore(t, shardRouter(4))
+	writeSpread(t, src)
+
+	dir := t.TempDir()
+	_, err := storagebackup.NewBackup(src, lg, backupOptions()).Create(t.Context(), dir)
+	require.NoError(t, err)
+
+	dst := newStore(t, nil)
+	_, err = storagebackup.NewRestore(storagebackend.New(dst), lg, storagebackup.RestoreOptions{}).
+		Restore(t.Context(), dir)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		collectLogs(t, src, cluster.ShardKeys(baseTenant, 4)...),
+		collectLogs(t, dst, baseTenant),
+	)
+}

--- a/internal/storagebackup/restore.go
+++ b/internal/storagebackup/restore.go
@@ -1,0 +1,245 @@
+package storagebackup
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+)
+
+// Sink is the write seam a restore ingests through: the storage engine's ordinary batch entry
+// points. *[github.com/oteldb/oteldb/internal/storagebackend.Backend] implements it.
+//
+// Restore deliberately has no way to place part files, and no way to name a destination tenant:
+// both are decisions the destination's write path makes, and letting a backup dictate them is
+// exactly what would pin the data to the shape of the cluster it came from.
+type Sink interface {
+	WriteLogs(ctx context.Context, batch siglog.Logs) error
+	WriteTraces(ctx context.Context, batch sigtrace.Traces) error
+	WriteMetrics(ctx context.Context, batch sigmetric.Metrics) error
+}
+
+// DefaultRestoreBatchSize is the default [RestoreOptions.BatchSize].
+const DefaultRestoreBatchSize = 5_000
+
+// RestoreOptions configures a [Restore].
+type RestoreOptions struct {
+	// Signals selects what to restore. Empty ⇒ every signal present in the backup.
+	Signals []signal.Signal
+	// Tenant restores only files backed up from this logical tenant. Empty ⇒ every tenant, which
+	// merges them all into the destination's own tenant.
+	Tenant signal.TenantID
+	// BatchSize is the number of records, spans or samples buffered per write. Zero ⇒
+	// [DefaultRestoreBatchSize].
+	BatchSize int
+}
+
+// RestoreStats counts what a restore ingested.
+type RestoreStats struct {
+	Files   int
+	Streams int
+	Rows    int
+	Batches int
+}
+
+// Restore re-ingests a backup directory through a [Sink].
+type Restore struct {
+	sink Sink
+	lg   *zap.Logger
+	opts RestoreOptions
+}
+
+// NewRestore creates a [Restore] writing into sink.
+func NewRestore(sink Sink, lg *zap.Logger, opts RestoreOptions) *Restore {
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = DefaultRestoreBatchSize
+	}
+	return &Restore{sink: sink, lg: lg, opts: opts}
+}
+
+// Restore walks dir and re-ingests every chunk file it holds. The manifest is not consulted: each
+// file carries its own header, so a backup that lost its manifest still restores.
+func (r *Restore) Restore(ctx context.Context, dir string) (RestoreStats, error) {
+	var stats RestoreStats
+
+	files, err := chunkFiles(dir)
+	if err != nil {
+		return stats, err
+	}
+	for _, name := range files {
+		fileStats, err := r.file(ctx, name)
+		if err != nil {
+			return stats, errors.Wrapf(err, "restore %s", name)
+		}
+		if fileStats.Files == 0 {
+			continue
+		}
+		stats.Files += fileStats.Files
+		stats.Streams += fileStats.Streams
+		stats.Rows += fileStats.Rows
+		stats.Batches += fileStats.Batches
+	}
+	return stats, nil
+}
+
+// file restores one chunk file. A file filtered out by the options yields zero stats.
+func (r *Restore) file(ctx context.Context, name string) (stats RestoreStats, rerr error) {
+	cr, h, err := openChunkReader(name)
+	if err != nil {
+		return stats, err
+	}
+	defer func() {
+		if err := cr.Close(); err != nil && rerr == nil {
+			rerr = err
+		}
+	}()
+
+	sig, err := signal.ParseSignal(h.Signal)
+	if err != nil {
+		return stats, err
+	}
+	if len(r.opts.Signals) > 0 && !slices.Contains(r.opts.Signals, sig) {
+		return stats, nil
+	}
+	if r.opts.Tenant != "" && signal.TenantID(h.Tenant) != r.opts.Tenant {
+		return stats, nil
+	}
+
+	acc := newAccumulator(r.sink, sig, r.opts.BatchSize)
+	for {
+		c, err := cr.Next()
+		switch {
+		case errors.Is(err, io.EOF):
+			if err := acc.Flush(ctx); err != nil {
+				return stats, err
+			}
+			stats.Files = 1
+			stats.Streams += acc.streams
+			stats.Rows += acc.rows
+			stats.Batches += acc.batches
+			r.lg.Info("Restored",
+				zap.String("signal", h.Signal),
+				zap.String("tenant", h.Tenant),
+				zap.String("day", h.Day),
+				zap.Int("streams", acc.streams),
+				zap.Int("rows", acc.rows),
+			)
+			return stats, nil
+		case err != nil:
+			return stats, err
+		}
+		if err := acc.Add(ctx, &c); err != nil {
+			return stats, err
+		}
+	}
+}
+
+// accumulator buffers converted chunks into one signal's ingest batch and writes it once it holds
+// batchSize rows.
+type accumulator struct {
+	sink      Sink
+	sig       signal.Signal
+	batchSize int
+
+	logs    siglog.Logs
+	traces  sigtrace.Traces
+	metrics sigmetric.Metrics
+
+	pending int
+	streams int
+	rows    int
+	batches int
+}
+
+func newAccumulator(sink Sink, sig signal.Signal, batchSize int) *accumulator {
+	return &accumulator{sink: sink, sig: sig, batchSize: batchSize}
+}
+
+// Add converts one chunk into the pending batch, flushing first if the batch is already full.
+func (a *accumulator) Add(ctx context.Context, c *Chunk) error {
+	var n int
+	switch a.sig {
+	case signal.Log:
+		n = appendLogs(&a.logs, c)
+	case signal.Trace:
+		n = appendTraces(&a.traces, c)
+	case signal.Metric:
+		var err error
+		if n, err = appendMetrics(&a.metrics, c); err != nil {
+			return errors.Wrap(err, "convert metric series")
+		}
+	default:
+		return errors.Errorf("signal %s cannot be restored", a.sig)
+	}
+
+	a.streams++
+	a.rows += n
+	a.pending += n
+	if a.pending >= a.batchSize {
+		return a.Flush(ctx)
+	}
+	return nil
+}
+
+// Flush writes the pending batch, if any.
+func (a *accumulator) Flush(ctx context.Context) error {
+	if a.pending == 0 {
+		return nil
+	}
+
+	var err error
+	switch a.sig {
+	case signal.Log:
+		err = a.sink.WriteLogs(ctx, a.logs)
+		a.logs.Reset()
+	case signal.Trace:
+		err = a.sink.WriteTraces(ctx, a.traces)
+		a.traces.Reset()
+	case signal.Metric:
+		err = a.sink.WriteMetrics(ctx, a.metrics)
+		a.metrics.Reset()
+	}
+	if err != nil {
+		return errors.Wrapf(err, "write %s batch", a.sig)
+	}
+
+	a.pending = 0
+	a.batches++
+	return nil
+}
+
+// chunkFiles lists a backup's chunk files in a deterministic order. Anything else in the tree —
+// the manifest, an interrupted ".tmp" file, an operator's notes — is ignored.
+func chunkFiles(dir string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), fileExt) {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	switch {
+	case os.IsNotExist(err):
+		return nil, errors.Errorf("backup directory %q does not exist", dir)
+	case err != nil:
+		return nil, errors.Wrap(err, "walk backup directory")
+	}
+
+	slices.Sort(out)
+	return out, nil
+}

--- a/internal/storagebackup/roundtrip_test.go
+++ b/internal/storagebackup/roundtrip_test.go
@@ -1,0 +1,226 @@
+package storagebackup_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/storagebackend"
+	"github.com/oteldb/oteldb/internal/storagebackup"
+)
+
+// writeSample fills store with one day of logs, traces and metrics exercising every field the
+// engine persists, so a dropped column shows up as a mismatch rather than as an untested field.
+func writeSample(tb testing.TB, store *storage.Storage) {
+	tb.Helper()
+
+	var logs siglog.Logs
+	for _, svc := range []string{"api", "worker"} {
+		rl := logs.AddResource()
+		rl.Resource = signal.Resource{
+			SchemaURL:  []byte("https://opentelemetry.io/schemas/1.24.0"),
+			Attributes: attrs(str("service.name", svc), num("service.instance", 7)),
+		}
+		sl := rl.AddScope()
+		sl.Scope = signal.Scope{
+			Name:       []byte("scope-" + svc),
+			Version:    []byte("v1.2.3"),
+			SchemaURL:  []byte("https://opentelemetry.io/schemas/1.24.0"),
+			Attributes: attrs(str("scope.kind", "library")),
+		}
+		for i := range 3 {
+			r := sl.AddRecord()
+			r.Timestamp = at(1, i)
+			r.ObservedTimestamp = at(1, i) + 500
+			r.SeverityNumber = int32(9 + i)
+			r.SeverityText = []byte("INFO")
+			r.Body = []byte(svc + "-body-" + string(rune('a'+i)))
+			r.TraceID = []byte("0123456789abcdef")
+			r.SpanID = []byte("01234567")
+			r.Flags = uint32(i + 1)
+			r.Dropped = uint32(i)
+			r.Attributes = attrs(str("http.route", "/v1/x"), num("http.status", int64(200+i)))
+		}
+	}
+	acc, err := store.WriteLogs(tb.Context(), logs)
+	require.NoError(tb, err)
+	require.Zero(tb, acc.Rejected)
+
+	var traces sigtrace.Traces
+	rs := traces.AddResource()
+	rs.Resource = signal.Resource{Attributes: attrs(str("service.name", "api"))}
+	ss := rs.AddScope()
+	ss.Scope = signal.Scope{Name: []byte("tracer"), Version: []byte("v0.1.0")}
+	for i := range 3 {
+		sp := ss.AddSpan()
+		sp.TraceID = []byte("trace-id-16bytes")
+		sp.SpanID = []byte{byte(i), 1, 2, 3, 4, 5, 6, 7}
+		if i > 0 {
+			sp.ParentSpanID = []byte{0, 1, 2, 3, 4, 5, 6, 7}
+		}
+		sp.Name = []byte("span-" + string(rune('a'+i)))
+		sp.Kind = int32(i + 1)
+		sp.StatusCode = int32(i % 3)
+		sp.StatusMessage = []byte("ok")
+		sp.Start = at(2, i)
+		sp.End = at(2, i) + 1_000_000
+		sp.Attributes = attrs(str("db.system", "clickhouse"), num("retries", int64(i)))
+
+		ev := sp.AddEvent()
+		ev.Time = at(2, i) + 10
+		ev.Name = []byte("exception")
+		ev.Attributes = attrs(str("exception.type", "boom"))
+
+		ln := sp.AddLink()
+		ln.TraceID = []byte("other-trace-id16")
+		ln.SpanID = []byte{9, 9, 9, 9, 9, 9, 9, 9}
+		ln.Attributes = attrs(str("link.kind", "follows"))
+	}
+	acc, err = store.WriteTraces(tb.Context(), traces)
+	require.NoError(tb, err)
+	require.Zero(tb, acc.Rejected)
+
+	var metrics sigmetric.Metrics
+	rm := metrics.AddResource()
+	rm.Resource = signal.Resource{Attributes: attrs(str("service.name", "api"))}
+	sm := rm.AddScope()
+	sm.Scope = signal.Scope{Name: []byte("meter")}
+
+	// One metric is finished before the next is added: AddMetric may reallocate the scope's metric
+	// slice, which would leave a pointer taken earlier writing into an abandoned array.
+	gauge := sm.AddMetric()
+	gauge.Name = []byte("queue_depth")
+	gauge.Unit = []byte("1")
+	gauge.Kind = sigmetric.KindGauge
+	for i := range 3 {
+		p := gauge.AddPoint()
+		p.Attributes = attrs(str("queue", "ingest"))
+		p.Ts = at(3, i)
+		p.Value = float64(i) + 0.5
+	}
+
+	counter := sm.AddMetric()
+	counter.Name = []byte("requests_total")
+	counter.Unit = []byte("{request}")
+	counter.Kind = sigmetric.KindSum
+	counter.Temporality = sigmetric.TemporalityCumulative
+	counter.Monotonic = true
+	for i := range 3 {
+		c := counter.AddPoint()
+		c.Attributes = attrs(str("method", "GET"), num("code", 200))
+		c.Ts = at(3, i)
+		c.Value = float64(10 * i)
+	}
+	acc, err = store.WriteMetrics(tb.Context(), metrics)
+	require.NoError(tb, err)
+	require.Zero(tb, acc.Rejected)
+}
+
+// backupOptions pins the window to the test day, so the run never consults the wall clock.
+func backupOptions() storagebackup.BackupOptions {
+	return storagebackup.BackupOptions{
+		From: day,
+		To:   day.AddDate(0, 0, 1),
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	lg := zaptest.NewLogger(t)
+	src := newStore(t, nil)
+	writeSample(t, src)
+
+	dir := t.TempDir()
+	stats, err := storagebackup.NewBackup(src, lg, backupOptions()).Create(t.Context(), dir)
+	require.NoError(t, err)
+	require.Equal(t, 3, stats.Files, "one file per signal for one day")
+	require.Positive(t, stats.Rows)
+
+	dst := newStore(t, nil)
+	rstats, err := storagebackup.NewRestore(storagebackend.New(dst), lg, storagebackup.RestoreOptions{}).
+		Restore(t.Context(), dir)
+	require.NoError(t, err)
+	require.Equal(t, 3, rstats.Files)
+	require.Equal(t, stats.Rows, rstats.Rows)
+
+	const tenant = signal.TenantID("default")
+
+	wantLogs := collectLogs(t, src, tenant)
+	require.Len(t, wantLogs, 6)
+	require.Equal(t, wantLogs, collectLogs(t, dst, tenant))
+
+	wantSpans := collectSpans(t, src, tenant)
+	require.Len(t, wantSpans, 3)
+	require.Equal(t, wantSpans, collectSpans(t, dst, tenant))
+
+	wantSeries := collectSeries(t, src, tenant)
+	require.Len(t, wantSeries, 2)
+	require.Equal(t, wantSeries, collectSeries(t, dst, tenant))
+
+	// Spot-check a field that a column-dropping bug would silently zero on both sides only if the
+	// engine never stored it, which the source assertion above already rules out.
+	require.Equal(t, "api-body-a", wantLogs[0].Body)
+	require.Equal(t, uint32(1), wantLogs[0].Flags)
+	require.Equal(t, map[string]string{"http.route": "1:/v1/x", "http.status": "3:200"}, wantLogs[0].Attrs)
+	require.Equal(t, sigmetric.TemporalityCumulative, wantSeries[1].Temporality)
+	require.True(t, wantSeries[1].Monotonic)
+}
+
+func TestRestoreSignalFilter(t *testing.T) {
+	t.Parallel()
+
+	lg := zaptest.NewLogger(t)
+	src := newStore(t, nil)
+	writeSample(t, src)
+
+	dir := t.TempDir()
+	_, err := storagebackup.NewBackup(src, lg, backupOptions()).Create(t.Context(), dir)
+	require.NoError(t, err)
+
+	dst := newStore(t, nil)
+	stats, err := storagebackup.NewRestore(storagebackend.New(dst), lg, storagebackup.RestoreOptions{
+		Signals: []signal.Signal{signal.Log},
+	}).Restore(t.Context(), dir)
+	require.NoError(t, err)
+	require.Equal(t, 1, stats.Files)
+
+	const tenant = signal.TenantID("default")
+	require.Len(t, collectLogs(t, dst, tenant), 6)
+	require.Empty(t, collectSpans(t, dst, tenant))
+	require.Empty(t, collectSeries(t, dst, tenant))
+}
+
+func TestBackupResume(t *testing.T) {
+	t.Parallel()
+
+	lg := zaptest.NewLogger(t)
+	src := newStore(t, nil)
+	writeSample(t, src)
+
+	dir := t.TempDir()
+	first, err := storagebackup.NewBackup(src, lg, backupOptions()).Create(t.Context(), dir)
+	require.NoError(t, err)
+	require.Equal(t, 3, first.Files)
+
+	opts := backupOptions()
+	opts.Resume = true
+	second, err := storagebackup.NewBackup(src, lg, opts).Create(t.Context(), dir)
+	require.NoError(t, err)
+	require.Zero(t, second.Files, "a completed day is not rewritten")
+	require.Equal(t, 3, second.Skipped)
+
+	// The skipped run must not have damaged what the first wrote.
+	dst := newStore(t, nil)
+	_, err = storagebackup.NewRestore(storagebackend.New(dst), lg, storagebackup.RestoreOptions{}).
+		Restore(t.Context(), dir)
+	require.NoError(t, err)
+	require.Equal(t, collectLogs(t, src, "default"), collectLogs(t, dst, "default"))
+}

--- a/internal/storagebackup/roundtrip_test.go
+++ b/internal/storagebackup/roundtrip_test.go
@@ -224,3 +224,32 @@ func TestBackupResume(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, collectLogs(t, src, "default"), collectLogs(t, dst, "default"))
 }
+
+// TestRoundTripSplitChunks runs the same round trip with a chunk limit small enough to split every
+// batch, since a busy day's batch is far larger than the limit a real backup runs with. A split is
+// invisible to restore: it sees the same stream written more than once.
+func TestRoundTripSplitChunks(t *testing.T) {
+	t.Parallel()
+
+	lg := zaptest.NewLogger(t)
+	src := newStore(t, nil)
+	writeSample(t, src)
+
+	opts := backupOptions()
+	opts.MaxChunkBytes = 512
+	dir := t.TempDir()
+	stats, err := storagebackup.NewBackup(src, lg, opts).Create(t.Context(), dir)
+	require.NoError(t, err)
+	require.Greater(t, stats.Chunks, stats.Streams, "the limit must have split at least one batch")
+
+	dst := newStore(t, nil)
+	rstats, err := storagebackup.NewRestore(storagebackend.New(dst), lg, storagebackup.RestoreOptions{}).
+		Restore(t.Context(), dir)
+	require.NoError(t, err)
+	require.Equal(t, stats.Rows, rstats.Rows)
+
+	const tenant = signal.TenantID("default")
+	require.Equal(t, collectLogs(t, src, tenant), collectLogs(t, dst, tenant))
+	require.Equal(t, collectSpans(t, src, tenant), collectSpans(t, dst, tenant))
+	require.Equal(t, collectSeries(t, src, tenant), collectSeries(t, dst, tenant))
+}

--- a/internal/storagebackup/signals.go
+++ b/internal/storagebackup/signals.go
@@ -1,0 +1,32 @@
+package storagebackup
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/go-faster/errors"
+
+	"github.com/oteldb/storage/signal"
+)
+
+// ParseSignals parses a comma-separated signal list ("log,trace,metric") as odbbackup and
+// odbrestore accept it. An empty list selects every backed-up signal.
+func ParseSignals(list string) ([]signal.Signal, error) {
+	list = strings.TrimSpace(list)
+	if list == "" {
+		return nil, nil
+	}
+
+	var out []signal.Signal
+	for name := range strings.SplitSeq(list, ",") {
+		sig, err := signal.ParseSignal(strings.TrimSpace(name))
+		if err != nil {
+			return nil, err
+		}
+		if !slices.Contains(BackupSignals, sig) {
+			return nil, errors.Errorf("signal %s is not backed up", sig)
+		}
+		out = append(out, sig)
+	}
+	return out, nil
+}

--- a/internal/storagebackup/split_internal_test.go
+++ b/internal/storagebackup/split_internal_test.go
@@ -1,0 +1,187 @@
+package storagebackup
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+)
+
+// bigChunk builds one batch of rows whose encoding is far larger than the limits below, standing in
+// for a busy tenant's day: a single fetch batch of a real cluster's traces runs to hundreds of
+// megabytes, which is what the writer must not need to hold in one chunk.
+func bigChunk(rows, bodyLen int) Chunk {
+	c := Chunk{
+		Series: signal.Series{
+			Resource: signal.Resource{
+				SchemaURL:  []byte("https://opentelemetry.io/schemas/1.24.0"),
+				Attributes: signal.NewAttributes(signal.KeyValue{Key: []byte("service.name"), Value: signal.StringValue([]byte("api"))}),
+			},
+			Scope: signal.Scope{Name: []byte("scope"), Version: []byte("v1")},
+		},
+		Columns: []fetch.NamedColumn{
+			{Name: "severity", Int64: make([]int64, 0, rows)},
+			{Name: "body", Bytes: make([][]byte, 0, rows)},
+			{Name: "ratio", Float64: make([]float64, 0, rows)},
+			{Name: "absent"},
+		},
+	}
+	for i := range rows {
+		c.Timestamps = append(c.Timestamps, int64(i))
+		c.Columns[0].Int64 = append(c.Columns[0].Int64, int64(i%24))
+		c.Columns[1].Bytes = append(c.Columns[1].Bytes, bytes.Repeat([]byte{byte('a' + i%26)}, bodyLen))
+		c.Columns[2].Float64 = append(c.Columns[2].Float64, float64(i)/3)
+	}
+	return c
+}
+
+// readChunks decodes every chunk of a file, copying what it keeps: the reader hands out aliases of
+// one buffer it reuses.
+func readChunks(tb testing.TB, name string) []Chunk {
+	tb.Helper()
+
+	r, _, err := openChunkReader(name)
+	require.NoError(tb, err)
+	defer func() {
+		require.NoError(tb, r.Close())
+	}()
+
+	var out []Chunk
+	for {
+		c, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			return out
+		}
+		require.NoError(tb, err)
+
+		cp, err := decodeChunk(bytes.Clone(appendChunk(nil, &c)))
+		require.NoError(tb, err)
+		out = append(out, cp)
+	}
+}
+
+// TestChunkWriterSplitsOversizedBatch pins the fix for a batch larger than the chunk limit: it is
+// split over several chunks instead of failing the day, and the rows come back in order.
+func TestChunkWriterSplitsOversizedBatch(t *testing.T) {
+	t.Parallel()
+
+	for _, limit := range []int{512, 4096, 1 << 16} {
+		t.Run(fmt.Sprintf("Limit%d", limit), func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			rel := "log/default/2024-01-02" + fileExt
+			w, err := createChunkWriter(dir, rel, FileHeader{Version: FormatVersion, Signal: "log"}, limit)
+			require.NoError(t, err)
+
+			want := bigChunk(500, 128)
+			require.Greater(t, len(appendChunk(nil, &want)), limit, "the batch must not fit in one chunk")
+			require.NoError(t, w.Write(&want))
+			require.NoError(t, w.Close())
+
+			require.Equal(t, 1, w.streams, "a split batch is still one stream")
+			require.Greater(t, w.chunks, 1, "an oversized batch is split")
+			require.Equal(t, len(want.Timestamps), w.rows)
+
+			got := readChunks(t, filepath.Join(dir, filepath.FromSlash(rel)))
+			require.Len(t, got, w.chunks)
+
+			var merged Chunk
+			for i, c := range got {
+				require.LessOrEqual(t, len(appendChunk(nil, &c)), limit, "chunk %d is over the limit", i)
+				require.True(t, want.Series.Equal(c.Series), "chunk %d lost the stream identity", i)
+				require.NotEmpty(t, c.Timestamps, "chunk %d is empty", i)
+				require.Len(t, c.Columns, len(want.Columns))
+				merged = concatChunks(merged, c)
+			}
+
+			require.Equal(t, want.Timestamps, merged.Timestamps)
+			for i := range want.Columns {
+				require.Equal(t, want.Columns[i].Name, merged.Columns[i].Name)
+				require.Equal(t, want.Columns[i].Int64, merged.Columns[i].Int64)
+				require.Equal(t, want.Columns[i].Bytes, merged.Columns[i].Bytes)
+				require.Equal(t, want.Columns[i].Float64, merged.Columns[i].Float64)
+			}
+		})
+	}
+}
+
+// TestChunkWriterSplitsSamples covers the metric shape, whose rows are values rather than columns.
+func TestChunkWriterSplitsSamples(t *testing.T) {
+	t.Parallel()
+
+	const limit = 1024
+	dir := t.TempDir()
+	rel := "metric/default/2024-01-02" + fileExt
+	w, err := createChunkWriter(dir, rel, FileHeader{Version: FormatVersion, Signal: "metric"}, limit)
+	require.NoError(t, err)
+
+	want := Chunk{Series: bigChunk(0, 0).Series}
+	for i := range 1000 {
+		want.Timestamps = append(want.Timestamps, int64(i))
+		want.Values = append(want.Values, float64(i)*1.5)
+	}
+	require.NoError(t, w.Write(&want))
+	require.NoError(t, w.Close())
+	require.Greater(t, w.chunks, 1)
+
+	var merged Chunk
+	for _, c := range readChunks(t, filepath.Join(dir, filepath.FromSlash(rel))) {
+		require.LessOrEqual(t, len(appendChunk(nil, &c)), limit)
+		merged = concatChunks(merged, c)
+	}
+	require.Equal(t, want.Timestamps, merged.Timestamps)
+	require.Equal(t, want.Values, merged.Values)
+}
+
+// TestChunkWriterRejectsOversizedRow pins the one case a split cannot help: a single row that does
+// not fit. It must say so rather than write a chunk no reader will accept.
+func TestChunkWriterRejectsOversizedRow(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	w, err := createChunkWriter(dir, "log/default/2024-01-02"+fileExt,
+		FileHeader{Version: FormatVersion, Signal: "log"}, 512)
+	require.NoError(t, err)
+	defer w.Abort()
+
+	c := bigChunk(2, 4096)
+	err = w.Write(&c)
+	require.ErrorContains(t, err, "single row")
+}
+
+// TestChunkLimitClamp pins that a writer never emits a chunk a reader would refuse.
+func TestChunkLimitClamp(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, DefaultMaxChunkBytes, clampChunkLimit(0))
+	require.Equal(t, DefaultMaxChunkBytes, clampChunkLimit(-1))
+	require.Equal(t, 1024, clampChunkLimit(1024))
+	require.Equal(t, maxChunkBytes, clampChunkLimit(maxChunkBytes*2))
+}
+
+// concatChunks appends b's rows to a, which is how a reader reassembles a batch the writer split.
+func concatChunks(a, b Chunk) Chunk {
+	if a.Columns == nil && a.Timestamps == nil {
+		a.Series = b.Series
+		a.Columns = make([]fetch.NamedColumn, len(b.Columns))
+		for i := range b.Columns {
+			a.Columns[i].Name = b.Columns[i].Name
+		}
+	}
+	a.Timestamps = append(a.Timestamps, b.Timestamps...)
+	a.Values = append(a.Values, b.Values...)
+	for i := range b.Columns {
+		a.Columns[i].Int64 = append(a.Columns[i].Int64, b.Columns[i].Int64...)
+		a.Columns[i].Float64 = append(a.Columns[i].Float64, b.Columns[i].Float64...)
+		a.Columns[i].Bytes = append(a.Columns[i].Bytes, b.Columns[i].Bytes...)
+	}
+	return a
+}

--- a/internal/storagebackup/split_internal_test.go
+++ b/internal/storagebackup/split_internal_test.go
@@ -27,9 +27,9 @@ func bigChunk(rows, bodyLen int) Chunk {
 			Scope: signal.Scope{Name: []byte("scope"), Version: []byte("v1")},
 		},
 		Columns: []fetch.NamedColumn{
-			{Name: "severity", Int64: make([]int64, 0, rows)},
-			{Name: "body", Bytes: make([][]byte, 0, rows)},
-			{Name: "ratio", Float64: make([]float64, 0, rows)},
+			fetch.Int64Column("severity", make([]int64, 0, rows)),
+			fetch.BytesColumn("body", make([][]byte, 0, rows)),
+			fetch.Float64Column("ratio", make([]float64, 0, rows)),
 			{Name: "absent"},
 		},
 	}

--- a/internal/storagebackup/stream_internal_test.go
+++ b/internal/storagebackup/stream_internal_test.go
@@ -1,0 +1,267 @@
+package storagebackup
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"testing/iotest"
+
+	"github.com/go-faster/errors"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testHeader = FileHeader{Version: FormatVersion, Signal: "log", Tenant: "default", Day: "2024-01-02", Start: 1, End: 2}
+
+// writeChunkFile writes chunks through the real writer and returns the bytes it produced, so the
+// stream under test is one a backup would actually have written.
+func writeChunkFile(tb testing.TB, limit int, chunks ...Chunk) []byte {
+	tb.Helper()
+
+	dir := tb.TempDir()
+	rel := "log/default/2024-01-02" + fileExt
+
+	w, err := createChunkWriter(dir, rel, testHeader, limit)
+	require.NoError(tb, err)
+
+	for i := range chunks {
+		require.NoError(tb, w.Write(&chunks[i]))
+	}
+	require.NoError(tb, w.Close())
+
+	raw, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(rel)))
+	require.NoError(tb, err)
+
+	return raw
+}
+
+// readAll drains a stream into the chunks it holds. Next reuses its buffer, so each chunk is
+// cloned by re-encoding it.
+func readAll(rd io.Reader) ([][]byte, FileHeader, error) {
+	r, h, err := newChunkReader(rd)
+	if err != nil {
+		return nil, h, err
+	}
+	defer func() { _ = r.Close() }()
+
+	var out [][]byte
+	for {
+		c, err := r.Next()
+		if errors.Is(err, io.EOF) {
+			return out, h, nil
+		}
+		if err != nil {
+			return out, h, err
+		}
+		out = append(out, appendChunk(nil, &c))
+	}
+}
+
+func sampleChunks() []Chunk {
+	cs := testChunks()
+	return []Chunk{cs["Columns"], cs["IdentityOnly"], cs["Samples"], cs["Empty"]}
+}
+
+// The reader sits on a decompressor, which delivers whatever a block boundary happens to give it,
+// so a frame arriving in pieces is the normal case rather than an edge one. These wrappers make it
+// the case in every test rather than only when a block lands badly.
+func TestChunkStreamShortReads(t *testing.T) {
+	t.Parallel()
+
+	chunks := sampleChunks()
+	raw := writeChunkFile(t, 0, chunks...)
+
+	want, _, err := readAll(bytes.NewReader(raw))
+	require.NoError(t, err)
+	require.Len(t, want, len(chunks))
+
+	for name, wrap := range map[string]func(io.Reader) io.Reader{
+		"OneByte":     iotest.OneByteReader,
+		"Half":        iotest.HalfReader,
+		"DataErr":     iotest.DataErrReader,
+		"OneByteData": func(r io.Reader) io.Reader { return iotest.OneByteReader(iotest.DataErrReader(r)) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, h, err := readAll(wrap(bytes.NewReader(raw)))
+			require.NoError(t, err)
+			require.Equal(t, testHeader, h)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+// Split chunks are the shape a busy tenant produces, and they are the ones a short read is most
+// likely to land inside, since a frame that needed splitting is the largest thing in the file.
+func TestChunkStreamShortReadsSplit(t *testing.T) {
+	t.Parallel()
+
+	big := bigChunk(3, 64)
+	raw := writeChunkFile(t, 512, big)
+
+	want, _, err := readAll(bytes.NewReader(raw))
+	require.NoError(t, err)
+	require.Greater(t, len(want), 1, "the batch was split, so the stream holds several frames")
+
+	got, _, err := readAll(iotest.OneByteReader(bytes.NewReader(raw)))
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// errAfter fails once n bytes have been handed over, so the failure lands mid-stream rather than
+// at the open, where it would only prove that a broken file is rejected.
+type errAfter struct {
+	r    io.Reader
+	n    int
+	fail error
+}
+
+func (e *errAfter) Read(p []byte) (int, error) {
+	if e.n <= 0 {
+		return 0, e.fail
+	}
+	if len(p) > e.n {
+		p = p[:e.n]
+	}
+	n, err := e.r.Read(p)
+	e.n -= n
+	return n, err
+}
+
+// A read that fails must surface as an error. The dangerous outcome is not a failed restore but a
+// silent one: an [io.EOF] here would look exactly like a file that ended, and restore would report
+// success over a fraction of the data.
+func TestChunkStreamReadError(t *testing.T) {
+	t.Parallel()
+
+	raw := writeChunkFile(t, 0, sampleChunks()...)
+	boom := errors.New("boom")
+
+	for name, at := range map[string]int{"AtOpen": 0, "MidStream": len(raw) / 2, "BeforeEnd": len(raw) - 1} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := readAll(&errAfter{r: bytes.NewReader(raw), n: at, fail: boom})
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, io.EOF, "a failed read must not be mistaken for the end of the file")
+		})
+	}
+
+	_, _, err := readAll(iotest.ErrReader(boom))
+	require.ErrorIs(t, err, boom)
+}
+
+// A file is published by rename, so a truncated one should not exist — but a backup lives on media
+// that a restore has no way to vouch for, so the reader must not turn a short file into a short
+// success.
+func TestChunkStreamTruncated(t *testing.T) {
+	t.Parallel()
+
+	chunks := sampleChunks()
+	raw := writeChunkFile(t, 0, chunks...)
+
+	full, _, err := readAll(bytes.NewReader(raw))
+	require.NoError(t, err)
+
+	for i := range len(raw) {
+		got, _, err := readAll(bytes.NewReader(raw[:i]))
+		if err == nil {
+			// zstd frames are self-delimiting, so a prefix that ends on a boundary can read
+			// cleanly. What it must never do is invent or reorder chunks.
+			require.LessOrEqual(t, len(got), len(full), "a prefix cannot hold more than the whole")
+			require.Equal(t, full[:len(got)], got, "a %d-byte prefix decoded a different chunk", i)
+			continue
+		}
+		require.Less(t, len(got), len(full)+1)
+	}
+}
+
+// The frame length comes out of the decompressed stream, so a handful of bytes can announce a
+// frame of any size up to the reader's bound. Allocating that up front turns a corrupt file into
+// an out-of-memory kill, which is the one failure a restore cannot report.
+func TestChunkStreamFrameLengthLie(t *testing.T) {
+	t.Parallel()
+
+	raw := lyingFrameFile(t, maxChunkBytes-1)
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	_, _, err := readAll(bytes.NewReader(raw))
+	require.Error(t, err)
+
+	runtime.ReadMemStats(&after)
+	grew := after.TotalAlloc - before.TotalAlloc
+	assert.Less(t, grew, uint64(16<<20), "a %d byte claim allocated %d bytes", maxChunkBytes-1, grew)
+}
+
+func TestChunkStreamFrameTooLarge(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := readAll(bytes.NewReader(lyingFrameFile(t, maxChunkBytes+1)))
+	require.ErrorContains(t, err, "exceeds")
+}
+
+// FuzzChunkStream drives the whole file reader, not just one chunk's payload: the magic, the
+// header, the framing and the zstd stream around them are all reachable by a corrupt backup, and
+// they are the parts [FuzzDecodeChunk] never sees.
+func FuzzChunkStream(f *testing.F) {
+	f.Add(writeChunkFile(f, 0, sampleChunks()...))
+	f.Add(writeChunkFile(f, 512, bigChunk(3, 64)))
+	f.Add(writeChunkFile(f, 0))
+	f.Add(lyingFrameFile(f, maxChunkBytes-1))
+	f.Add([]byte{})
+	f.Add([]byte(fileMagic))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		got, _, err := readAll(bytes.NewReader(data))
+		if err != nil {
+			return
+		}
+		// Anything the reader accepted has to survive being written back out and read again, so a
+		// crafted file cannot yield chunks the writer could not have produced.
+		var chunks []Chunk
+		for _, raw := range got {
+			c, err := decodeChunk(raw)
+			require.NoError(t, err)
+			chunks = append(chunks, c)
+		}
+
+		again, h, err := readAll(bytes.NewReader(writeChunkFile(t, 0, chunks...)))
+		require.NoError(t, err)
+		require.Equal(t, testHeader, h)
+		require.Equal(t, got, again)
+	})
+}
+
+// lyingFrameFile is a well-formed file whose first frame after the header claims n bytes and then
+// ends.
+func lyingFrameFile(tb testing.TB, n uint64) []byte {
+	tb.Helper()
+
+	var buf bytes.Buffer
+
+	enc, err := zstd.NewWriter(&buf)
+	require.NoError(tb, err)
+
+	raw, err := json.Marshal(testHeader)
+	require.NoError(tb, err)
+
+	var frame [binary.MaxVarintLen64]byte
+	body := append([]byte(fileMagic), appendBlob(nil, raw)...)
+	body = append(body, frame[:binary.PutUvarint(frame[:], n)]...)
+
+	_, err = enc.Write(body)
+	require.NoError(tb, err)
+	require.NoError(tb, enc.Close())
+
+	return buf.Bytes()
+}

--- a/internal/storagebackup/testdata_test.go
+++ b/internal/storagebackup/testdata_test.go
@@ -1,0 +1,302 @@
+package storagebackup_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage"
+	"github.com/oteldb/storage/backend"
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+)
+
+// day is the fixed UTC day every test writes into, so nothing depends on the wall clock.
+var day = time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+// at returns an instant within [day], as unix nanoseconds.
+func at(h, m int) int64 {
+	return day.Add(time.Duration(h)*time.Hour + time.Duration(m)*time.Minute).UnixNano()
+}
+
+// newStore opens an ephemeral in-memory engine. tenantFn, when non-nil, is the engine's
+// record→tenant routing callback — the seam a cluster's shard placement rides on.
+func newStore(tb testing.TB, tenantFn func(signal.Resource, signal.Scope) signal.TenantID) *storage.Storage {
+	tb.Helper()
+
+	opts := []storage.Option{
+		storage.WithBackend(backend.Memory()),
+		storage.WithDurability(storage.DurabilityEphemeral),
+	}
+	if tenantFn != nil {
+		opts = append(opts, storage.WithTenant(tenantFn))
+	}
+
+	store, err := storage.Open(tb.Context(), storage.Options{}, opts...)
+	require.NoError(tb, err)
+	tb.Cleanup(func() {
+		require.NoError(tb, store.Close(context.WithoutCancel(tb.Context())))
+	})
+	return store
+}
+
+func attrs(kvs ...signal.KeyValue) signal.Attributes { return signal.NewAttributes(kvs...) }
+
+func str(k, v string) signal.KeyValue {
+	return signal.KeyValue{Key: []byte(k), Value: signal.StringValue([]byte(v))}
+}
+
+func num(k string, v int64) signal.KeyValue {
+	return signal.KeyValue{Key: []byte(k), Value: signal.IntValue(v)}
+}
+
+// attrMap renders attributes as kind-tagged strings, so a test fails when a value round-trips with
+// the right text but the wrong type.
+func attrMap(a signal.Attributes) map[string]string {
+	if len(a) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(a))
+	for _, kv := range a {
+		out[string(kv.Key)] = fmt.Sprintf("%d:%s", kv.Value.Kind(), kv.Value.AppendText(nil))
+	}
+	return out
+}
+
+// logRow is one restored log record, flattened for comparison.
+type logRow struct {
+	Resource     map[string]string
+	ScopeName    string
+	ScopeVersion string
+	ScopeAttrs   map[string]string
+	Timestamp    int64
+	Observed     int64
+	Severity     int32
+	SeverityText string
+	Body         string
+	TraceID      string
+	SpanID       string
+	Flags        uint32
+	Dropped      uint32
+	Attrs        map[string]string
+}
+
+// spanRow is one restored span, flattened for comparison.
+type spanRow struct {
+	Resource      map[string]string
+	ScopeName     string
+	TraceID       string
+	SpanID        string
+	ParentSpanID  string
+	Name          string
+	Kind          int32
+	StatusCode    int32
+	StatusMessage string
+	Start         int64
+	End           int64
+	Attrs         map[string]string
+	Events        []string
+	Links         []string
+}
+
+// seriesRow is one restored metric series, flattened for comparison.
+type seriesRow struct {
+	Resource    map[string]string
+	Name        string
+	Unit        string
+	Kind        sigmetric.PointKind
+	Temporality sigmetric.Temporality
+	Monotonic   bool
+	Attrs       map[string]string
+	Samples     []string
+}
+
+// scan drains every batch of one tenant and signal over the whole test day.
+func scan(tb testing.TB, store *storage.Storage, tenant signal.TenantID, sig signal.Signal) []*fetch.Batch {
+	tb.Helper()
+
+	var fetcher fetch.Fetcher
+	switch sig {
+	case signal.Log:
+		fetcher = store.LogFetcher(tenant)
+	case signal.Trace:
+		fetcher = store.TraceFetcher(tenant)
+	default:
+		fetcher = store.Fetcher(tenant)
+	}
+
+	it, err := fetcher.Fetch(tb.Context(), fetch.Request{
+		Tenant: tenant,
+		Signal: sig,
+		Start:  day.UnixNano(),
+		End:    day.AddDate(0, 0, 1).UnixNano() - 1,
+	})
+	require.NoError(tb, err)
+	defer func() {
+		require.NoError(tb, it.Close())
+	}()
+
+	var out []*fetch.Batch
+	for {
+		b, err := it.Next(tb.Context())
+		if err == io.EOF {
+			return out
+		}
+		require.NoError(tb, err)
+		out = append(out, b)
+	}
+}
+
+func collectLogs(tb testing.TB, store *storage.Storage, tenants ...signal.TenantID) []logRow {
+	tb.Helper()
+
+	var out []logRow
+	for _, tenant := range tenants {
+		for _, b := range scan(tb, store, tenant, signal.Log) {
+			cols := columns(b)
+			for i := range b.Timestamps {
+				out = append(out, logRow{
+					Resource:     attrMap(b.Series.Resource.Attributes),
+					ScopeName:    string(b.Series.Scope.Name),
+					ScopeVersion: string(b.Series.Scope.Version),
+					ScopeAttrs:   attrMap(b.Series.Scope.Attributes),
+					Timestamp:    b.Timestamps[i],
+					Observed:     cols.int(siglog.ColObserved, i),
+					Severity:     int32(cols.int(siglog.ColSeverity, i)),
+					SeverityText: string(cols.raw(siglog.ColSeverityText, i)),
+					Body:         string(cols.raw(siglog.ColBody, i)),
+					TraceID:      fmt.Sprintf("%x", cols.raw(siglog.ColTraceID, i)),
+					SpanID:       fmt.Sprintf("%x", cols.raw(siglog.ColSpanID, i)),
+					Flags:        uint32(cols.int(siglog.ColFlags, i)),
+					Dropped:      uint32(cols.int(siglog.ColDropped, i)),
+					Attrs:        attrMap(decodeAttrs(tb, cols.raw(siglog.ColAttrs, i))),
+				})
+			}
+		}
+	}
+	slices.SortFunc(out, func(a, b logRow) int { return strings.Compare(a.Body, b.Body) })
+	return out
+}
+
+func collectSpans(tb testing.TB, store *storage.Storage, tenants ...signal.TenantID) []spanRow {
+	tb.Helper()
+
+	var out []spanRow
+	for _, tenant := range tenants {
+		for _, b := range scan(tb, store, tenant, signal.Trace) {
+			cols := columns(b)
+			for i := range b.Timestamps {
+				row := spanRow{
+					Resource:      attrMap(b.Series.Resource.Attributes),
+					ScopeName:     string(b.Series.Scope.Name),
+					TraceID:       fmt.Sprintf("%x", cols.raw(sigtrace.ColTraceID, i)),
+					SpanID:        fmt.Sprintf("%x", cols.raw(sigtrace.ColSpanID, i)),
+					ParentSpanID:  fmt.Sprintf("%x", cols.raw(sigtrace.ColParentSpanID, i)),
+					Name:          string(cols.raw(sigtrace.ColName, i)),
+					Kind:          int32(cols.int(sigtrace.ColKind, i)),
+					StatusCode:    int32(cols.int(sigtrace.ColStatusCode, i)),
+					StatusMessage: string(cols.raw(sigtrace.ColStatusMsg, i)),
+					Start:         b.Timestamps[i],
+					End:           b.Timestamps[i] + cols.int(sigtrace.ColDuration, i),
+					Attrs:         attrMap(decodeAttrs(tb, cols.raw(sigtrace.ColAttrs, i))),
+				}
+				if raw := cols.raw(sigtrace.ColEvents, i); len(raw) > 0 {
+					evs, err := sigtrace.DecodeEvents(raw)
+					require.NoError(tb, err)
+					for _, ev := range evs {
+						row.Events = append(row.Events, fmt.Sprintf("%d/%s/%v", ev.Time, ev.Name, attrMap(ev.Attributes)))
+					}
+				}
+				if raw := cols.raw(sigtrace.ColLinks, i); len(raw) > 0 {
+					links, err := sigtrace.DecodeLinks(raw)
+					require.NoError(tb, err)
+					for _, ln := range links {
+						row.Links = append(row.Links, fmt.Sprintf("%x/%x/%v", ln.TraceID, ln.SpanID, attrMap(ln.Attributes)))
+					}
+				}
+				out = append(out, row)
+			}
+		}
+	}
+	slices.SortFunc(out, func(a, b spanRow) int { return strings.Compare(a.SpanID, b.SpanID) })
+	return out
+}
+
+func collectSeries(tb testing.TB, store *storage.Storage, tenants ...signal.TenantID) []seriesRow {
+	tb.Helper()
+
+	var out []seriesRow
+	for _, tenant := range tenants {
+		for _, b := range scan(tb, store, tenant, signal.Metric) {
+			row := seriesRow{Resource: attrMap(b.Series.Resource.Attributes), Attrs: map[string]string{}}
+			for _, kv := range b.Series.Attributes {
+				switch string(kv.Key) {
+				case string(sigmetric.LabelName):
+					row.Name = string(kv.Value.Str())
+				case string(sigmetric.LabelUnit):
+					row.Unit = string(kv.Value.Str())
+				case string(sigmetric.LabelKind):
+					row.Kind = sigmetric.PointKind(kv.Value.Int())
+				case string(sigmetric.LabelTemporality):
+					row.Temporality = sigmetric.Temporality(kv.Value.Int())
+				case string(sigmetric.LabelMonotonic):
+					row.Monotonic = kv.Value.Bool()
+				default:
+					row.Attrs[string(kv.Key)] = fmt.Sprintf("%d:%s", kv.Value.Kind(), kv.Value.AppendText(nil))
+				}
+			}
+			for i := range b.Timestamps {
+				row.Samples = append(row.Samples, fmt.Sprintf("%d=%g", b.Timestamps[i], b.Values[i]))
+			}
+			slices.Sort(row.Samples)
+			out = append(out, row)
+		}
+	}
+	slices.SortFunc(out, func(a, b seriesRow) int {
+		if c := strings.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return strings.Compare(fmt.Sprint(a.Attrs), fmt.Sprint(b.Attrs))
+	})
+	return out
+}
+
+func decodeAttrs(tb testing.TB, raw []byte) signal.Attributes {
+	tb.Helper()
+
+	if len(raw) == 0 {
+		return nil
+	}
+	a, _, err := signal.DecodeAttributes(raw)
+	require.NoError(tb, err)
+	return a
+}
+
+type batchCols struct{ b *fetch.Batch }
+
+func columns(b *fetch.Batch) batchCols { return batchCols{b: b} }
+
+func (c batchCols) int(name string, i int) int64 {
+	col, ok := c.b.Column(name)
+	if !ok || i >= len(col.Int64) {
+		return 0
+	}
+	return col.Int64[i]
+}
+
+func (c batchCols) raw(name string, i int) []byte {
+	col, ok := c.b.Column(name)
+	if !ok || i >= len(col.Bytes) {
+		return nil
+	}
+	return col.Bytes[i]
+}


### PR DESCRIPTION
Fixes #1341

`odbbackup`/`odbrestore` only spoke ClickHouse, so `internal/storagebackend` had no way to get data
out or back in — and no way to change `shards_per_tenant` without stranding history.

## Scope

**In:**

- `internal/storagebackup` — backup and restore for the storage engine, covering **logs, traces and
  metrics**.
- A `-backend clickhouse|storage` selector on the **existing two commands** rather than two new
  binaries (the issue's preference, and the right one: an operator learns one tool, and the
  ClickHouse path is untouched). The two formats stay separate — a backup restores into the backend
  it came from.
- `storagebackend.Backend.Store()`, the accessor the backup driver needs to reach the raw fetch
  seam and `Inspect()`.

**Deliberately out:**

- **Profiles.** A profile row stores only a content-addressed stack id into a per-tenant symbol side
  store. Rebuilding an ingestible `profile.Profiles` means re-interning a dictionary from resolved
  frames, which loses mappings, addresses and the original string table. That deserves its own
  export, not a lossy approximation folded in here. The format is keyed by signal name, so adding
  `profile` later needs no format change.
- **A cluster-mode integration test.** The re-shard property is proved hermetically (below); an
  end-to-end test against a real ring needs etcd.
- **Mid-file resume.** Restart granularity is (tenant, signal, day).

## Format

```
<dir>/manifest.json
<dir>/<signal>/<tenant>/<YYYY-MM-DD>.obk.zst
```

One file per (logical tenant, signal, UTC day) — the same day-at-a-time slicing chstorage's backup
uses. A file is a zstd stream of a magic, a JSON header, then length-delimited chunks; one chunk is
one fetch batch (a stream identity plus its rows). The manifest is informational: restore walks the
tree and trusts each file's own header, so a backup that lost its manifest still restores.

**Restore goes through the write path.** It re-ingests via the engine's ordinary `WriteLogs` /
`WriteTraces` / `WriteMetrics`, never by placing part files, so tenant routing and — in cluster mode
— the shard key and its ring placement are derived again from the *destination's* configuration.
Backup records the **logical** tenant (`cluster.TenantOfShard`), folding `default/_s0`… back into
`default`; recording the shard keys would pin the data to a cluster of that exact shape, which is
the bug.

**Restartable, no ingest downtime.** A day file is written to `.tmp` and renamed only after its last
chunk, so a file present under its final name is complete; `-resume` skips those. The scan reads
head ∪ parts through the fetch seam, so concurrent ingest is safe — `-lag` (default 1h) keeps the
window behind the ingest edge so the newest day is not scanned while it fills.

## Fidelity contract

Stated against what the *engine stores*; what ingest drops was gone before any backup ran. Full text
in the package doc.

- **Exact:** stream identity (resource + scope, schema URLs, attribute types); every column of the
  logs schema (observed ts, severity number/text, body, trace/span id, flags, dropped, attrs); span
  start/duration, kind, status code and message, ids, name, attributes, events and links; metric
  series identity including the reserved `__name__`/`__unit__`/`__kind__`/`__temporality__`/
  `__monotonic__` labels, and every sample.
- **Approximated:** span nested-set ids are derived per write batch, so restore recomputes them per
  restored batch — the same approximation live ingest makes when a trace's spans arrive in separate
  exports. Data lands in the destination's tenant, so restoring several logical tenants into a
  single-tenant destination merges them (`-tenant` avoids it).
- **Lost:** metric sample `StartTs` (the engine never persists it) and lossy-sampling scale factors
  (the ingest model has no field for the weight — backup warns when it sees them). Span trace state,
  flags and dropped counts are dropped at ingest, not by the backup.

## Tests

- `TestRoundTrip` — write → back up → restore into a **fresh** store, then compare logs, spans and
  series read straight from each engine (not through the backup code), field by field including
  attribute *kinds*.
- `TestReshard` — source engine keyed by a 2-shard router, destination by a 3-shard one. Asserts the
  backup holds one logical tenant dir, that the restored data occupies all three shards **including
  `default/_s2`, a key that does not exist in the source shape**, and that every record survives.
  `TestReshardToSingleShard` covers collapsing 4 shards to 1.
- `TestBackupResume`, `TestRestoreSignalFilter`, chunk-format table tests, truncation tests, a
  writer-abort test, and `FuzzDecodeChunk` (1.2M execs clean, re-encode/re-decode equivalence).

**Negative controls** (change reverted, tests kept, confirmed failing, then restored and confirmed
passing):

1. Drop the shard-key normalization in `Backup.tenants` → `TestReshard` **FAILS**; restored →
   **PASSES**.
2. Stop restoring the logs `flags` column in `appendLogs` → `TestRoundTrip` **FAILS**; restored →
   **PASSES**.

`go build ./... && go test ./...` clean; `golangci-lint run` clean on the touched packages.

## Fixes from a run against real data

Running the binary over a 1.4 GB copy of a live node's data directory turned up two bugs, both
fixed here.

**An oversized batch exceeded the chunk cap.** One chunk was one fetch batch, so a chunk was as
large as one stream's whole day — 572 MB of traces against the 512 MiB cap, which failed the day
and with it the backup. A batch over the limit is now split by row over as many chunks as it needs,
each repeating the stream identity: every chunk still decodes on its own (no continuation in the
format, and `FuzzDecodeChunk` seeds a split's pieces), and restore sees a split batch as several
writes of the same stream — the shape live ingest already produces when a stream's records arrive
in more than one export. The limit is `BackupOptions.MaxChunkBytes` (default 64 MiB, clamped to
what a reader accepts), which also bounds the encoder's buffer instead of letting it track the
busiest day. `TestChunkWriterSplitsOversizedBatch` / `TestChunkWriterSplitsSamples` /
`TestRoundTripSplitChunks` cover it with an injected small cap, so nothing allocates 572 MB.

**Backup opened the data directory read-write and mutated it.** Opening the engine replayed the
WAL into a head, the close that followed flushed it into a new part, and the WAL was checkpointed —
the live node had 45 trace parts, the copy had 46 afterwards. Against a running node that is a
second writer discarding segments the node still owns. `odbbackup` now opens the engine read-only:
no WAL recovery, no flush, no merges, no retention, no cluster membership. The cost is the
unflushed head — a read-only open sees flushed parts only, and warns when the WAL is non-empty;
with the default `-lag` that data is outside the window anyway, so keep `-lag` at or above the
engine's flush interval. `TestBackupDoesNotWriteToDataDir` fingerprints every file of a directory
in a live node's state (parts flushed, more data only in the WAL) and requires the tree to be
byte-identical after a backup.

`odbrestore` has the same "two writers on one backend" hazard on its *destination*, but there the
writing is the point; it cannot be made read-only. Its package doc and `-storage-dir` help now say
the destination must not be a running node's data directory — restore into a stopped node, then
start it.

**Negative controls for both:** reverting the split (keeping the injectable cap) makes the three
split tests fail with `chunk of N bytes exceeds the limit`; not propagating `ReadOnly` makes
`TestBackupDoesNotWriteToDataDir` fail on the tree comparison. Both pass again with the fixes in
place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

