### PR TITLE
test(storagebackup): stop charging sibling tests to the frame-length assertion

### DIFF
--- a/internal/storagebackup/stream_internal_test.go
+++ b/internal/storagebackup/stream_internal_test.go
@@ -187,8 +187,8 @@ func TestChunkStreamTruncated(t *testing.T) {
 // frame of any size up to the reader's bound. Allocating that up front turns a corrupt file into
 // an out-of-memory kill, which is the one failure a restore cannot report.
 func TestChunkStreamFrameLengthLie(t *testing.T) {
-	t.Parallel()
-
+	// Deliberately not parallel: MemStats.TotalAlloc counts the whole process, so a sibling test
+	// allocating inside the measurement window is charged to this one.
 	raw := lyingFrameFile(t, maxChunkBytes-1)
 
 	var before, after runtime.MemStats


### PR DESCRIPTION
`TestChunkStreamFrameLengthLie` asserts that a frame claiming 512 MB does not allocate 512 MB, by
reading `runtime.MemStats.TotalAlloc` on either side of the read. `TotalAlloc` is a **process-wide**
counter and the test was `t.Parallel()`, so every sibling test allocating inside that window was
charged to it — the reported number was the package's allocations, not the reader's.

Two separate agents hit it this week on full-suite runs, reporting ~21 MB against the 16 MB bound.
Measured here on the package under `-race`:

```
before: 8 of 12 runs failed
after:  0 of 12 runs failed
```

Dropping `t.Parallel()` is the whole fix: Go runs sequential tests to completion before releasing
the parallel ones, so the measurement window has the process to itself. The bound and the property
under test are unchanged.

I wrote this test in #1344, so the flake is mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)