### PR TITLE
fix(handlers): report a read-budget refusal as a client error

### DIFF
--- a/internal/lokihandler/budgeterr_test.go
+++ b/internal/lokihandler/budgeterr_test.go
@@ -1,0 +1,45 @@
+package lokihandler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage/readbudget"
+
+	"github.com/oteldb/oteldb/internal/lokiapi"
+)
+
+// Logs go through the same record engines and the same budget as traces, and this handler already
+// treats the chstorage too-large errors as the client's problem. A budget refusal is the same kind
+// of thing and takes the same status.
+func TestLokiBudgetErrorsAreClientErrors(t *testing.T) {
+	t.Parallel()
+
+	budget := errors.Wrap(readbudget.ErrExceeded, "reserve 1227385730 bytes: holding 0 of 966367641")
+
+	for name, err := range map[string]error{
+		"evalErr":      evalErr(context.Background(), budget, "eval"),
+		"executionErr": executionErr(context.Background(), budget, "execute"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := errors.Into[*lokiapi.ErrorStatusCode](err)
+			require.True(t, ok)
+			assert.Equal(t, http.StatusBadRequest, got.StatusCode)
+		})
+	}
+}
+
+func TestLokiFaultsStayServerErrors(t *testing.T) {
+	t.Parallel()
+
+	got, ok := errors.Into[*lokiapi.ErrorStatusCode](executionErr(context.Background(), errors.New("disk on fire"), "execute"))
+	require.True(t, ok)
+	assert.Equal(t, http.StatusInternalServerError, got.StatusCode)
+}

--- a/internal/lokihandler/error.go
+++ b/internal/lokihandler/error.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/go-faster/errors"
 
+	"github.com/oteldb/storage/readbudget"
+
 	"github.com/oteldb/oteldb/internal/chstorage"
 	"github.com/oteldb/oteldb/internal/logql"
 	"github.com/oteldb/oteldb/internal/logql/lexer"
@@ -16,8 +18,11 @@ import (
 func evalErr(ctx context.Context, err error, msg string) error {
 	_, isLexerErr := errors.Into[*lexer.Error](err)
 	_, isParseErr := errors.Into[*logql.ParseError](err)
+	// [readbudget.ErrExceeded] joins the too-large family: same cause (the query asked for more than
+	// it is allowed to hold), same remedy (narrow it), so it takes the same status these already do.
 	isTooLarge := errors.Is(err, chstorage.ErrLogsTooManySamples) ||
-		errors.Is(err, chstorage.ErrLogsResultTooLarge)
+		errors.Is(err, chstorage.ErrLogsResultTooLarge) ||
+		errors.Is(err, readbudget.ErrExceeded)
 	if isLexerErr || isParseErr || isTooLarge {
 		return &lokiapi.ErrorStatusCode{
 			StatusCode: http.StatusBadRequest,
@@ -39,6 +44,15 @@ func validationErr(ctx context.Context, err error, msg string) error {
 }
 
 func executionErr(ctx context.Context, err error, msg string) error {
+	if errors.Is(err, readbudget.ErrExceeded) {
+		return &lokiapi.ErrorStatusCode{
+			StatusCode: http.StatusBadRequest,
+			Response: lokiapi.Error(appendTrace(ctx, fmt.Sprintf(
+				"%s: query needs more memory than its budget allows; narrow the time range or use a more selective matcher: %s",
+				msg, err))),
+		}
+	}
+
 	return &lokiapi.ErrorStatusCode{
 		StatusCode: http.StatusInternalServerError,
 		Response:   lokiapi.Error(appendTrace(ctx, fmt.Sprintf("%s: %s", msg, err))),

--- a/internal/tempohandler/budgeterr_test.go
+++ b/internal/tempohandler/budgeterr_test.go
@@ -1,0 +1,54 @@
+package tempohandler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage/readbudget"
+
+	"github.com/oteldb/oteldb/internal/tempoapi"
+)
+
+// A budget refusal means the query asked for more than it may hold, so the data is intact and a
+// narrower window answers. Reported as 5xx it reads as a server fault and sends the user to check
+// the server, which is the one place nothing is wrong.
+func TestExecutionErrSeparatesBudgetFromFault(t *testing.T) {
+	t.Parallel()
+
+	for name, tt := range map[string]struct {
+		err  error
+		code int
+	}{
+		"budget": {
+			errors.Wrap(readbudget.ErrExceeded, "reserve 1227385730 bytes: holding 0 of 966367641"),
+			http.StatusUnprocessableEntity,
+		},
+		// The sentinel arrives wrapped in the peer's address when the read was fanned out, which is
+		// the shape a clustered deployment actually produces.
+		"budget from a peer": {
+			errors.Wrap(errors.Wrap(readbudget.ErrExceeded, `"oteldb-1:7946" fetch`), "select spansets"),
+			http.StatusUnprocessableEntity,
+		},
+		"fault": {errors.New("disk on fire"), http.StatusInternalServerError},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := errors.Into[*tempoapi.ErrorStatusCode](executionErr(context.Background(), tt.err, "eval"))
+			require.True(t, ok)
+			require.Equal(t, tt.code, got.StatusCode)
+
+			if tt.code == http.StatusInternalServerError {
+				return
+			}
+
+			assert.Contains(t, string(got.Response), "narrow the time range",
+				"the response says what to do about it")
+		})
+	}
+}

--- a/internal/tempohandler/error.go
+++ b/internal/tempohandler/error.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/go-faster/errors"
+	"github.com/oteldb/storage/readbudget"
+
 	"github.com/oteldb/oteldb/internal/tempoapi"
 )
 
@@ -16,6 +19,18 @@ func validationErr(ctx context.Context, err error, msg string) error {
 }
 
 func executionErr(ctx context.Context, err error, msg string) error {
+	// A read refused for want of budget is the query's fault, not the server's: the data is intact
+	// and a narrower window or a more selective matcher answers. Reported as 5xx it sends the reader
+	// to check the server, which is the one place the problem is not.
+	if errors.Is(err, readbudget.ErrExceeded) {
+		return &tempoapi.ErrorStatusCode{
+			StatusCode: http.StatusUnprocessableEntity,
+			Response: tempoapi.Error(appendTrace(ctx, fmt.Sprintf(
+				"%s: query needs more memory than its budget allows; narrow the time range or use a more selective matcher: %s",
+				msg, err))),
+		}
+	}
+
 	return &tempoapi.ErrorStatusCode{
 		StatusCode: http.StatusInternalServerError,
 		Response:   tempoapi.Error(appendTrace(ctx, fmt.Sprintf("%s: %s", msg, err))),


### PR DESCRIPTION
Fixes #1346.

## Problem

A TraceQL search over Grafana Explore's default 24h range on a live cluster:

```
500
eval: select spansets: fetch candidate traces: cluster: "oteldb-1:7946" fetch returned 500:
reserve 1227385730 bytes: holding 0 of 966367641: readbudget: query exceeds its memory budget
```

Grafana renders that as **"failed to execute search query status: 500 Internal Server Error"**, so a window that is merely too wide reads as a server fault and sends the user to check the server — the one place nothing is wrong. The same query over 6h returns 200.

`readbudget`'s doc states the contract:

> It is load shedding, not a storage fault: the data is intact and a narrower window or a more selective matcher will answer, so an embedder should map it to a 4xx rather than a 5xx.

## Change

- **Tempo** (`internal/tempohandler/error.go`): `executionErr` maps `readbudget.ErrExceeded` to **422**, matching upstream Tempo's use of 422 for limit refusals.
- **Loki** (`internal/lokihandler/error.go`): the sentinel joins the existing `isTooLarge` family in `evalErr`, and `executionErr` gains the same branch — **400**, the status this handler already returns for `chstorage.ErrLogsTooManySamples` / `ErrLogsResultTooLarge`. Same cause, same remedy, so the same status.

Both responses name the remedy rather than only the failure: *narrow the time range or use a more selective matcher*.

The codes differ per handler because each follows its own upstream and the precedent already in that file.

## Sequencing — this only fully works after a storage bump

`cluster.statusError` flattens a peer's error into a plain string, so `readbudget.ErrExceeded` survives a **local** read but not a fanned-out one. On a cluster the sentinel does not arrive, and this mapping cannot fire.

oteldb/storage#496 carries the sentinel across the wire. Until that is released and the dependency bumped here, this fixes single-node deployments only; the clustered case follows automatically once the bump lands, with no further change here.

The test covers the peer-wrapped shape (`"oteldb-1:7946" fetch` inside `select spansets`) so the clustered path is pinned in advance.

## Tests

`internal/tempohandler/budgeterr_test.go` and `internal/lokihandler/budgeterr_test.go`: a budget refusal — bare and peer-wrapped — maps to the client status and the message says what to do; an ordinary error stays 500.

**Negative control:** disabling each branch (kept compiling) makes the budget cases fail with the wrong status while the fault case still passes; restored, all pass.

`go build ./...`, package tests, and `golangci-lint run` on both packages are clean.