### PR TITLE
feat(logs): answer level/detected_level from the data, spelled the way Loki spells it

### DIFF
--- a/integration/lokie2e/loki_e2e.go
+++ b/integration/lokie2e/loki_e2e.go
@@ -6,6 +6,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 
+	"github.com/oteldb/oteldb/internal/logql/logqlengine/logqlabels"
 	"github.com/oteldb/oteldb/internal/logstorage"
 	"github.com/oteldb/oteldb/internal/otelstorage"
 )
@@ -36,25 +37,6 @@ func NewBatchSet() *BatchSet {
 	} {
 		s.Labels[v] = []logstorage.Label{}
 	}
-	for _, i := range []plog.SeverityNumber{
-		plog.SeverityNumberUnspecified,
-		plog.SeverityNumberTrace,
-		plog.SeverityNumberDebug,
-		plog.SeverityNumberInfo,
-		plog.SeverityNumberWarn,
-		plog.SeverityNumberError,
-		plog.SeverityNumberFatal,
-	} {
-		s.addLabel(logstorage.Label{
-			Name:  logstorage.LabelSeverity,
-			Value: i.String(),
-		})
-		s.addLabel(logstorage.Label{
-			Name:  logstorage.LabelDetectedLevel,
-			Value: i.String(),
-		})
-	}
-
 	return s
 }
 
@@ -85,6 +67,14 @@ func (s *BatchSet) Append(raw plog.Logs) error {
 
 func (s *BatchSet) addRecord(record plog.LogRecord) error {
 	ts := record.Timestamp()
+
+	// The level labels are enumerated from the records that carry a severity, not from the enum:
+	// both backends answer with the levels the window holds, so seeding every severity plog can name
+	// would expect values nothing was ingested with.
+	if level := logqlabels.Level(record.SeverityNumber(), record.SeverityText()); level != "" {
+		s.addLabel(logstorage.Label{Name: logstorage.LabelSeverity, Value: level})
+		s.addLabel(logstorage.Label{Name: logstorage.LabelDetectedLevel, Value: level})
+	}
 
 	if _, ok := s.Records[ts]; ok {
 		return errors.Errorf("duplicate record with timestamp %v", ts)

--- a/internal/chstorage/querier_logs.go
+++ b/internal/chstorage/querier_logs.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ClickHouse/ch-go/proto"
 	"github.com/go-faster/errors"
-	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/maps"
@@ -168,18 +167,11 @@ func (q *Querier) LabelValues(ctx context.Context, labelName string, opts logsto
 	switch labelName {
 	case logstorage.LabelBody, logstorage.LabelSpanID, logstorage.LabelTraceID:
 	case logstorage.LabelSeverity, logstorage.LabelDetectedLevel:
-		// FIXME(tdakkota): do a proper query with filtering
-		values = []string{
-			plog.SeverityNumberUnspecified.String(),
-			plog.SeverityNumberTrace.String(),
-			plog.SeverityNumberDebug.String(),
-			plog.SeverityNumberInfo.String(),
-			plog.SeverityNumberWarn.String(),
-			plog.SeverityNumberError.String(),
-			plog.SeverityNumberFatal.String(),
+		got, err := q.levelValues(ctx, opts, limit)
+		if err != nil {
+			return nil, errors.Wrap(err, "level values")
 		}
-		values = values[:min(len(values), limit)]
-		slices.Sort(values)
+		values = got
 	default:
 		queryLabels := make([]string, 0, 1+len(opts.Query.Matchers))
 		queryLabels = append(queryLabels, labelName)

--- a/internal/chstorage/querier_logs_levels.go
+++ b/internal/chstorage/querier_logs_levels.go
@@ -1,0 +1,81 @@
+package chstorage
+
+import (
+	"context"
+	"maps"
+	"slices"
+
+	"github.com/ClickHouse/ch-go/proto"
+	"github.com/go-faster/errors"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/chstorage/chsql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine/logqlabels"
+	"github.com/oteldb/oteldb/internal/logstorage"
+)
+
+// levelValues returns the distinct levels the matching records were written with, as
+// [logqlabels.Level] spells them.
+//
+// The severity columns are the whole query: grouping by them reads two low-cardinality columns and
+// nothing else, and the group count is bounded by the severity enum rather than by the window. So a
+// tenant that only ever logs info and error offers two levels, instead of the fourteen the enum can
+// name — which is what the old static list returned, whatever the data held.
+func (q *Querier) levelValues(ctx context.Context, opts logstorage.LabelsOptions, limit int) ([]string, error) {
+	table := q.tables.Logs
+
+	queryLabels := make([]string, 0, len(opts.Query.Matchers))
+	for _, m := range opts.Query.Matchers {
+		queryLabels = append(queryLabels, string(m.Label))
+	}
+	mapping, err := q.getLabelMapping(ctx, queryLabels)
+	if err != nil {
+		return nil, errors.Wrap(err, "get label mapping")
+	}
+
+	var (
+		severityNumber proto.ColUInt8
+		severityText   = new(proto.ColStr).LowCardinality()
+
+		query = chsql.Select(table,
+			chsql.Column("severity_number", &severityNumber),
+			chsql.Column("severity_text", severityText),
+		).
+			GroupBy(chsql.Ident("severity_number"), chsql.Ident("severity_text")).
+			Where(chsql.InTimeRange("timestamp", opts.Start, opts.End, proto.PrecisionNano))
+	)
+	for _, m := range opts.Query.Matchers {
+		query.Where(q.logQLLabelMatcher(m, mapping))
+	}
+
+	values := map[string]struct{}{}
+	if err := q.do(ctx, selectQuery{
+		Query: query,
+		OnResult: func(_ context.Context, _ proto.Block) error {
+			for i := 0; i < severityNumber.Rows(); i++ {
+				var text string
+				if i < severityText.Rows() {
+					text = severityText.Row(i)
+				}
+				if v := logqlabels.Level(plog.SeverityNumber(severityNumber.Row(i)), text); v != "" {
+					values[v] = struct{}{}
+				}
+			}
+
+			return nil
+		},
+
+		Type:   "LabelValues",
+		Signal: "logs",
+		Table:  table,
+	}); err != nil {
+		return nil, err
+	}
+
+	out := slices.Sorted(maps.Keys(values))
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+
+	return out, nil
+}

--- a/internal/logql/logqlengine/logqlabels/label_set.go
+++ b/internal/logql/logqlengine/logqlabels/label_set.go
@@ -120,11 +120,11 @@ var severityStrings = func() (r map[plog.SeverityNumber]pcommon.Value) {
 		plog.SeverityNumberFatal3,
 		plog.SeverityNumberFatal4,
 	} {
-		// Canonical OTel SeverityText is upper-case ("ERROR", "WARN", …). plog's
-		// String() is title-case ("Error"); normalize so the conventional
-		// {level="ERROR"} selector matches (and so the embedded engine agrees with
-		// chstorage, which resolves level matchers case-foldedly).
-		r[n] = pcommon.NewValueStr(strings.ToUpper(n.String()))
+		// Loki spells a level lower-case ("error", "warn", …), and Grafana's Logs
+		// Drilldown offers exactly those values; plog's String() is title-case
+		// ("Error"). Both backends resolve a level matcher case-insensitively, so a
+		// selector written any of the three ways still matches.
+		r[n] = pcommon.NewValueStr(strings.ToLower(n.String()))
 	}
 	return r
 }()
@@ -144,7 +144,7 @@ func (l *LabelSet) SetFromRecord(record logstorage.Record) {
 		l.Set(logstorage.LabelSeverity, s)
 		l.Set(logstorage.LabelDetectedLevel, s)
 	} else if severityText := record.SeverityText; severityText != "" {
-		s := pcommon.NewValueStr(strings.ToUpper(severityText))
+		s := pcommon.NewValueStr(strings.ToLower(severityText))
 		l.Set(logstorage.LabelSeverity, s)
 		l.Set(logstorage.LabelDetectedLevel, s)
 	}
@@ -246,4 +246,22 @@ func (l *LabelSet) SetError(typ string, err error) {
 // GetError returns error label.
 func (l *LabelSet) GetError() (string, bool) {
 	return l.GetString(logql.ErrorLabel)
+}
+
+// Level returns the level a record's severity is labeled with, exactly as [LabelSet.SetFromRecord]
+// writes it: the severity number's name when it is set, else the raw severity text, both
+// lower-cased. Empty when the record carries neither.
+//
+// It is the one place the rule lives, so a backend enumerating levels straight from its severity
+// columns offers the values its own query results are labeled with.
+func Level(number plog.SeverityNumber, text string) string {
+	if number != plog.SeverityNumberUnspecified {
+		if s, ok := severityStrings[number]; ok {
+			return s.Str()
+		}
+
+		return strings.ToLower(number.String())
+	}
+
+	return strings.ToLower(text)
 }

--- a/internal/logql/logqlengine/logqlabels/label_set_record_test.go
+++ b/internal/logql/logqlengine/logqlabels/label_set_record_test.go
@@ -46,19 +46,19 @@ func TestSetFromRecord_ServiceNameDefault(t *testing.T) {
 	assert.Equal(t, "api", v)
 }
 
-func TestSetFromRecord_LevelUppercase(t *testing.T) {
-	// SeverityNumber path.
+func TestSetFromRecord_LevelLowercase(t *testing.T) {
+	// SeverityNumber path: plog spells it "Error", Loki spells it "error".
 	l := NewLabelSet()
 	l.SetFromRecord(logstorage.Record{SeverityNumber: plog.SeverityNumberError})
 	for _, label := range []string{logstorage.LabelSeverity, logstorage.LabelDetectedLevel} {
 		v, ok := getStr(t, &l, label)
 		require.True(t, ok, label)
-		assert.Equal(t, "ERROR", v, label)
+		assert.Equal(t, "error", v, label)
 	}
 
-	// SeverityText path (number unspecified) is also normalized to upper-case.
-	l.SetFromRecord(logstorage.Record{SeverityText: "warn"})
+	// SeverityText path (number unspecified) is normalized the same way.
+	l.SetFromRecord(logstorage.Record{SeverityText: "WARN"})
 	v, ok := getStr(t, &l, logstorage.LabelSeverity)
 	require.True(t, ok)
-	assert.Equal(t, "WARN", v)
+	assert.Equal(t, "warn", v)
 }

--- a/internal/storagebackend/bench_logs_test.go
+++ b/internal/storagebackend/bench_logs_test.go
@@ -89,6 +89,11 @@ func BenchmarkLogsQuery(b *testing.B) {
 		{"select_service", `{service_name="api"}`, false},
 		{"line_filter", `{service_name="api"} |= "GET"`, false},
 		{"json_status", `{service_name="api"} | json | status>=400`, false},
+		// A level selector is resolved case-insensitively and cannot be pushed into the fetch
+		// (severity is a column, not an attribute key), so every materialized record is re-checked
+		// against it — which is where any per-record work in that check shows up.
+		{"select_level", `{service_name="api", level="error"}`, false},
+		{"select_level_regexp", `{service_name="api", level=~"e.+"}`, false},
 		{"metric_count_by_level", `sum by (level) (count_over_time({service_name="api"}[1m]))`, true},
 		{"metric_rate_by_level", `sum by (level) (rate({service_name="api"}[1m]))`, true},
 	}

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -3,7 +3,9 @@ package storagebackend
 import (
 	"cmp"
 	"context"
+	"regexp"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/go-faster/errors"
@@ -499,11 +501,51 @@ func (c logColumns) recordInto(batch *fetch.Batch, i int, attrBuf *signal.Attrib
 func matchSelector(set logqlabels.LabelSet, matchers []logql.LabelMatcher) bool {
 	for _, m := range matchers {
 		value, _ := set.GetString(m.Label)
+		if isLevelLabelName(string(m.Label)) {
+			if !matchLevel(m, value) {
+				return false
+			}
+
+			continue
+		}
 		if !matchLabel(m, value) {
 			return false
 		}
 	}
 	return true
+}
+
+// matchLevel evaluates a severity-derived matcher case-insensitively, so {level="ERROR"},
+// {level="Error"} and {level="error"} select the same records however the label is spelled here.
+// chstorage does the same by resolving the matcher to a severity number instead of comparing text,
+// and one selector must not mean two things on the two backends.
+func matchLevel(m logql.LabelMatcher, value string) bool {
+	switch m.Op {
+	case logql.OpEq:
+		return strings.EqualFold(value, m.Value)
+	case logql.OpNotEq:
+		return !strings.EqualFold(value, m.Value)
+	case logql.OpRe:
+		return m.Re != nil && matchAnyCase(m.Re, value)
+	case logql.OpNotRe:
+		return m.Re != nil && !matchAnyCase(m.Re, value)
+	default:
+		return false
+	}
+}
+
+// matchAnyCase reports whether re matches value in any of the three spellings a level is written in
+// — lower ("error"), upper ("ERROR") and plog's title case ("Error") — mirroring the casings
+// chstorage tries when it turns a regexp level matcher into a set of severity numbers.
+func matchAnyCase(re *regexp.Regexp, value string) bool {
+	if value == "" {
+		return re.MatchString(value)
+	}
+	lower := strings.ToLower(value)
+
+	return re.MatchString(lower) ||
+		re.MatchString(strings.ToUpper(lower)) ||
+		re.MatchString(strings.ToUpper(lower[:1])+lower[1:])
 }
 
 // matchLabel evaluates one LogQL label matcher against a value.
@@ -547,6 +589,19 @@ func (q *LogQuerier) LabelNames(ctx context.Context, opts logstorage.LabelsOptio
 			}
 		}
 	}
+	// Severity is a record column, so neither enumeration above reaches it. Report the level labels
+	// only when the window holds records that set one, which costs the same projected read that
+	// answers their values.
+	levels, err := q.levelValues(ctx, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "level values")
+	}
+	if len(levels) > 0 {
+		for _, name := range []string{logstorage.LabelSeverity, logstorage.LabelDetectedLevel} {
+			names[name] = struct{}{}
+		}
+	}
+
 	out := sortedKeys(names)
 	if opts.Limit > 0 && len(out) > opts.Limit {
 		out = out[:opts.Limit]
@@ -561,6 +616,19 @@ func (q *LogQuerier) LabelNames(ctx context.Context, opts logstorage.LabelsOptio
 // The record half mirrors [LogQuerier.LabelNames], which advertises those attribute keys: a name it
 // offers whose values endpoint always answers empty is worse than one it never offered.
 func (q *LogQuerier) LabelValues(ctx context.Context, labelName string, opts logstorage.LabelsOptions) (iterators.Iterator[logstorage.Label], error) {
+	if isLevelLabelName(labelName) {
+		levels, err := q.levelValues(ctx, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "level values")
+		}
+		out := make([]logstorage.Label, len(levels))
+		for i, v := range levels {
+			out[i] = logstorage.Label{Name: labelName, Value: v}
+		}
+
+		return iterators.Slice(out), nil
+	}
+
 	values := map[string]struct{}{}
 	if err := q.forEachLogStreamLabel(ctx, opts.Start, opts.End, opts.Query.Matchers, func(name, value string) {
 		if name == labelName {
@@ -664,7 +732,9 @@ func (q *LogQuerier) Series(ctx context.Context, opts logstorage.SeriesOptions) 
 	return out, nil
 }
 
-// DetectedLabels implements [logstorage.Querier]. It returns the cardinality of each stream label.
+// DetectedLabels implements [logstorage.Querier]. It returns the cardinality of each stream label,
+// plus the severity-derived labels — which are what Grafana's Logs Drilldown builds its level filter
+// from, and which no stream carries.
 func (q *LogQuerier) DetectedLabels(ctx context.Context, opts logstorage.LabelsOptions) ([]logstorage.DetectedLabel, error) {
 	values := map[string]map[string]struct{}{}
 	if err := q.forEachLogStreamLabel(ctx, opts.Start, opts.End, opts.Query.Matchers, func(name, value string) {
@@ -676,6 +746,19 @@ func (q *LogQuerier) DetectedLabels(ctx context.Context, opts logstorage.LabelsO
 		set[value] = struct{}{}
 	}); err != nil {
 		return nil, err
+	}
+
+	levels, err := q.levelValues(ctx, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "level values")
+	}
+	if len(levels) > 0 {
+		set := make(map[string]struct{}, len(levels))
+		for _, v := range levels {
+			set[v] = struct{}{}
+		}
+		values[logstorage.LabelSeverity] = set
+		values[logstorage.LabelDetectedLevel] = set
 	}
 
 	out := make([]logstorage.DetectedLabel, 0, len(values))

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -181,9 +181,10 @@ func (n *logStreamNode) materialize(ctx context.Context, batches []*fetch.Batch)
 	}
 	offsets[len(batches)] = total
 
+	selector := prepareSelector(n.selector)
 	workers := n.q.b.logParallelism
 	if workers <= 1 || total < logMaterializeThreshold {
-		return n.materializeRange(batches, offsets, 0, total), nil
+		return n.materializeRange(selector, batches, offsets, 0, total), nil
 	}
 	if workers > total {
 		workers = total
@@ -203,7 +204,7 @@ func (n *logStreamNode) materialize(ctx context.Context, batches []*fetch.Batch)
 			if err := grpCtx.Err(); err != nil {
 				return err
 			}
-			results[w] = n.materializeRange(batches, offsets, lo, hi)
+			results[w] = n.materializeRange(selector, batches, offsets, lo, hi)
 			return nil
 		})
 	}
@@ -223,7 +224,7 @@ func (n *logStreamNode) materialize(ctx context.Context, batches []*fetch.Batch)
 // single materialization primitive shared by the sequential and parallel paths, so both produce the
 // same entries in the same order for a given range. It reads only immutable batch state and builds a
 // fresh label set per record, so it is safe to call concurrently over disjoint ranges.
-func (n *logStreamNode) materializeRange(batches []*fetch.Batch, offsets []int, lo, hi int) []logqlengine.Entry {
+func (n *logStreamNode) materializeRange(selector preparedSelector, batches []*fetch.Batch, offsets []int, lo, hi int) []logqlengine.Entry {
 	out := make([]logqlengine.Entry, 0, max(hi-lo, 0))
 	// Per-call scratch (safe: each concurrent range owns its own). A record dropped by the selector
 	// reuses the scratch label set and attribute map; a kept record hands them off into the entry and
@@ -244,7 +245,7 @@ func (n *logStreamNode) materializeRange(batches []*fetch.Batch, offsets []int, 
 			set.Reset()
 			record := cols.recordInto(batch, i, &attrBuf, attrMap)
 			set.SetFromRecord(record)
-			if !matchSelector(set, n.selector) {
+			if !selector.match(set) {
 				attrMap.Clear() // reuse the map for the next dropped row
 				continue
 			}
@@ -498,54 +499,76 @@ func (c logColumns) recordInto(batch *fetch.Batch, i int, attrBuf *signal.Attrib
 
 // matchSelector reports whether the label set satisfies every selector matcher, treating an absent
 // label as the empty string (Loki semantics).
-func matchSelector(set logqlabels.LabelSet, matchers []logql.LabelMatcher) bool {
-	for _, m := range matchers {
-		value, _ := set.GetString(m.Label)
-		if isLevelLabelName(string(m.Label)) {
-			if !matchLevel(m, value) {
-				return false
-			}
+type preparedSelector []preparedMatcher
 
-			continue
+// preparedMatcher is one selector matcher with its per-record work hoisted out. A severity-derived
+// matcher is resolved case-insensitively — chstorage resolves one to a severity number rather than
+// comparing text, and a selector must not mean two things on the two backends — and that folding is
+// compiled in here, once per query, instead of being redone for every record materialized.
+type preparedMatcher struct {
+	logql.LabelMatcher
+	// level marks a severity-derived label, tested once here rather than per record.
+	level bool
+	// foldRe is a level regexp recompiled case-insensitively, so matching is one pass over the
+	// record's own spelling instead of a pass per casing it might have been written in.
+	foldRe *regexp.Regexp
+}
+
+// prepareSelector compiles matchers for repeated evaluation. It is called once per query; [match]
+// is called once per record.
+func prepareSelector(matchers []logql.LabelMatcher) preparedSelector {
+	if len(matchers) == 0 {
+		return nil
+	}
+
+	out := make(preparedSelector, len(matchers))
+	for i, m := range matchers {
+		p := preparedMatcher{LabelMatcher: m, level: isLevelLabelName(string(m.Label))}
+		if p.level && m.Re != nil {
+			// A pattern anchored by the parser stays anchored: the flag group only sets case
+			// folding for what follows it. A pattern that will not recompile keeps its own casing
+			// rather than failing the query.
+			if re, err := regexp.Compile("(?i)" + m.Re.String()); err == nil {
+				p.foldRe = re
+			}
 		}
-		if !matchLabel(m, value) {
+		out[i] = p
+	}
+
+	return out
+}
+
+// match reports whether set satisfies every matcher.
+func (p preparedSelector) match(set logqlabels.LabelSet) bool {
+	for _, m := range p {
+		value, _ := set.GetString(m.Label)
+		if !m.matches(value) {
 			return false
 		}
 	}
+
 	return true
 }
 
-// matchLevel evaluates a severity-derived matcher case-insensitively, so {level="ERROR"},
-// {level="Error"} and {level="error"} select the same records however the label is spelled here.
-// chstorage does the same by resolving the matcher to a severity number instead of comparing text,
-// and one selector must not mean two things on the two backends.
-func matchLevel(m logql.LabelMatcher, value string) bool {
+func (m preparedMatcher) matches(value string) bool {
+	if !m.level {
+		return matchLabel(m.LabelMatcher, value)
+	}
+
 	switch m.Op {
 	case logql.OpEq:
 		return strings.EqualFold(value, m.Value)
 	case logql.OpNotEq:
 		return !strings.EqualFold(value, m.Value)
 	case logql.OpRe:
-		return m.Re != nil && matchAnyCase(m.Re, value)
+		re := cmp.Or(m.foldRe, m.Re)
+		return re != nil && re.MatchString(value)
 	case logql.OpNotRe:
-		return m.Re != nil && !matchAnyCase(m.Re, value)
+		re := cmp.Or(m.foldRe, m.Re)
+		return re != nil && !re.MatchString(value)
 	default:
 		return false
 	}
-}
-
-// matchAnyCase reports whether re matches value in any of the three spellings a level is written in
-// — lower ("error"), upper ("ERROR") and plog's title case ("Error") — mirroring the casings
-// chstorage tries when it turns a regexp level matcher into a set of severity numbers.
-func matchAnyCase(re *regexp.Regexp, value string) bool {
-	if value == "" {
-		return re.MatchString(value)
-	}
-	lower := strings.ToLower(value)
-
-	return re.MatchString(lower) ||
-		re.MatchString(strings.ToUpper(lower)) ||
-		re.MatchString(strings.ToUpper(lower[:1])+lower[1:])
 }
 
 // matchLabel evaluates one LogQL label matcher against a value.
@@ -802,11 +825,12 @@ func (q *LogQuerier) logStreams(ctx context.Context, start, end time.Time, match
 		return nil, errors.Wrap(err, "log series")
 	}
 
+	selector := prepareSelector(matchers)
 	var out []logqlabels.LabelSet
 	for _, s := range series {
 		set := logqlabels.NewLabelSet()
 		set.SetAttrs(otelAttrs(s.Resource.Attributes), otelAttrs(s.Scope.Attributes))
-		if !matchSelector(set, matchers) {
+		if !selector.match(set) {
 			continue
 		}
 		out = append(out, set)

--- a/internal/storagebackend/logs_levels.go
+++ b/internal/storagebackend/logs_levels.go
@@ -53,12 +53,12 @@ func (q *LogQuerier) levelValues(ctx context.Context, opts logstorage.LabelsOpti
 
 	// A level matcher is never pushed into the fetch (severity is not an attribute key), so apply it
 	// here: `label_values(detected_level, {detected_level=~"e.*"})` should narrow the answer.
-	for _, m := range opts.Query.Matchers {
-		if !isLevelLabelName(string(m.Label)) {
+	for _, m := range prepareSelector(opts.Query.Matchers) {
+		if !m.level {
 			continue
 		}
 		for v := range values {
-			if !matchLevel(m, v) {
+			if !m.matches(v) {
 				delete(values, v)
 			}
 		}

--- a/internal/storagebackend/logs_levels.go
+++ b/internal/storagebackend/logs_levels.go
@@ -1,0 +1,73 @@
+package storagebackend
+
+import (
+	"context"
+
+	siglog "github.com/oteldb/storage/signal/log"
+
+	"github.com/oteldb/oteldb/internal/logstorage"
+)
+
+// isLevelLabelName reports whether name is one of the severity-derived labels. They are neither
+// stream identity nor record attributes — every record carries severity in its own columns — so
+// they need an enumeration path of their own.
+func isLevelLabelName(name string) bool {
+	return name == logstorage.LabelSeverity || name == logstorage.LabelDetectedLevel
+}
+
+// levelValues returns the distinct levels the records matching opts were written with, spelled as
+// [logqlabels.LabelSet.SetFromRecord] writes them.
+//
+// The answer comes from the data rather than from the enum: a tenant that only ever logs info and
+// error should offer two levels, not the fourteen plog can name.
+//
+// It reads only the level: the fetch projects the two severity columns, so the attributes column —
+// whose decode dominates a record materialization — is never touched. That is as narrow as this can
+// be today. [storage.Storage.ColumnValues] would answer a bytes column straight from the part
+// dictionaries, but a level comes from the severity *number* first, and numeric columns are not
+// enumerable.
+//
+// The result is a superset when the selector is not fully pushed down: re-checking it in memory
+// needs the label set this projection deliberately does not read. That matches ColumnValues, which
+// is documented as answering with a window superset, and it is the right way to be wrong for
+// autocomplete — offering a level that matches nothing beats hiding one that does.
+func (q *LogQuerier) levelValues(ctx context.Context, opts logstorage.LabelsOptions) ([]string, error) {
+	lo, hi := seriesWindow(opts.Start, opts.End)
+	node := &logStreamNode{q: q, selector: opts.Query.Matchers}
+	batches, _, err := node.fetchBatches(ctx, lo, hi, fetchOptions{
+		projection: []string{siglog.ColSeverity, siglog.ColSeverityText},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	values := map[string]struct{}{}
+	for _, batch := range batches {
+		cols := newLogColumns(batch)
+		for i := range batch.Timestamps {
+			if v := levelValue(cols.severity, cols.severityText, i); v != "" {
+				values[v] = struct{}{}
+			}
+		}
+	}
+
+	// A level matcher is never pushed into the fetch (severity is not an attribute key), so apply it
+	// here: `label_values(detected_level, {detected_level=~"e.*"})` should narrow the answer.
+	for _, m := range opts.Query.Matchers {
+		if !isLevelLabelName(string(m.Label)) {
+			continue
+		}
+		for v := range values {
+			if !matchLevel(m, v) {
+				delete(values, v)
+			}
+		}
+	}
+
+	out := sortedKeys(values)
+	if opts.Limit > 0 && len(out) > opts.Limit {
+		out = out[:opts.Limit]
+	}
+
+	return out, nil
+}

--- a/internal/storagebackend/logs_sampling.go
+++ b/internal/storagebackend/logs_sampling.go
@@ -2,7 +2,6 @@ package storagebackend
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -202,19 +201,20 @@ func (n *bucketSamplingNode) groupLabels(key string) map[string]string {
 	return m
 }
 
-// levelValue mirrors logqlabels.SetFromRecord's level label: the upper-cased severity number's name,
-// or the upper-cased raw severity text when the number is unspecified. The casing must match
-// SetFromRecord (which upper-cases both) so the bucketed and generic paths agree on the series key.
+// levelValue mirrors logqlabels.SetFromRecord's level label: the lower-cased severity number's name,
+// or the lower-cased raw severity text when the number is unspecified. The casing must match
+// SetFromRecord (which lower-cases both) so the bucketed and generic paths agree on the series key.
 func levelValue(severity []int64, text [][]byte, i int) string {
+	var number plog.SeverityNumber
 	if i < len(severity) {
-		if s := severity[i]; s != int64(plog.SeverityNumberUnspecified) {
-			return strings.ToUpper(plog.SeverityNumber(s).String())
-		}
+		number = plog.SeverityNumber(severity[i])
 	}
+	var raw string
 	if i < len(text) {
-		return strings.ToUpper(string(text[i]))
+		raw = string(text[i])
 	}
-	return ""
+
+	return logqlabels.Level(number, raw)
 }
 
 // isLevelLabel reports whether a grouping label is one of the severity-derived labels the bucketed

--- a/internal/storagebackend/signals_test.go
+++ b/internal/storagebackend/signals_test.go
@@ -439,3 +439,73 @@ func drainLabels(
 
 	return out
 }
+
+// TestBackendLogLevels pins Grafana Logs Drilldown's level filter. Severity is a record column, so
+// it is neither stream identity nor an attribute and neither enumeration reaches it: the filter used
+// to be offered no values at all. The values must be the levels the data holds — not the fourteen
+// the enum can name — and must be spelled the way a query result labels a record, or picking one
+// selects nothing.
+func TestBackendLogLevels(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "api")
+	sl := rl.ScopeLogs().AppendEmpty()
+	for _, severity := range []plog.SeverityNumber{
+		plog.SeverityNumberInfo,
+		plog.SeverityNumberError,
+		plog.SeverityNumberInfo,
+	} {
+		rec := sl.LogRecords().AppendEmpty()
+		rec.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		rec.Body().SetStr("request served")
+		rec.SetSeverityNumber(severity)
+	}
+	// A record with no severity number falls back to its text, lower-cased like the rest.
+	rec := sl.LogRecords().AppendEmpty()
+	rec.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+	rec.Body().SetStr("odd one")
+	rec.SetSeverityText("NOTICE")
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	var (
+		lq         = b.Logs()
+		start, end = ts.Add(-time.Hour), ts.Add(time.Hour)
+		opts       = logstorage.LabelsOptions{Start: start, End: end}
+		want       = []string{"error", "info", "notice"}
+	)
+
+	names, err := lq.LabelNames(ctx, opts)
+	require.NoError(t, err)
+	require.Contains(t, names, "level")
+	require.Contains(t, names, "detected_level")
+
+	require.Equal(t, want, drainLabels(ctx, t, lq, "detected_level", opts), "levels come from the data")
+	require.Equal(t, want, drainLabels(ctx, t, lq, "level", opts), "both spellings answer alike")
+
+	detected, err := lq.DetectedLabels(ctx, opts)
+	require.NoError(t, err)
+	var cardinality int
+	for _, l := range detected {
+		if l.Name == "detected_level" {
+			cardinality = l.Cardinality
+		}
+	}
+	require.Equal(t, len(want), cardinality, "Drilldown sizes its filter from this")
+
+	// Whatever case the selector is written in, it selects the same records: chstorage resolves a
+	// level matcher to a severity number rather than comparing text, and the two backends must not
+	// disagree about what a query means.
+	for _, value := range []string{"error", "ERROR", "Error"} {
+		node, err := lq.Query(ctx, []logql.LabelMatcher{
+			{Label: "detected_level", Op: logql.OpEq, Value: value},
+		})
+		require.NoError(t, err)
+		it, err := node.EvalPipeline(ctx, logqlengine.EvalParams{Start: start, End: end, Limit: -1})
+		require.NoError(t, err)
+		require.Len(t, drain(t, it), 1, value)
+	}
+}


### PR DESCRIPTION
Closes #1357.

Grafana Logs Drilldown's **Log levels** filter showed "No options found" on a storagebackend cluster.
Severity is a record column — neither stream identity nor an attribute — so `LabelNames`,
`LabelValues` and `DetectedLabels` all walked straight past it.

## What changed

**Enumeration (storagebackend).** `level` and `detected_level` are now reported by `LabelNames` and
`DetectedLabels`, and answered by `LabelValues`. The values come from the data: a tenant that only
logs info and error offers two levels, not the fourteen `plog` can name.

**Reads only the level.** The fetch projects `ColSeverity` + `ColSeverityText` and nothing else, so
the attributes column — whose decode dominates a record materialization — is never touched. That is
the same trick the bucketed sampling path already uses. `ColumnValues` would be cheaper still
(straight from the part dictionaries) but cannot serve this: a level comes from the severity
*number* first, and storage does not enumerate numeric columns.

**Lower-case, per Loki.** `SetFromRecord` now writes `error` rather than `ERROR`, which is how Loki
spells a level and what Drilldown offers. To keep existing selectors working — and because chstorage
already resolved level matchers case-foldedly — storagebackend now matches them case-insensitively
too, across `=`, `!=`, `=~` and `!~`. One selector must not mean two things on the two backends.

**chstorage parity.** `LabelValues` drops its static list (and its `FIXME(tdakkota): do a proper
query with filtering`) for a grouped query over the same two columns; the group count is bounded by
the severity enum, not by the window. The shared `logqlabels.Level` is now the single place the
number-then-text rule lives, so both backends offer exactly the values their own results are labeled
with.

## Verification

`TestBackendLogLevels` ingests info/error records plus one carrying only `SeverityText: "NOTICE"`,
and asserts the label names, the values (`error, info, notice` — from the data, including the
text-only fallback), the `detected_level` cardinality Drilldown sizes its filter from, and that
`error`, `ERROR` and `Error` all select the same record.

Negative control: with the level branches disabled in `LabelValues` and `matchSelector` the test
fails on both halves; restored, it passes. `TestSetFromRecord_LevelLowercase` pins the casing at the
source. `go build ./...`, `go test ./...` and `golangci-lint run` over the touched packages are clean.

## Note for review

This changes the value of a label that appears in query results, so any saved dashboard panel that
matched `{level="ERROR"}` still works (matching is case-insensitive), but one that *displays* or
*groups by* the level will now show `error`. That seemed worth the parity with Loki, but it is the
kind of change worth knowing about before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)