### PR TITLE
fix(tempohandler): stop reporting bad TraceQL as a server fault

### DIFF
--- a/internal/tempohandler/error.go
+++ b/internal/tempohandler/error.go
@@ -9,6 +9,9 @@ import (
 	"github.com/oteldb/storage/readbudget"
 
 	"github.com/oteldb/oteldb/internal/tempoapi"
+	"github.com/oteldb/oteldb/internal/traceql"
+	"github.com/oteldb/oteldb/internal/traceql/lexer"
+	"github.com/oteldb/oteldb/internal/traceql/traceqlengine"
 )
 
 func validationErr(ctx context.Context, err error, msg string) error {
@@ -31,8 +34,29 @@ func executionErr(ctx context.Context, err error, msg string) error {
 		}
 	}
 
+	// [traceqlengine.Engine.Eval] parses the query itself, so a malformed query comes back as an
+	// execution failure. It is the client's text that is wrong, not the server.
+	_, isLexerErr := errors.Into[*lexer.Error](err)
+	_, isSyntaxErr := errors.Into[*traceql.SyntaxError](err)
+	_, isTypeErr := errors.Into[*traceql.TypeError](err)
+	if isLexerErr || isSyntaxErr || isTypeErr {
+		return queryErr(ctx, http.StatusBadRequest, err, msg)
+	}
+
+	// A query the engine does not implement yet is valid TraceQL the server cannot answer.
+	if _, ok := errors.Into[*traceqlengine.UnsupportedError](err); ok {
+		return queryErr(ctx, http.StatusNotImplemented, err, msg)
+	}
+
 	return &tempoapi.ErrorStatusCode{
 		StatusCode: http.StatusInternalServerError,
+		Response:   tempoapi.Error(appendTrace(ctx, fmt.Sprintf("%s: %s", msg, err))),
+	}
+}
+
+func queryErr(ctx context.Context, code int, err error, msg string) error {
+	return &tempoapi.ErrorStatusCode{
+		StatusCode: code,
 		Response:   tempoapi.Error(appendTrace(ctx, fmt.Sprintf("%s: %s", msg, err))),
 	}
 }

--- a/internal/tempohandler/queryerr_test.go
+++ b/internal/tempohandler/queryerr_test.go
@@ -1,0 +1,68 @@
+package tempohandler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oteldb/storage/readbudget"
+
+	"github.com/oteldb/oteldb/internal/iterators"
+	"github.com/oteldb/oteldb/internal/tempoapi"
+	"github.com/oteldb/oteldb/internal/traceql/traceqlengine"
+)
+
+type failingQuerier struct {
+	err error
+}
+
+func (q failingQuerier) SelectSpansets(context.Context, traceqlengine.SelectSpansetsParams) (iterators.Iterator[traceqlengine.Trace], error) {
+	if q.err != nil {
+		return nil, q.err
+	}
+	return iterators.Slice([]traceqlengine.Trace(nil)), nil
+}
+
+// A query the engine rejects is not a server fault: neither a query it cannot parse nor one it does
+// not implement yet says anything about the health of the server, and 500 sends the reader to look
+// at the one place nothing is wrong.
+func TestSearchTraceQLStatusCodes(t *testing.T) {
+	t.Parallel()
+
+	for name, tt := range map[string]struct {
+		query      string
+		querierErr error
+		code       int
+	}{
+		"unsupported intrinsic": {"{nestedSetParent<0}", nil, http.StatusNotImplemented},
+		"unsupported intrinsic in conjunction": {
+			"{nestedSetParent<0 && true}", nil, http.StatusNotImplemented,
+		},
+		"unsupported child count": {"{childCount>1}", nil, http.StatusNotImplemented},
+		"syntax error":            {"{", nil, http.StatusBadRequest},
+		"lexer error":             {`{.foo="bar}`, nil, http.StatusBadRequest},
+		"budget exceeded": {
+			`{.foo="bar"}`,
+			errors.Wrap(readbudget.ErrExceeded, "reserve 1227385730 bytes"),
+			http.StatusUnprocessableEntity,
+		},
+		"fault": {`{.foo="bar"}`, errors.New("disk on fire"), http.StatusInternalServerError},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			engine := traceqlengine.NewEngine(failingQuerier{err: tt.querierErr}, traceqlengine.Options{})
+			api := NewTempoAPI(nil, engine, TempoAPIOptions{})
+
+			_, err := api.Search(context.Background(), tempoapi.SearchParams{
+				Q: tempoapi.NewOptString(tt.query),
+			})
+			got, ok := errors.Into[*tempoapi.ErrorStatusCode](err)
+			require.True(t, ok, "expected an API error, got %v", err)
+			require.Equal(t, tt.code, got.StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1353.

`{nestedSetParent<0}` answered 500, and so did `{`. Neither is the server's fault. `internal/tempohandler/error.go` now classifies what comes back from `executionErr`:

- `*traceql/lexer.Error`, `*traceql.SyntaxError`, `*traceql.TypeError` -> **400** (the client's text is wrong),
- `*traceqlengine.UnsupportedError` -> **501** (valid TraceQL the engine has not implemented: nested-set intrinsics, `childCount`, parent-scoped attributes, unsupported stages),
- `readbudget.ErrExceeded` -> 422 as before, everything else stays 500.

This mirrors what LogQL already does in `internal/lokihandler/error.go` (400 for lexer/parse) and `lokihandler.go` (501 for `logqlerrors.UnsupportedError`).

## Why classify in the handler rather than move the parse out of `Engine.Eval`

The issue offered moving `traceql.Parse` out of `Engine.Eval` so a syntax error reaches `validationErr` naturally. `Eval` has one production caller but many test callers (`traceqlengine`, `storagebackend` golden/pushdown benchmarks, `integration/tempoe2e`), all of which pass query text; splitting parse from eval changes its signature and every one of them, and the handler edit lands in `tempohandler.go`, which #1355 is holding right now. The classification is type-based (`errors.Into` on the concrete error types), not string matching, so it is exact — and `UnsupportedError` needs the same treatment regardless, since that one genuinely surfaces during execution and cannot be hoisted into a parse step. One mechanism for both beats two.

`executionErr` is shared by every handler (search, search-by-tags, tag names, tag values, trace-by-id). The parse and unsupported errors are only constructed on the TraceQL eval path, so the other handlers are unaffected in practice; and if one ever did surface such an error, 400/501 is the right answer there too.

## Verification

`internal/tempohandler/queryerr_test.go` drives `TempoAPI.Search` end to end over a real engine and asserts the status for an unsupported intrinsic (501, also inside `&& true`), `childCount` (501), a syntax error and a lexer error (400), a budget refusal (422) and a genuine fault (500). Reverting `error.go` alone fails the 501 and 400 cases and leaves the 422/500 ones passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)