### PR TITLE
fix(otlpdirect): reject timeless log records instead of storing them at the epoch

### DIFF
--- a/internal/otlpdirect/fuzz_test.go
+++ b/internal/otlpdirect/fuzz_test.go
@@ -65,7 +65,7 @@ func FuzzConvertLogs(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		var c otlpdirect.LogsConverter
 
-		got, err := c.Convert(data)
+		got, _, err := c.Convert(data)
 		if err != nil {
 			return
 		}
@@ -88,7 +88,7 @@ func FuzzConvertLogs(f *testing.F) {
 		}
 
 		// Reuse must not corrupt the previous batch's scratch into the next one.
-		if _, err := c.Convert(data); err != nil {
+		if _, _, err := c.Convert(data); err != nil {
 			t.Fatalf("second convert of the same input failed: %v", err)
 		}
 	})

--- a/internal/otlpdirect/handler.go
+++ b/internal/otlpdirect/handler.go
@@ -136,7 +136,7 @@ func (h *Handler) ingestLogs(ctx context.Context, src []byte) (items, rejected i
 	c, _ := h.logs.Get().(*LogsConverter)
 	defer h.logs.Put(c)
 
-	batch, err := c.Convert(src)
+	batch, dropped, err := c.Convert(src)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -145,7 +145,7 @@ func (h *Handler) ingestLogs(ctx context.Context, src []byte) (items, rejected i
 		return 0, 0, writeError{err: err}
 	}
 
-	return countRecords(batch), 0, nil
+	return countRecords(batch), dropped, nil
 }
 
 func (h *Handler) Traces() http.Handler { return h.serve(signal.Trace, h.ingestTraces) }

--- a/internal/otlpdirect/logs.go
+++ b/internal/otlpdirect/logs.go
@@ -48,30 +48,34 @@ type LogsConverter struct {
 	kvScratch [][]byte
 }
 
-// Convert decodes a serialized ExportLogsServiceRequest.
+// Convert decodes a serialized ExportLogsServiceRequest, returning how many records it could not
+// represent (a record carrying no usable time — see [LogsConverter.record]).
 //
 // The returned batch aliases src: every key, string value, body and id is a sub-slice of it. It
 // stays valid until the next Convert on this converter, and src must not be recycled until the
 // write consuming the batch has returned.
-func (c *LogsConverter) Convert(src []byte) (*log.Logs, error) {
+func (c *LogsConverter) Convert(src []byte) (_ *log.Logs, dropped int, _ error) {
 	c.batch.Reset()
 	c.dec.reset()
 
 	resources, err := collect(src, fieldExportResourceLogs, "resource logs")
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	for _, data := range resources {
-		if err := c.resourceLogs(data); err != nil {
-			return nil, err
+		n, err := c.resourceLogs(data)
+		if err != nil {
+			return nil, 0, err
 		}
+
+		dropped += n
 	}
 
-	return &c.batch, nil
+	return &c.batch, dropped, nil
 }
 
-func (c *LogsConverter) resourceLogs(src []byte) error {
+func (c *LogsConverter) resourceLogs(src []byte) (dropped int, _ error) {
 	var (
 		fc     easyproto.FieldContext
 		res    signal.Resource
@@ -81,30 +85,30 @@ func (c *LogsConverter) resourceLogs(src []byte) error {
 
 	for len(src) > 0 {
 		if src, err = fc.NextField(src); err != nil {
-			return errors.Wrap(err, "read resource logs field")
+			return 0, errors.Wrap(err, "read resource logs field")
 		}
 
 		switch fc.FieldNum {
 		case fieldResourceLogsResource:
 			data, ok := fc.MessageData()
 			if !ok {
-				return errors.New("read resource")
+				return 0, errors.New("read resource")
 			}
 
 			if res.Attributes, err = c.dec.resource(data); err != nil {
-				return err
+				return 0, err
 			}
 		case fieldResourceLogsScope:
 			data, ok := fc.MessageData()
 			if !ok {
-				return errors.New("read scope logs")
+				return 0, errors.New("read scope logs")
 			}
 
 			scopes = append(scopes, data)
 		case fieldResourceLogsSchemaURL:
 			v, ok := fc.Bytes()
 			if !ok {
-				return errors.New("read resource schema url")
+				return 0, errors.New("read resource schema url")
 			}
 
 			res.SchemaURL = v
@@ -115,15 +119,18 @@ func (c *LogsConverter) resourceLogs(src []byte) error {
 	rl.Resource = res
 
 	for _, data := range scopes {
-		if err := c.scopeLogs(rl, data); err != nil {
-			return err
+		n, err := c.scopeLogs(rl, data)
+		if err != nil {
+			return dropped, err
 		}
+
+		dropped += n
 	}
 
-	return nil
+	return dropped, nil
 }
 
-func (c *LogsConverter) scopeLogs(rl *log.ResourceLogs, src []byte) error {
+func (c *LogsConverter) scopeLogs(rl *log.ResourceLogs, src []byte) (dropped int, _ error) {
 	var (
 		fc        easyproto.FieldContext
 		scopeData []byte
@@ -138,28 +145,28 @@ func (c *LogsConverter) scopeLogs(rl *log.ResourceLogs, src []byte) error {
 	// place would overwrite a schema_url already read.
 	for len(src) > 0 {
 		if src, err = fc.NextField(src); err != nil {
-			return errors.Wrap(err, "read scope logs field")
+			return 0, errors.Wrap(err, "read scope logs field")
 		}
 
 		switch fc.FieldNum {
 		case fieldScopeLogsScope:
 			data, ok := fc.MessageData()
 			if !ok {
-				return errors.New("read scope")
+				return 0, errors.New("read scope")
 			}
 
 			scopeData = data
 		case fieldScopeLogsRecords:
 			data, ok := fc.MessageData()
 			if !ok {
-				return errors.New("read log record")
+				return 0, errors.New("read log record")
 			}
 
 			records = append(records, data)
 		case fieldScopeLogsSchemaURL:
 			v, ok := fc.Bytes()
 			if !ok {
-				return errors.New("read scope schema url")
+				return 0, errors.New("read scope schema url")
 			}
 
 			schemaURL = v
@@ -168,7 +175,7 @@ func (c *LogsConverter) scopeLogs(rl *log.ResourceLogs, src []byte) error {
 
 	sc, err := c.dec.scope(scopeData)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	sc.SchemaURL = schemaURL
@@ -177,15 +184,25 @@ func (c *LogsConverter) scopeLogs(rl *log.ResourceLogs, src []byte) error {
 	sl.Scope = sc
 
 	for _, data := range records {
-		if err := c.record(sl, data); err != nil {
-			return err
+		n, err := c.record(sl, data)
+		if err != nil {
+			return dropped, err
 		}
+
+		dropped += n
 	}
 
-	return nil
+	return dropped, nil
 }
 
-func (c *LogsConverter) record(sl *log.ScopeLogs, src []byte) error {
+// record appends one log record, returning 1 when it had to be dropped. time_unix_nano is optional
+// in OTLP — a receiver tailing files or journald with no timestamp parser leaves it unset — so an
+// unset event time falls back to the observed time, as the spec prescribes. Without the fallback
+// such a record sorts at the unix epoch, which no query window covers and which retention then
+// collects as ancient. A record with neither time has nothing to sort or query by and is refused
+// here, where the caller can still report it to the sender. This is the rule pdataconv applies on
+// the collector ingest path.
+func (c *LogsConverter) record(sl *log.ScopeLogs, src []byte) (dropped int, _ error) {
 	var (
 		fc  easyproto.FieldContext
 		rec log.Record
@@ -196,47 +213,47 @@ func (c *LogsConverter) record(sl *log.ScopeLogs, src []byte) error {
 
 	for len(src) > 0 {
 		if src, err = fc.NextField(src); err != nil {
-			return errors.Wrap(err, "read log record field")
+			return 0, errors.Wrap(err, "read log record field")
 		}
 
 		switch fc.FieldNum {
 		case fieldLogTime:
 			v, ok := fc.Fixed64()
 			if !ok {
-				return errors.New("read log timestamp")
+				return 0, errors.New("read log timestamp")
 			}
 
 			rec.Timestamp = int64(v)
 		case fieldLogObservedTime:
 			v, ok := fc.Fixed64()
 			if !ok {
-				return errors.New("read log observed timestamp")
+				return 0, errors.New("read log observed timestamp")
 			}
 
 			rec.ObservedTimestamp = int64(v)
 		case fieldLogSeverityNum:
 			v, ok := fc.Enum()
 			if !ok {
-				return errors.New("read log severity number")
+				return 0, errors.New("read log severity number")
 			}
 
 			rec.SeverityNumber = v
 		case fieldLogSeverityText:
 			v, ok := fc.Bytes()
 			if !ok {
-				return errors.New("read log severity text")
+				return 0, errors.New("read log severity text")
 			}
 
 			rec.SeverityText = v
 		case fieldLogBody:
 			data, ok := fc.MessageData()
 			if !ok {
-				return errors.New("read log body")
+				return 0, errors.New("read log body")
 			}
 
 			body, err := c.dec.anyValue(data)
 			if err != nil {
-				return err
+				return 0, err
 			}
 
 			// The model stores a body as text, so a non-string body is rendered the way the pdata
@@ -245,35 +262,35 @@ func (c *LogsConverter) record(sl *log.ScopeLogs, src []byte) error {
 		case fieldLogAttributes:
 			data, ok := fc.MessageData()
 			if !ok {
-				return errors.New("read log attribute")
+				return 0, errors.New("read log attribute")
 			}
 
 			kvs = append(kvs, data)
 		case fieldLogDropped:
 			v, ok := fc.Uint32()
 			if !ok {
-				return errors.New("read log dropped count")
+				return 0, errors.New("read log dropped count")
 			}
 
 			rec.Dropped = v
 		case fieldLogFlags:
 			v, ok := fc.Fixed32()
 			if !ok {
-				return errors.New("read log flags")
+				return 0, errors.New("read log flags")
 			}
 
 			rec.Flags = v
 		case fieldLogTraceID:
 			v, ok := fc.Bytes()
 			if !ok {
-				return errors.New("read log trace id")
+				return 0, errors.New("read log trace id")
 			}
 
 			rec.TraceID = v
 		case fieldLogSpanID:
 			v, ok := fc.Bytes()
 			if !ok {
-				return errors.New("read log span id")
+				return 0, errors.New("read log span id")
 			}
 
 			rec.SpanID = v
@@ -282,11 +299,19 @@ func (c *LogsConverter) record(sl *log.ScopeLogs, src []byte) error {
 
 	c.kvScratch = kvs // keep the grown capacity for the next record
 
+	if rec.Timestamp == 0 {
+		rec.Timestamp = rec.ObservedTimestamp
+	}
+
+	if rec.Timestamp == 0 {
+		return 1, nil
+	}
+
 	if rec.Attributes, err = c.dec.attributes(kvs); err != nil {
-		return err
+		return 0, err
 	}
 
 	*sl.AddRecord() = rec
 
-	return nil
+	return 0, nil
 }

--- a/internal/otlpdirect/logs_test.go
+++ b/internal/otlpdirect/logs_test.go
@@ -26,16 +26,17 @@ func marshal(tb testing.TB, ld plog.Logs) []byte {
 }
 
 // convertBoth decodes src directly and via the pdata path, returning both batches for comparison.
+// The two paths must also agree on how many records they refused.
 func convertBoth(tb testing.TB, ld plog.Logs) (direct, viaPdata *log.Logs) {
 	tb.Helper()
 
 	var c otlpdirect.LogsConverter
 
-	direct, err := c.Convert(marshal(tb, ld))
+	direct, dropped, err := c.Convert(marshal(tb, ld))
 	require.NoError(tb, err)
 
 	viaPdata = &log.Logs{}
-	require.Zero(tb, pdataconv.AppendLogs(viaPdata, ld))
+	require.Equal(tb, pdataconv.AppendLogs(viaPdata, ld), dropped)
 
 	return canonical(direct), canonical(viaPdata)
 }
@@ -181,9 +182,10 @@ func TestConvertLogsEmpty(t *testing.T) {
 
 	var c otlpdirect.LogsConverter
 
-	got, err := c.Convert(nil)
+	got, dropped, err := c.Convert(nil)
 	require.NoError(t, err)
 	assert.Empty(t, got.Resources)
+	assert.Zero(t, dropped)
 
 	direct, viaPdata := convertBoth(t, plog.NewLogs())
 	assert.Equal(t, viaPdata, direct)
@@ -208,10 +210,10 @@ func TestConvertLogsReuseIsIsolated(t *testing.T) {
 	sr.Body().SetStr("second")
 	sr.Attributes().PutStr("b", "2")
 
-	_, err := c.Convert(marshal(t, first))
+	_, _, err := c.Convert(marshal(t, first))
 	require.NoError(t, err)
 
-	got, err := c.Convert(marshal(t, second))
+	got, _, err := c.Convert(marshal(t, second))
 	require.NoError(t, err)
 
 	want := &log.Logs{}
@@ -247,7 +249,7 @@ func BenchmarkConvertLogs(b *testing.B) {
 		b.SetBytes(int64(len(raw)))
 
 		for b.Loop() {
-			if _, err := c.Convert(raw); err != nil {
+			if _, _, err := c.Convert(raw); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/internal/otlpdirect/logs_time_test.go
+++ b/internal/otlpdirect/logs_time_test.go
@@ -1,0 +1,127 @@
+package otlpdirect_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+
+	"github.com/oteldb/storage/signal"
+
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+)
+
+// TestConvertLogsTimeFallback pins the rule for the two optional OTLP timestamps: an unset event
+// time falls back to the observed time, and a record with neither is refused rather than stored at
+// the unix epoch. convertBoth also asserts the pdata path answers the same way.
+func TestConvertLogsTimeFallback(t *testing.T) {
+	t.Parallel()
+
+	const (
+		event    = 1_700_000_000_000_000_000
+		observed = 1_700_000_001_000_000_000
+	)
+
+	for _, tt := range []struct {
+		name      string
+		event     pcommon.Timestamp
+		observed  pcommon.Timestamp
+		want      int64
+		wantDrops int
+	}{
+		{name: "no time", wantDrops: 1},
+		{name: "observed only", observed: observed, want: observed},
+		{name: "both", event: event, observed: observed, want: event},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ld := plog.NewLogs()
+			rec := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+			rec.Body().SetStr("hello")
+			rec.SetTimestamp(tt.event)
+			rec.SetObservedTimestamp(tt.observed)
+
+			direct, viaPdata := convertBoth(t, ld)
+			assert.Equal(t, viaPdata, direct)
+
+			var c otlpdirect.LogsConverter
+
+			got, dropped, err := c.Convert(marshal(t, ld))
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDrops, dropped)
+
+			records := got.Resources[0].Scopes[0].Records
+			if tt.wantDrops > 0 {
+				assert.Empty(t, records)
+				return
+			}
+
+			require.Len(t, records, 1)
+			assert.Equal(t, tt.want, records[0].Timestamp)
+			assert.Equal(t, int64(tt.observed), records[0].ObservedTimestamp)
+		})
+	}
+}
+
+// TestHandlerLogsPartialSuccess pins that a timeless record is reported to the sender as a rejected
+// log record instead of vanishing, while the rest of the batch is stored.
+func TestHandlerLogsPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	mux, stats := serveOTLP(t, sink)
+
+	rec := post(mux, otlpdirect.LogsPath, marshal(t, logsWithTimelessRecord()), nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	rejected, message := decodePartialSuccess(t, rec.Body.Bytes())
+	assert.Equal(t, int64(1), rejected)
+	assert.NotEmpty(t, message, "a partial success must say what happened")
+
+	assert.Equal(t, 1, sink.logs, "the timestamped record is still stored")
+	require.Len(t, *stats, 1)
+	assert.Equal(t, 1, (*stats)[0].Rejected)
+	assert.Equal(t, signal.Log, (*stats)[0].Signal)
+}
+
+// TestGRPCLogsPartialSuccess pins the same count over gRPC, where the generated client reads it
+// back as rejected_log_records.
+func TestGRPCLogsPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	sink := &recordingSink{}
+	cc := serveGRPC(t, sink)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	req := plogotlp.NewExportRequestFromLogs(logsWithTimelessRecord())
+
+	resp, err := plogotlp.NewGRPCClient(cc).Export(ctx, req)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), resp.PartialSuccess().RejectedLogRecords())
+	assert.NotEmpty(t, resp.PartialSuccess().ErrorMessage())
+	assert.Equal(t, 1, sink.logs, "the timestamped record is still stored")
+}
+
+// logsWithTimelessRecord builds a batch of two records, one of which carries no time at all.
+func logsWithTimelessRecord() plog.Logs {
+	ld := plog.NewLogs()
+	records := ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
+
+	records.AppendEmpty().Body().SetStr("timeless")
+
+	stored := records.AppendEmpty()
+	stored.SetTimestamp(1_700_000_000_000_000_000)
+	stored.Body().SetStr("stored")
+
+	return ld
+}

--- a/internal/otlpdirect/order_test.go
+++ b/internal/otlpdirect/order_test.go
@@ -81,10 +81,10 @@ func TestConvertLogsIsFieldOrderIndependent(t *testing.T) {
 
 	var asc, desc otlpdirect.LogsConverter
 
-	up, err := asc.Convert(encodeScopeLogs(true))
+	up, _, err := asc.Convert(encodeScopeLogs(true))
 	require.NoError(t, err)
 
-	down, err := desc.Convert(encodeScopeLogs(false))
+	down, _, err := desc.Convert(encodeScopeLogs(false))
 	require.NoError(t, err)
 
 	require.Equal(t, canonical(down), canonical(up))

--- a/internal/storagebackend/dropped.go
+++ b/internal/storagebackend/dropped.go
@@ -1,0 +1,56 @@
+package storagebackend
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+
+	"github.com/oteldb/storage/signal"
+)
+
+const (
+	meterName = "github.com/oteldb/oteldb/internal/storagebackend"
+	// droppedRecords counts what an OTLP batch carried that the conversion could not represent.
+	droppedRecords = "oteldb.storage.dropped_records"
+
+	// reasonNoTimestamp is a log record carrying neither time_unix_nano nor
+	// observed_time_unix_nano: nothing to sort or query it by.
+	reasonNoTimestamp = "no_timestamp"
+)
+
+const (
+	droppedSignalKey = attribute.Key("signal")
+	droppedReasonKey = attribute.Key("reason")
+)
+
+// WithMeterProvider reports ingest-side drops through mp.
+//
+// The Consume* sinks implement the collector's consumer signatures, which return only an error, so
+// a batch that was mostly written has no in-band way to report the records it refused. This counter
+// is the only place those become visible; without it they vanish silently. A Backend built without
+// a provider still ingests, it just does not count.
+func WithMeterProvider(mp otelmetric.MeterProvider) Option {
+	return func(b *Backend) {
+		if mp == nil {
+			return
+		}
+		c, err := mp.Meter(meterName).Int64Counter(droppedRecords,
+			otelmetric.WithDescription("Records an OTLP batch carried that could not be represented, by signal and reason."),
+		)
+		if err != nil {
+			return
+		}
+		b.dropped = c
+	}
+}
+
+func (b *Backend) countDropped(ctx context.Context, sig signal.Signal, reason string, n int) {
+	if n <= 0 || b.dropped == nil {
+		return
+	}
+	b.dropped.Add(ctx, int64(n), otelmetric.WithAttributes(
+		droppedSignalKey.String(sig.String()),
+		droppedReasonKey.String(reason),
+	))
+}

--- a/internal/storagebackend/ingest.go
+++ b/internal/storagebackend/ingest.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/oteldb/storage/otlp/pdataconv"
+	"github.com/oteldb/storage/signal"
 	siglog "github.com/oteldb/storage/signal/log"
 	sigmetric "github.com/oteldb/storage/signal/metric"
 	sigprofile "github.com/oteldb/storage/signal/profile"
@@ -34,7 +35,7 @@ func (b *Backend) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
 // used when the storage backend serves logs.
 func (b *Backend) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	var batch siglog.Logs
-	pdataconv.AppendLogs(&batch, ld)
+	b.countDropped(ctx, signal.Log, reasonNoTimestamp, pdataconv.AppendLogs(&batch, ld))
 
 	if b.store == nil {
 		return ErrNoEngine

--- a/internal/storagebackend/ingest_agreement_test.go
+++ b/internal/storagebackend/ingest_agreement_test.go
@@ -1,0 +1,222 @@
+package storagebackend_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/oteldb/storage"
+	siglog "github.com/oteldb/storage/signal/log"
+	sigmetric "github.com/oteldb/storage/signal/metric"
+	sigprofile "github.com/oteldb/storage/signal/profile"
+	sigtrace "github.com/oteldb/storage/signal/trace"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+	"github.com/oteldb/oteldb/internal/otlpdirect"
+	"github.com/oteldb/oteldb/internal/storagebackend"
+)
+
+// TestLogIngestPathsAgreeOnTime pins that oteldb's two OTLP log ingest paths — odbingest's direct
+// wire decoder and the collector consumer over pdataconv — store the same record at the same time,
+// and refuse the same record, for every combination of the two optional OTLP timestamps.
+//
+// They disagreed before: the collector path fell back to the observed time and refused a record
+// with neither, while the direct decoder stored both at the unix epoch, outside every query window.
+func TestLogIngestPathsAgreeOnTime(t *testing.T) {
+	event := time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC)
+	observed := event.Add(time.Second)
+
+	for _, tt := range []struct {
+		name      string
+		event     time.Time
+		observed  time.Time
+		want      []time.Time
+		wantDrops int
+	}{
+		{
+			name: "no time",
+			// Neither time: nothing to sort or query the record by, so both paths refuse it.
+			wantDrops: 1,
+		},
+		{
+			name:     "observed only",
+			observed: observed,
+			want:     []time.Time{observed},
+		},
+		{
+			name:     "both",
+			event:    event,
+			observed: observed,
+			want:     []time.Time{event},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ld := logsAt(tt.event, tt.observed)
+
+			viaCollector, collectorDrops := ingestViaCollector(t, ld)
+			viaDirect, directDrops := ingestViaOTLPDirect(t, ld)
+
+			require.Equal(t, tt.want, viaCollector)
+			require.Equal(t, viaCollector, viaDirect, "both ingest paths must store the same record")
+
+			require.Equal(t, tt.wantDrops, collectorDrops)
+			require.Equal(t, collectorDrops, directDrops, "both ingest paths must refuse the same record")
+		})
+	}
+}
+
+// logsAt builds a one-record batch, leaving a zero time unset the way an OTLP sender does.
+func logsAt(event, observed time.Time) plog.Logs {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "api")
+
+	rec := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	rec.Body().SetStr("hello")
+	rec.SetSeverityNumber(plog.SeverityNumberInfo)
+
+	if !event.IsZero() {
+		rec.SetTimestamp(pcommon.Timestamp(event.UnixNano()))
+	}
+
+	if !observed.IsZero() {
+		rec.SetObservedTimestamp(pcommon.Timestamp(observed.UnixNano()))
+	}
+
+	return ld
+}
+
+// ingestViaCollector writes through [storagebackend.Backend.ConsumeLogs], the sink the collector
+// exporter drives, and reads the drop count back off its counter — the only report that path has.
+func ingestViaCollector(t *testing.T, ld plog.Logs) (stored []time.Time, dropped int) {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	b, ctx := backendWithMeter(t, sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	return storedTimestamps(ctx, t, b), int(droppedRecordCount(ctx, t, reader))
+}
+
+// ingestViaOTLPDirect posts the same batch as OTLP/HTTP to the [otlpdirect] handler odbingest
+// serves, and takes the drop count from the ingest stats that feed partial_success.
+func ingestViaOTLPDirect(t *testing.T, ld plog.Logs) (stored []time.Time, rejected int) {
+	t.Helper()
+
+	b, ctx := backendWithMeter(t, nil)
+
+	var stats []otlpdirect.Stats
+	h := otlpdirect.NewHandler(backendSink{b}, otlpdirect.HandlerConfig{
+		Observer: func(s otlpdirect.Stats) { stats = append(stats, s) },
+	})
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	raw, err := (&plog.ProtoMarshaler{}).MarshalLogs(ld)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, otlpdirect.LogsPath, bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body)
+
+	require.Len(t, stats, 1)
+
+	return storedTimestamps(ctx, t, b), stats[0].Rejected
+}
+
+func backendWithMeter(t *testing.T, mp *sdkmetric.MeterProvider) (*storagebackend.Backend, context.Context) {
+	t.Helper()
+
+	ctx := context.Background()
+	store, err := storage.InMemory()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
+
+	var opts []storagebackend.Option
+	if mp != nil {
+		opts = append(opts, storagebackend.WithMeterProvider(mp))
+	}
+
+	return storagebackend.New(store, opts...), ctx
+}
+
+// storedTimestamps reads every record back over a window starting at the unix epoch, so a record
+// stored at the epoch is seen rather than silently missed.
+func storedTimestamps(ctx context.Context, t *testing.T, b *storagebackend.Backend) []time.Time {
+	t.Helper()
+
+	node, err := b.Logs().Query(ctx, []logql.LabelMatcher{
+		{Label: "service_name", Op: logql.OpEq, Value: "api"},
+	})
+	require.NoError(t, err)
+
+	it, err := node.EvalPipeline(ctx, logqlengine.EvalParams{
+		Start: time.Unix(0, 0),
+		End:   time.Now().Add(time.Hour),
+		Limit: -1,
+	})
+	require.NoError(t, err)
+
+	var out []time.Time
+	for _, e := range drain(t, it) {
+		out = append(out, e.Timestamp.AsTime().UTC())
+	}
+
+	return out
+}
+
+func droppedRecordCount(ctx context.Context, t *testing.T, reader *sdkmetric.ManualReader) int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	var total int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "oteldb.storage.dropped_records" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			for _, dp := range sum.DataPoints {
+				total += dp.Value
+			}
+		}
+	}
+
+	return total
+}
+
+// backendSink adapts a [storagebackend.Backend] to [otlpdirect.Sink]; the handler needs all four
+// signals, and the Backend has no native profiles write.
+type backendSink struct{ *storagebackend.Backend }
+
+func (s backendSink) WriteLogs(ctx context.Context, batch siglog.Logs) error {
+	return s.Backend.WriteLogs(ctx, batch)
+}
+
+func (s backendSink) WriteTraces(ctx context.Context, batch sigtrace.Traces) error {
+	return s.Backend.WriteTraces(ctx, batch)
+}
+
+func (s backendSink) WriteMetrics(ctx context.Context, batch sigmetric.Metrics) error {
+	return s.Backend.WriteMetrics(ctx, batch)
+}
+
+func (backendSink) WriteProfiles(context.Context, *sigprofile.Profiles) error { return nil }

--- a/internal/storagebackend/open.go
+++ b/internal/storagebackend/open.go
@@ -142,6 +142,7 @@ func Open(ctx context.Context, cfg Config, lg *zap.Logger, m *app.Telemetry) (*B
 	)
 	b := New(store,
 		WithLogParallelism(cfg.LogQueryParallelism),
+		WithMeterProvider(m.MeterProvider()),
 	)
 	return b, store.Close, nil
 }

--- a/internal/storagebackend/storagebackend.go
+++ b/internal/storagebackend/storagebackend.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	promstorage "github.com/prometheus/prometheus/storage"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	otelmetric "go.opentelemetry.io/otel/metric"
 
 	"github.com/oteldb/storage"
 	"github.com/oteldb/storage/otlp/pdataconv"
@@ -64,6 +65,8 @@ type Backend struct {
 	// re-scanned by GC every query. The cache is keyed by content-addressed series id, so an entry is
 	// valid for the life of the series; it is bounded by resident cardinality.
 	labels *storagepromql.LabelCache
+	// dropped counts records the OTLP conversion refused. Nil unless [WithMeterProvider] was given.
+	dropped otelmetric.Int64Counter
 }
 
 // Option configures a [Backend].


### PR DESCRIPTION
Fixes #1350.

Two OTLP log ingest paths disagreed about a record with no `time_unix_nano`, and neither told the
sender. `pdataconv` (the collector path) falls back to `observed_time_unix_nano` and refuses a
record with neither; `internal/otlpdirect` (odbingest) had no such rule and stored both at the unix
epoch, outside every query window.

## Changes

- `otlpdirect.LogsConverter` adopts the `pdataconv` rule and returns the count, mirroring
  `MetricsConverter.Convert`. `ingestLogs` threads it into the existing `rejected` return, so it
  reaches `partial_success.rejected_log_records` (HTTP and gRPC) and the
  `odbingest.otlp.rejected_items` counter.
- `storagebackend.Backend.ConsumeLogs` no longer discards `pdataconv.AppendLogs`'s `dropped`: it
  adds it to a new `oteldb.storage.dropped_records` counter (`signal`, `reason` attributes), wired
  from `Open` via the `*app.Telemetry` meter provider. The collector's `ConsumeLogsFunc` returns
  only an error and failing the whole batch would be worse than the drop, so a counter is the
  honest ceiling on that path.
- `TestLogIngestPathsAgreeOnTime` (`internal/storagebackend`) drives **both** real ingest paths —
  `ConsumeLogs`, and the `otlpdirect` HTTP handler over a `storagebackend.Backend` sink — over
  `{no time, observed only, both}`, and asserts they store the same record at the same time and
  refuse the same one. `convertBoth` in `internal/otlpdirect` now also pins that the two converters
  agree on the drop count.

## Release note

Log records carrying neither `time_unix_nano` nor `observed_time_unix_nano` are now rejected by the
OTLP endpoints and reported as `rejected_log_records`, instead of being stored at the unix epoch.
Such records were never queryable, so nothing that worked stops working; senders that emit them now
see the rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)