### PR TITLE
fix(tracing): mark a span failed, not just annotated, when it records an error

### DIFF
--- a/cmd/otelbench/chtracker/chtracker.go
+++ b/cmd/otelbench/chtracker/chtracker.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/oteldb/oteldb/internal/tempoapi"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // Tracker is a query tracker.
@@ -58,7 +59,7 @@ func (t *Tracker[Q]) Track(ctx context.Context, meta Q, cb func(context.Context,
 
 		defer func() {
 			if rerr != nil {
-				span.RecordError(rerr)
+				xspan.Fail(span, rerr)
 				span.SetStatus(codes.Error, rerr.Error())
 			} else {
 				span.SetStatus(codes.Ok, "")

--- a/cmd/otelbench/chtracker/chtracker.go
+++ b/cmd/otelbench/chtracker/chtracker.go
@@ -60,7 +60,6 @@ func (t *Tracker[Q]) Track(ctx context.Context, meta Q, cb func(context.Context,
 		defer func() {
 			if rerr != nil {
 				xspan.Fail(span, rerr)
-				span.SetStatus(codes.Error, rerr.Error())
 			} else {
 				span.SetStatus(codes.Ok, "")
 			}

--- a/internal/adminhandler/adminhandler.go
+++ b/internal/adminhandler/adminhandler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/oteldb/storage"
@@ -208,11 +207,7 @@ func (a *AdminAPI) GetStorage(ctx context.Context, _ adminapi.GetStorageParams) 
 func (a *AdminAPI) collectCHStats(ctx context.Context) (_ []adminapi.TableStats, rerr error) {
 	ctx, span := a.tracer.Start(ctx, "adminhandler.storage.clickhouse")
 	defer func() {
-		if rerr != nil {
-			xspan.Fail(span, rerr)
-			span.SetStatus(codes.Error, rerr.Error())
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	tables, err := a.opts.CHStorage.CollectStorageStats(ctx)
@@ -232,11 +227,7 @@ func (a *AdminAPI) GetEfficiency(
 		trace.WithAttributes(attribute.Bool("adminhandler.parts", params.Parts.Or(false))),
 	)
 	defer func() {
-		if rerr != nil {
-			xspan.Fail(span, rerr)
-			span.SetStatus(codes.Error, rerr.Error())
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	stats := &adminapi.EfficiencyStats{
@@ -274,11 +265,7 @@ func (a *AdminAPI) attachParts(
 		trace.WithAttributes(attribute.String("adminhandler.tenant", string(tenant))),
 	)
 	defer func() {
-		if rerr != nil {
-			xspan.Fail(span, rerr)
-			span.SetStatus(codes.Error, rerr.Error())
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var total int

--- a/internal/adminhandler/adminhandler.go
+++ b/internal/adminhandler/adminhandler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oteldb/storage/signal"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // Component describes a wired oteldb service for the health report.
@@ -208,7 +209,7 @@ func (a *AdminAPI) collectCHStats(ctx context.Context) (_ []adminapi.TableStats,
 	ctx, span := a.tracer.Start(ctx, "adminhandler.storage.clickhouse")
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 			span.SetStatus(codes.Error, rerr.Error())
 		}
 		span.End()
@@ -232,7 +233,7 @@ func (a *AdminAPI) GetEfficiency(
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 			span.SetStatus(codes.Error, rerr.Error())
 		}
 		span.End()
@@ -274,7 +275,7 @@ func (a *AdminAPI) attachParts(
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 			span.SetStatus(codes.Error, rerr.Error())
 		}
 		span.End()

--- a/internal/chstorage/inserter_logs.go
+++ b/internal/chstorage/inserter_logs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/oteldb/oteldb/internal/logstorage"
 	"github.com/oteldb/oteldb/internal/semconv"
+	"github.com/oteldb/oteldb/internal/xspan"
 	"github.com/oteldb/oteldb/internal/xsync"
 )
 
@@ -64,7 +65,7 @@ func (i *Inserter) submitLogs(ctx context.Context, logs *logColumns, attrs *logA
 	))
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 		} else {
 			i.stats.Inserts.Add(ctx, 1,
 				metric.WithAttributes(semconv.Signal(semconv.SignalLogs)),

--- a/internal/chstorage/inserter_metrics.go
+++ b/internal/chstorage/inserter_metrics.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/oteldb/oteldb/internal/metricstorage"
 	"github.com/oteldb/oteldb/internal/semconv"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 func (i *Inserter) insertBatch(ctx context.Context, b *metricsBatch) (rerr error) {
 	ctx, span := i.tracer.Start(ctx, "chstorage.metrics.insertBatch")
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 		} else {
 			i.stats.InsertedSeries.Add(ctx, int64(b.timeseries.name.Rows()))
 			i.stats.InsertedPoints.Add(ctx, int64(b.points.value.Rows()))

--- a/internal/chstorage/inserter_traces.go
+++ b/internal/chstorage/inserter_traces.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oteldb/oteldb/internal/semconv"
 	"github.com/oteldb/oteldb/internal/traceql"
 	"github.com/oteldb/oteldb/internal/tracestorage"
+	"github.com/oteldb/oteldb/internal/xspan"
 	"github.com/oteldb/oteldb/internal/xsync"
 )
 
@@ -69,7 +70,7 @@ func (i *Inserter) submitTraces(
 
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 		} else {
 			i.stats.Inserts.Add(ctx, 1,
 				metric.WithAttributes(semconv.Signal(semconv.SignalTraces)),

--- a/internal/chstorage/querier_logs.go
+++ b/internal/chstorage/querier_logs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oteldb/oteldb/internal/logstorage"
 	"github.com/oteldb/oteldb/internal/otelstorage"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 var (
@@ -42,7 +43,7 @@ func (q *Querier) LabelNames(ctx context.Context, opts logstorage.LabelsOptions)
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 		} else {
 			span.AddEvent("names_fetched", trace.WithAttributes(
 				attribute.Int("chstorage.total_names", len(result)),
@@ -153,10 +154,7 @@ func (q *Querier) LabelValues(ctx context.Context, labelName string, opts logsto
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	limit := q.labelLimit
@@ -258,10 +256,7 @@ func (q *Querier) DetectedLabels(ctx context.Context, opts logstorage.LabelsOpti
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	limit := q.labelLimit
@@ -373,10 +368,7 @@ func (q *Querier) DetectedFields(ctx context.Context, opts logstorage.LabelsOpti
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	limit := q.labelLimit
@@ -492,10 +484,7 @@ func (q *Querier) getLabelMapping(ctx context.Context, labels []string) (_ map[s
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -591,7 +580,7 @@ func (q *Querier) Series(ctx context.Context, opts logstorage.SeriesOptions) (re
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 		} else {
 			span.AddEvent("series_fetched", trace.WithAttributes(
 				attribute.Int("chstorage.total_series", len(result)),

--- a/internal/chstorage/querier_logs_query.go
+++ b/internal/chstorage/querier_logs_query.go
@@ -26,6 +26,7 @@ import (
 	"github.com/oteldb/oteldb/internal/logstorage"
 	"github.com/oteldb/oteldb/internal/xattribute"
 	"github.com/oteldb/oteldb/internal/xregexp"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // ErrLogsTooManySamples means that a LogQL sample query (e.g. count_over_time,
@@ -64,10 +65,7 @@ func (v *LogsQuery[E]) Execute(ctx context.Context, q *Querier) (_ iterators.Ite
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	mapping, err := q.getLabelMapping(ctx, v.Sel.mappingLabels())
@@ -232,10 +230,7 @@ func (v *SampleQuery) Execute(ctx context.Context, q *Querier) (_ logqlengine.Sa
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	// Gather all labels for mapping fetch.
@@ -406,10 +401,7 @@ func (v *BucketedSampleQuery) Execute(ctx context.Context, q *Querier) (_ logqlm
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	if v.Range <= 0 {

--- a/internal/chstorage/querier_metrics.go
+++ b/internal/chstorage/querier_metrics.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oteldb/oteldb/internal/metricscache"
 	"github.com/oteldb/oteldb/internal/promapi"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 var _ storage.Queryable = (*Querier)(nil)
@@ -219,7 +220,7 @@ func (p *promQuerier) Select(ctx context.Context, sortSeries bool, hints *storag
 	)
 	defer func() {
 		if resultSet != nil && resultSet.Err() != nil {
-			span.RecordError(resultSet.Err())
+			xspan.Fail(span, resultSet.Err())
 		}
 		span.End()
 	}()
@@ -364,10 +365,7 @@ func (p *promQuerier) querySeriesSingleflight(ctx context.Context, samplePoints 
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -380,10 +378,7 @@ func (p *promQuerier) querySeriesSingleflight(ctx context.Context, samplePoints 
 			trace.WithLinks(parentLink),
 		)
 		defer func() {
-			if rerr != nil {
-				span.RecordError(rerr)
-			}
-			span.End()
+			xspan.End(span, rerr)
 		}()
 		parentSpan.AddLink(trace.LinkFromContext(ctx))
 		return p.querySeries(ctx, samplePoints, params)
@@ -542,10 +537,7 @@ func (p *promQuerier) queryPointsCached(ctx context.Context, table string, start
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	fetch := func(ctx context.Context, fetchStart, fetchEnd time.Time) (map[[16]byte]*series[pointData], error) {
@@ -589,10 +581,7 @@ func (p *promQuerier) querySampledPointsCached(
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	fetch := func(ctx context.Context, fetchStart, fetchEnd time.Time) (map[[16]byte]*series[pointData], error) {
@@ -823,10 +812,7 @@ func (p *promQuerier) queryPoints(ctx context.Context, table string, start, end 
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -996,10 +982,7 @@ func (p *promQuerier) querySampledPointsPerSeries(
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -1343,10 +1326,7 @@ func (p *promQuerier) queryExpHistograms(ctx context.Context, table string, star
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (

--- a/internal/chstorage/querier_metrics_exemplars.go
+++ b/internal/chstorage/querier_metrics_exemplars.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oteldb/oteldb/internal/chstorage/chsql"
 	"github.com/oteldb/oteldb/internal/promapi"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 var _ storage.ExemplarQueryable = (*Querier)(nil)
@@ -63,10 +64,7 @@ func (q *exemplarQuerier) Select(startMs, endMs int64, matcherSets ...[]*labels.
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	timeseries, err := q.queryTimeseries(ctx, start, end, matcherSets)

--- a/internal/chstorage/querier_metrics_labels.go
+++ b/internal/chstorage/querier_metrics_labels.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oteldb/oteldb/internal/metricstorage"
 	"github.com/oteldb/oteldb/internal/otelstorage"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // LabelValues returns all potential values for a label name.
@@ -38,7 +39,7 @@ func (p *promQuerier) LabelValues(ctx context.Context, labelName string, hints *
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 		} else {
 			span.AddEvent("values_fetched", trace.WithAttributes(
 				attribute.Int("chstorage.total_values", len(result)),
@@ -77,10 +78,7 @@ func (p *promQuerier) getLabelValues(ctx context.Context, labelName string, matc
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -137,10 +135,7 @@ func (p *promQuerier) getMatchingLabelValues(ctx context.Context, labelName stri
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -229,7 +224,7 @@ func (p *promQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints,
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 		} else {
 			span.AddEvent("names_fetched", trace.WithAttributes(
 				attribute.Int("chstorage.total_names", len(result)),
@@ -263,10 +258,7 @@ func (p *promQuerier) getLabelNames(ctx context.Context) (result []string, rerr 
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -303,10 +295,7 @@ func (p *promQuerier) getMatchingLabelNames(ctx context.Context, matchers []*lab
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (

--- a/internal/chstorage/querier_metrics_rate.go
+++ b/internal/chstorage/querier_metrics_rate.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/oteldb/oteldb/internal/chstorage/chsql"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 const promStaleNaNBits uint64 = 0x7ff0000000000002
@@ -257,10 +258,7 @@ func (o *rateSelector) loadSeries(ctx context.Context) error {
 			xattribute.StringerSlice("promql.selector.filter", o.filter.Matchers()),
 		))
 		defer func() {
-			if err != nil {
-				span.RecordError(err)
-			}
-			span.End()
+			xspan.End(span, err)
 		}()
 
 		r, queryErr := o.querier.querySeriesSingleflight(ctx, true, o.params)
@@ -333,10 +331,7 @@ func (p *promQuerier) queryRatePointsCached(
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	fetch := func(ctx context.Context, fetchStart, fetchEnd time.Time) (map[[16]byte]*series[pointData], error) {
@@ -387,10 +382,7 @@ func (p *promQuerier) queryRatePointsByHash(
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	if len(timeseries) == 0 || start.IsZero() || end.IsZero() || window <= 0 {

--- a/internal/chstorage/querier_metrics_scanners.go
+++ b/internal/chstorage/querier_metrics_scanners.go
@@ -30,6 +30,7 @@ import (
 	"github.com/oteldb/oteldb/internal/metricstorage"
 	"github.com/oteldb/oteldb/internal/promql"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 type promScanners struct {
@@ -433,10 +434,7 @@ func (o *vectorSelector) loadSeries(ctx context.Context) error {
 			xattribute.StringerSlice("promql.selector.filter", o.filter.Matchers()),
 		))
 		defer func() {
-			if err != nil {
-				span.RecordError(err)
-			}
-			span.End()
+			xspan.End(span, err)
 		}()
 
 		r, queryErr := o.querier.querySeriesSingleflight(ctx, true, o.params)

--- a/internal/chstorage/querier_metrics_series.go
+++ b/internal/chstorage/querier_metrics_series.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oteldb/oteldb/internal/metricstorage"
 	"github.com/oteldb/oteldb/internal/promapi"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // OnlySeries selects only labels from series.
@@ -56,10 +57,7 @@ func (p *promQuerier) selectOnlySeries(
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (

--- a/internal/chstorage/querier_metrics_timeseries.go
+++ b/internal/chstorage/querier_metrics_timeseries.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oteldb/oteldb/internal/chstorage/chsql"
 	"github.com/oteldb/oteldb/internal/metricstorage"
 	"github.com/oteldb/oteldb/internal/promapi"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 type timeseriesQuerier struct {
@@ -104,10 +105,7 @@ func hashPrometheusMatchers(h *xxh3.Hasher, sets [][]*labels.Matcher) {
 func (q *timeseriesQuerier) Query(ctx context.Context, start, end time.Time, matcherSets [][]*labels.Matcher) (_ map[[16]byte]labels.Labels, rerr error) {
 	ctx, span := q.tracer.Start(ctx, "chstorage.metrics.timeseries.Query")
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -155,10 +153,7 @@ func (q *timeseriesQuerier) queryTimeseries(ctx context.Context, parentSpan trac
 		trace.WithLinks(parentLink),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 	if parentSpan != nil {
 		parentSpan.AddLink(trace.LinkFromContext(ctx))
@@ -276,10 +271,7 @@ func (q *timeseriesQuerier) QueryMetadata(ctx context.Context, params metricstor
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -333,10 +325,7 @@ func (q *timeseriesQuerier) queryMetadata(
 		trace.WithLinks(parentLink),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 	if parentSpan != nil {
 		parentSpan.AddLink(trace.LinkFromContext(ctx))

--- a/internal/chstorage/querier_traces.go
+++ b/internal/chstorage/querier_traces.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oteldb/oteldb/internal/traceql/traceqlengine"
 	"github.com/oteldb/oteldb/internal/tracestorage"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // SearchTags performs search by given tags.
@@ -38,10 +39,7 @@ func (q *Querier) SearchTags(ctx context.Context, tags map[string]string, opts t
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	subquery := chsql.Select(table, chsql.Column("trace_id", nil)).
@@ -122,10 +120,7 @@ func (q *Querier) TagNames(ctx context.Context, opts tracestorage.TagNamesOption
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -192,10 +187,7 @@ func (q *Querier) TagValues(ctx context.Context, tag traceql.Attribute, opts tra
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	switch tag.Prop {
@@ -254,10 +246,7 @@ func (q *Querier) spanNames(ctx context.Context, tag traceql.Attribute, opts tra
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -323,10 +312,7 @@ func (q *Querier) attributeValues(ctx context.Context, tag traceql.Attribute, op
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	// FIXME(tdakkota): respect time range parameters.
@@ -402,10 +388,7 @@ func (q *Querier) TraceByID(ctx context.Context, id otelstorage.TraceID, opts tr
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (
@@ -458,10 +441,7 @@ func (q *Querier) SelectSpansets(ctx context.Context, params traceqlengine.Selec
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var (

--- a/internal/clusteradmin/fanout.go
+++ b/internal/clusteradmin/fanout.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // nodeAnswer is what one member contributed to a fan-out: its value, or why it has none.
@@ -47,7 +48,7 @@ func fanout[T any](
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 			span.SetStatus(codes.Error, rerr.Error())
 		}
 		span.End()
@@ -84,7 +85,7 @@ func fanout[T any](
 			out[i] = nodeAnswer[T]{Peer: p, Value: v, Err: err, Took: time.Since(started)}
 
 			if err != nil {
-				nodeSpan.RecordError(err)
+				xspan.Fail(nodeSpan, err)
 				nodeSpan.SetStatus(codes.Error, err.Error())
 
 				a.opts.Logger.Warn("Node did not answer",

--- a/internal/clusteradmin/fanout.go
+++ b/internal/clusteradmin/fanout.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -47,11 +46,7 @@ func fanout[T any](
 		trace.WithAttributes(attribute.String("clusteradmin.op", name)),
 	)
 	defer func() {
-		if rerr != nil {
-			xspan.Fail(span, rerr)
-			span.SetStatus(codes.Error, rerr.Error())
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	peers, err := a.opts.Peers.Peers()
@@ -86,7 +81,6 @@ func fanout[T any](
 
 			if err != nil {
 				xspan.Fail(nodeSpan, err)
-				nodeSpan.SetStatus(codes.Error, err.Error())
 
 				a.opts.Logger.Warn("Node did not answer",
 					zap.String("op", name), zap.String("node", p.Node), zap.String("addr", p.Addr),

--- a/internal/clusteradmin/forward.go
+++ b/internal/clusteradmin/forward.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // forward answers a request addressed to one named member, by asking that member and returning its
@@ -30,7 +31,7 @@ func forward[T any](
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 			span.SetStatus(codes.Error, rerr.Error())
 		}
 		span.End()

--- a/internal/clusteradmin/forward.go
+++ b/internal/clusteradmin/forward.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/oteldb/oteldb/internal/adminapi"
@@ -30,11 +29,7 @@ func forward[T any](
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			xspan.Fail(span, rerr)
-			span.SetStatus(codes.Error, rerr.Error())
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var zero T

--- a/internal/logql/logqlengine/engine.go
+++ b/internal/logql/logqlengine/engine.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // Engine is a LogQL evaluation engine.
@@ -105,10 +106,7 @@ func (e *Engine) NewQuery(ctx context.Context, query string) (q Query, rerr erro
 		attribute.String("logql.query", query),
 	))
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	expr, err := logql.Parse(query, e.parseOpts)
@@ -125,10 +123,7 @@ func (e *Engine) NewQueryFromExpr(ctx context.Context, expr logql.Expr) (q Query
 		attribute.String("logql.query", "<query>"),
 	))
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 	return e.newQuery(ctx, expr)
 }

--- a/internal/logql/logqlengine/engine_literal_query.go
+++ b/internal/logql/logqlengine/engine_literal_query.go
@@ -11,6 +11,7 @@ import (
 	"github.com/oteldb/oteldb/internal/logql"
 	"github.com/oteldb/oteldb/internal/lokiapi"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // LiteralQuery is simple literal expression query.
@@ -44,10 +45,7 @@ func (q *LiteralQuery) Eval(ctx context.Context, params EvalParams) (data lokiap
 	))
 	defer func() {
 		q.stats.QueryDuration.Record(ctx, time.Since(start).Seconds())
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	if params.IsInstant() {

--- a/internal/logql/logqlengine/engine_log_query.go
+++ b/internal/logql/logqlengine/engine_log_query.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oteldb/oteldb/internal/logql"
 	"github.com/oteldb/oteldb/internal/lokiapi"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // LogQuery represents a log query.
@@ -73,10 +74,7 @@ func (q *LogQuery) eval(ctx context.Context, params EvalParams) (data lokiapi.St
 	))
 	defer func() {
 		q.stats.QueryDuration.Record(ctx, time.Since(start).Seconds())
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	iter, err := q.Root.EvalPipeline(ctx, params)

--- a/internal/logql/logqlengine/engine_metric_query.go
+++ b/internal/logql/logqlengine/engine_metric_query.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oteldb/oteldb/internal/logql/logqlengine/logqlmetric"
 	"github.com/oteldb/oteldb/internal/lokiapi"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // MetricQuery represents a metric query.
@@ -60,10 +61,7 @@ func (q *MetricQuery) eval(ctx context.Context, params EvalParams) (data lokiapi
 	))
 	defer func() {
 		q.stats.QueryDuration.Record(ctx, time.Since(start).Seconds())
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	iter, err := q.Root.EvalMetric(ctx, MetricParams{

--- a/internal/logql/logqlengine/engine_optimizer.go
+++ b/internal/logql/logqlengine/engine_optimizer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/go-faster/errors"
+
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // Optimizer defines an interface for optimizer.
@@ -21,10 +23,7 @@ func DefaultOptimizers() []Optimizer {
 func (e *Engine) applyOptimizers(ctx context.Context, q Query) (_ Query, rerr error) {
 	ctx, span := e.tracer.Start(ctx, "logql.Engine.applyOptimizers")
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	var err error

--- a/internal/profileql/profileqlengine/engine.go
+++ b/internal/profileql/profileqlengine/engine.go
@@ -18,6 +18,7 @@ import (
 	"github.com/oteldb/oteldb/internal/profilestorage"
 	"github.com/oteldb/oteldb/internal/pyroscopeapi"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // Engine is a ProfileQL evaluation engine.
@@ -83,10 +84,7 @@ func (e *Engine) Select(ctx context.Context, query string, params EvalParams) (r
 		),
 	)
 	defer func() {
-		if rerr != nil {
-			span.RecordError(rerr)
-		}
-		span.End()
+		xspan.End(span, rerr)
 	}()
 
 	expr, err := profileql.Parse(query)

--- a/internal/scarecrow/engine.go
+++ b/internal/scarecrow/engine.go
@@ -275,7 +275,6 @@ func (q *query) Exec(ctx context.Context) *promql.Result {
 		err = queryContextErr(ctx, err)
 
 		xspan.Fail(span, err)
-		span.SetStatus(codes.Error, err.Error())
 
 		return &promql.Result{Err: err}
 	}

--- a/internal/scarecrow/engine.go
+++ b/internal/scarecrow/engine.go
@@ -13,6 +13,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // Opts configures an [Engine].
@@ -272,7 +274,7 @@ func (q *query) Exec(ctx context.Context) *promql.Result {
 		// mapping) cannot tell the two engines apart.
 		err = queryContextErr(ctx, err)
 
-		span.RecordError(err)
+		xspan.Fail(span, err)
 		span.SetStatus(codes.Error, err.Error())
 
 		return &promql.Result{Err: err}

--- a/internal/scarecrow/pushdown_count.go
+++ b/internal/scarecrow/pushdown_count.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-faster/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // countSeries answers `count(selector)` from a [SeriesCounter] without reading a sample.
@@ -112,7 +114,7 @@ func (o *countSeries) count(ctx context.Context, refs []int64, lookback int64) e
 	for step, maxt := range refs {
 		n, err := o.counter.CountSeries(ctx, maxt-lookback, maxt, o.matchers)
 		if err != nil {
-			span.RecordError(err)
+			xspan.Fail(span, err)
 
 			return errors.Wrapf(err, "count series at %d", maxt)
 		}
@@ -245,7 +247,7 @@ func (o *countSeriesBy) collect(ctx context.Context, refs []int64) ([]map[string
 	for i, maxt := range refs {
 		counts, err := o.counter.CountSeriesBy(ctx, maxt-lookback, maxt, o.by, o.matchers)
 		if err != nil {
-			span.RecordError(err)
+			xspan.Fail(span, err)
 
 			return nil, errors.Wrapf(err, "count series by %s at %d", o.by, maxt)
 		}

--- a/internal/scarecrow/pushdown_grid.go
+++ b/internal/scarecrow/pushdown_grid.go
@@ -6,6 +6,8 @@ import (
 	"github.com/go-faster/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // gridFor derives the [WindowGrid] covering refs, or ok=false when refs are not a multi-step,
@@ -56,7 +58,7 @@ func aggregateGrid(
 
 	out, err := scanner.AggregateGrid(ctx, grid, matchers)
 	if err != nil {
-		span.RecordError(err)
+		xspan.Fail(span, err)
 
 		return nil, errors.Wrap(err, "aggregate grid")
 	}

--- a/internal/scarecrow/pushdown_overtime.go
+++ b/internal/scarecrow/pushdown_overtime.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-faster/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // aggregateOverTime answers a reducer `*_over_time` from an [AggregateScanner] instead of folding
@@ -127,7 +129,7 @@ func (o *aggregateOverTime) collect(
 
 		aggs, err := o.scanner.AggregateOverTime(ctx, maxt-rngMs, maxt, o.matchers)
 		if err != nil {
-			span.RecordError(err)
+			xspan.Fail(span, err)
 
 			return errors.Wrapf(err, "aggregate over time at %d", maxt)
 		}

--- a/internal/scarecrow/selector.go
+++ b/internal/scarecrow/selector.go
@@ -10,6 +10,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/value"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // vectorSelect folds a series' raw samples onto the step grid using PromQL lookback: step t
@@ -120,7 +122,7 @@ func (o *vectorSelect) Schema(ctx context.Context) (*Schema, error) {
 
 	series, err := o.scanner.Series(ctx, mint, maxt, o.matchers)
 	if err != nil {
-		span.RecordError(err)
+		xspan.Fail(span, err)
 
 		return nil, errors.Wrap(err, "enumerate series")
 	}
@@ -170,7 +172,7 @@ func (o *vectorSelect) Next(ctx context.Context) (*Column, error) {
 		span.End()
 
 		if err != nil {
-			span.RecordError(err)
+			xspan.Fail(span, err)
 
 			return nil, errors.Wrap(err, "scan series")
 		}

--- a/internal/traceql/traceqlengine/engine.go
+++ b/internal/traceql/traceqlengine/engine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oteldb/oteldb/internal/traceql"
 	"github.com/oteldb/oteldb/internal/tracestorage"
 	"github.com/oteldb/oteldb/internal/xattribute"
+	"github.com/oteldb/oteldb/internal/xspan"
 )
 
 // Engine is a TraceQL evaluation engine.
@@ -71,7 +72,7 @@ func (e *Engine) Eval(ctx context.Context, query string, params EvalParams) (tra
 	)
 	defer func() {
 		if rerr != nil {
-			span.RecordError(rerr)
+			xspan.Fail(span, rerr)
 		} else if traces != nil {
 			var spans int
 			for _, m := range traces.Traces {

--- a/internal/traceql/traceqlengine/engine_test.go
+++ b/internal/traceql/traceqlengine/engine_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/oteldb/oteldb/internal/tempoapi"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestEngine(t *testing.T) {
@@ -364,6 +367,33 @@ func TestTimeRange(t *testing.T) {
 				tt.start.AsTime(),
 				tt.end.AsTime(),
 			))
+		})
+	}
+}
+
+func TestEvalMarksSpanFailed(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{"ParseError", `{ .a = }`},
+		{"UnsupportedAttribute", `{nestedSetParent<0}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := tracetest.NewSpanRecorder()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+			engine := NewEngine(&MemoryQuerier{}, Options{TracerProvider: tp})
+
+			_, err := engine.Eval(context.Background(), tt.query, EvalParams{Limit: 100})
+			require.Error(t, err)
+
+			spans := rec.Ended()
+			require.Len(t, spans, 1)
+			// A span that only records the exception event keeps an unset status, so an error-filtered
+			// trace view hides the one span that carries the cause.
+			require.Equal(t, codes.Error, spans[0].Status().Code)
+			require.Equal(t, err.Error(), spans[0].Status().Description)
 		})
 	}
 }

--- a/internal/xspan/xspan.go
+++ b/internal/xspan/xspan.go
@@ -19,6 +19,13 @@ func Fail(span trace.Span, err error) {
 }
 
 // End marks span as failed if err is non-nil, then ends it.
+//
+// Call it from a deferred closure:
+//
+//	defer func() { xspan.End(span, rerr) }()
+//
+// A plain defer evaluates rerr where the defer statement is, while it is still nil, so every span
+// would report success.
 func End(span trace.Span, err error) {
 	Fail(span, err)
 	span.End()

--- a/internal/xspan/xspan.go
+++ b/internal/xspan/xspan.go
@@ -1,0 +1,25 @@
+// Package xspan provides helpers for reporting errors on a [trace.Span].
+package xspan
+
+import (
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Fail records err on span and marks the span as failed.
+//
+// [trace.Span.RecordError] only appends an exception event: a span whose status is left unset reads
+// as a success, so error-filtered views hide the very span that carries the cause.
+func Fail(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+// End marks span as failed if err is non-nil, then ends it.
+func End(span trace.Span, err error) {
+	Fail(span, err)
+	span.End()
+}

--- a/internal/xspan/xspan_test.go
+++ b/internal/xspan/xspan_test.go
@@ -1,0 +1,65 @@
+package xspan_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/oteldb/oteldb/internal/xspan"
+)
+
+func recorded(t *testing.T, do func(tracer trace.Tracer)) tracetest.SpanStub {
+	t.Helper()
+
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	do(tp.Tracer("test"))
+
+	spans := rec.Ended()
+	require.Len(t, spans, 1)
+	return tracetest.SpanStubFromReadOnlySpan(spans[0])
+}
+
+func TestEnd(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantCode   codes.Code
+		wantMsg    string
+		wantEvents int
+	}{
+		{"Nil", nil, codes.Unset, "", 0},
+		{"Error", errors.New("boom"), codes.Error, "boom", 1},
+		{"Wrapped", errors.Wrap(errors.New("boom"), "eval"), codes.Error, "eval: boom", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := recorded(t, func(tracer trace.Tracer) {
+				_, span := tracer.Start(context.Background(), "op")
+				xspan.End(span, tt.err)
+			})
+
+			require.Equal(t, tt.wantCode, got.Status.Code)
+			require.Equal(t, tt.wantMsg, got.Status.Description)
+			require.Len(t, got.Events, tt.wantEvents)
+		})
+	}
+}
+
+func TestFailDoesNotEnd(t *testing.T) {
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+
+	_, span := tp.Tracer("test").Start(context.Background(), "op")
+	xspan.Fail(span, errors.New("boom"))
+	require.Empty(t, rec.Ended())
+
+	span.End()
+	require.Len(t, rec.Ended(), 1)
+}


### PR DESCRIPTION
Closes #1354.

`span.RecordError` only appends an `exception` event — per the OTel spec the span's status stays
`Unset` unless `SetStatus` is called too. So a span that recorded an error still reads as a success,
and filtering a trace view by error status hides the one span that knows what went wrong.

65 hand-written call sites across `internal/` and `cmd/` record an error on a span. Eight of them
set a status too; the other 57 did not, so those spans read as successes. The trace that prompted
this (a TraceQL search failing per #1353):

```
svc=odbselect  span=Eval          status=Unset  msg=""
    exception: build pipeline: build spanset evaluater: unsupported attribute "nestedSetParent"
svc=odbselect  span=Search        status=Error  msg="Internal"
    exception: code: 500, message: Internal Server Error: internal server error response
svc=odbselect  span=tempo.search  status=Error  msg=""
```

## Change

`internal/xspan`:

- `Fail(span, err)` — `RecordError` + `SetStatus(codes.Error, err.Error())`, no-op on a nil error.
- `End(span, err)` — `Fail` then `End`, which collapses the

  ```go
  defer func() {
      if rerr != nil {
          span.RecordError(rerr)
      }
      span.End()
  }()
  ```

  block that the call sites repeated verbatim.

Sites that do more in the deferred func (add a result event, bump a counter on success) keep their
block and call `xspan.Fail`. The eight sites that already called `SetStatus` themselves drop that
line, since `Fail` now makes the call.

`End` must be called from a deferred closure, which its godoc says: a plain
`defer xspan.End(span, rerr)` evaluates `rerr` at the defer statement, while it is still nil, and
every span would silently report success.

## Verification

`TestEvalMarksSpanFailed` covers both ways a TraceQL search fails — a parse error and an unsupported
attribute — and asserts the `Eval` span ends with `codes.Error` and the error's own message as the
description. Negative control: with `xspan.Fail` reverted to `span.RecordError` in `engine.go`, both
subtests fail on `expected: 0x1, actual: 0x0` (`codes.Error` vs `codes.Unset`); restored, they pass.

`TestEnd` table-tests the helper against a `tracetest` recorder, including that a wrapped error's
full message reaches the status description, and `TestFailDoesNotEnd` pins that `Fail` leaves the
span open.

`go build ./...`, `go test ./...` and `golangci-lint run` on every touched package are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
