### PR TITLE
perf(storagebackend): drop a level's non-matching records at the fetch

### DIFF
--- a/internal/storagebackend/bench_logs_test.go
+++ b/internal/storagebackend/bench_logs_test.go
@@ -16,11 +16,28 @@ import (
 	"github.com/oteldb/oteldb/internal/storagebackend"
 )
 
+// evenLevels rotates through every severity, which is the pessimistic corpus for a level query:
+// the matched level is a sixth of the window and no part holds one level only.
+var evenLevels = []int{0, 1, 2, 3, 4, 5}
+
+// skewedLevels is the shape real telemetry has — mostly info, a warn in twelve, an error in fifty —
+// which is where filtering a level before materialization is worth the most.
+var skewedLevels = func() (out []int) {
+	for range 45 {
+		out = append(out, 2)
+	}
+	out = append(out, 3, 3, 3, 3, 4)
+
+	return out
+}()
+
 // genBenchLogs builds n synthetic log records modeled on the benchmark's
 // otelbench stream: one service, rotating severities, http.method/status_code
 // attributes, and a JSON body carrying level/method/status — so line filters,
 // json parsing and metric aggregation all exercise real data.
-func genBenchLogs(n int, start time.Time) plog.Logs {
+//
+// mix is the level distribution, as indices into the severity table cycled over the records.
+func genBenchLogs(n int, start time.Time, mix []int) plog.Logs {
 	levels := []struct {
 		num  plog.SeverityNumber
 		text string
@@ -42,7 +59,7 @@ func genBenchLogs(n int, start time.Time) plog.Logs {
 	recs := sl.LogRecords()
 	recs.EnsureCapacity(n)
 	for i := range n {
-		lv := levels[i%len(levels)]
+		lv := levels[mix[i%len(mix)]]
 		method := methods[i%len(methods)]
 		status := statuses[i%len(statuses)]
 		ts := start.Add(time.Duration(i) * time.Millisecond)
@@ -65,6 +82,39 @@ func genBenchLogs(n int, start time.Time) plog.Logs {
 // representative suite query. Apple-to-apple with the docker benchmark's queries,
 // but in-process so it profiles in seconds.
 func BenchmarkLogsQuery(b *testing.B) {
+	runLogsQueryBench(b, evenLevels, []benchQuery{
+		{"select_service", `{service_name="api"}`, false},
+		{"line_filter", `{service_name="api"} |= "GET"`, false},
+		{"json_status", `{service_name="api"} | json | status>=400`, false},
+		// A level selector is resolved case-insensitively and cannot be applied exactly by the fetch
+		// (the level is the severity number when set, else the severity text — two columns), so every
+		// surviving record is re-checked against it. The fetch still drops what the severity number
+		// alone disproves.
+		{"select_level", `{service_name="api", level="error"}`, false},
+		{"select_level_regexp", `{service_name="api", level=~"e.+"}`, false},
+		{"metric_count_by_level", `sum by (level) (count_over_time({service_name="api"}[1m]))`, true},
+		{"metric_rate_by_level", `sum by (level) (rate({service_name="api"}[1m]))`, true},
+	})
+}
+
+// BenchmarkLogsQuerySkewedLevels is [BenchmarkLogsQuery]'s level queries over a corpus skewed the
+// way production logs are. The even corpus understates what filtering a level at the fetch is
+// worth: there, five of six records are dropped, here forty-nine of fifty.
+func BenchmarkLogsQuerySkewedLevels(b *testing.B) {
+	runLogsQueryBench(b, skewedLevels, []benchQuery{
+		{"select_level", `{service_name="api", level="error"}`, false},
+		{"select_level_regexp", `{service_name="api", level=~"e.+"}`, false},
+		{"metric_count_by_level", `sum by (level) (count_over_time({service_name="api"}[1m]))`, true},
+	})
+}
+
+type benchQuery struct {
+	name   string
+	q      string
+	metric bool
+}
+
+func runLogsQueryBench(b *testing.B, mix []int, queries []benchQuery) {
 	const n = 50_000
 	ctx := context.Background()
 	store, err := storage.InMemory()
@@ -73,7 +123,7 @@ func BenchmarkLogsQuery(b *testing.B) {
 	backend := storagebackend.New(store)
 
 	start := time.Now().Add(-10 * time.Minute).Truncate(time.Second)
-	require.NoError(b, backend.ConsumeLogs(ctx, genBenchLogs(n, start)))
+	require.NoError(b, backend.ConsumeLogs(ctx, genBenchLogs(n, start, mix)))
 
 	engine, err := logqlengine.NewEngine(backend.Logs(), logqlengine.Options{
 		Optimizers: []logqlengine.Optimizer{&storagebackend.LogQLOptimizer{}},
@@ -81,23 +131,6 @@ func BenchmarkLogsQuery(b *testing.B) {
 	require.NoError(b, err)
 
 	end := start.Add(time.Duration(n) * time.Millisecond).Add(time.Minute)
-	queries := []struct {
-		name   string
-		q      string
-		metric bool
-	}{
-		{"select_service", `{service_name="api"}`, false},
-		{"line_filter", `{service_name="api"} |= "GET"`, false},
-		{"json_status", `{service_name="api"} | json | status>=400`, false},
-		// A level selector is resolved case-insensitively and cannot be pushed into the fetch
-		// (severity is a column, not an attribute key), so every materialized record is re-checked
-		// against it — which is where any per-record work in that check shows up.
-		{"select_level", `{service_name="api", level="error"}`, false},
-		{"select_level_regexp", `{service_name="api", level=~"e.+"}`, false},
-		{"metric_count_by_level", `sum by (level) (count_over_time({service_name="api"}[1m]))`, true},
-		{"metric_rate_by_level", `sum by (level) (rate({service_name="api"}[1m]))`, true},
-	}
-
 	for _, tc := range queries {
 		b.Run(tc.name, func(b *testing.B) {
 			params := logqlengine.EvalParams{
@@ -114,7 +147,7 @@ func BenchmarkLogsQuery(b *testing.B) {
 
 			b.ReportAllocs()
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if _, err := q.Eval(ctx, params); err != nil {
 					b.Fatal(err)
 				}

--- a/internal/storagebackend/logs.go
+++ b/internal/storagebackend/logs.go
@@ -311,14 +311,20 @@ func (n *logStreamNode) streamFilters(ctx context.Context, lo, hi int64) (matche
 	}
 	add(n.selector)       // stream selector labels
 	add(n.pipelineLabels) // offloaded pipeline label filters (| L="v")
+
+	// A level matcher resolves through no attribute key — severity is a record column — so it is
+	// pushed separately, as the superset condition [levelCondition] builds.
+	if c, ok := levelCondition(n.selector); ok {
+		conditions = append(conditions, c)
+	}
 	if len(wanted) == 0 {
 		// Nothing to push: fully pushed only when the selector is empty (match-all).
-		return nil, nil, len(n.selector) == 0
+		return nil, conditions, len(n.selector) == 0
 	}
 
 	keys, err := n.q.b.src.LogKeys(ctx, n.q.b.tenant, lo, hi)
 	if err != nil {
-		return nil, nil, false // best effort: fall back to in-memory filtering.
+		return nil, conditions, false // best effort: fall back to in-memory filtering.
 	}
 
 	// Resolve each wanted normalized label to its raw attribute key(s) and their merged scope. A

--- a/internal/storagebackend/logs_level_pushdown.go
+++ b/internal/storagebackend/logs_level_pushdown.go
@@ -1,0 +1,81 @@
+package storagebackend
+
+import (
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/storage/query/fetch"
+	"github.com/oteldb/storage/signal"
+	siglog "github.com/oteldb/storage/signal/log"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine/logqlabels"
+)
+
+// maxSeverityNumber is the largest severity number OTLP names ([plog.SeverityNumberFatal4]).
+const maxSeverityNumber = int64(plog.SeverityNumberFatal4)
+
+// levelCondition resolves the selector's level matchers to a per-record condition on the severity
+// column, so the fetch drops non-matching records before they are materialized into entries.
+//
+// It is a **superset**, never an exact filter: a level is the severity number's name when the number
+// is set, else the record's severity text ([logqlabels.Level]), and a condition sees one column. So
+// every value the number cannot decide — unspecified (0), or a number OTLP does not name — passes
+// through to the in-memory [matchSelector] re-check, which is what keeps a text-only record
+// (`SeverityText: "NOTICE"`, no number) from being dropped here.
+//
+// For the same reason the level never counts as applied: `selectorPushed` stays false whenever a
+// level matcher is present.
+//
+// The condition carries no [fetch.Condition.AnyEqual] hint, for two reasons. It would be unsound:
+// a set hint must contain every value Match accepts, and Match accepts any number OTLP does not
+// name — an unbounded set. And it would buy nothing: severity is an int64 column, the record engine
+// builds blooms over byte columns only, and it compiles an int column to a per-value memo that
+// consults Match alone. So no part is skipped by this; what is saved is the materialization of the
+// records it drops.
+func levelCondition(matchers []logql.LabelMatcher) (fetch.Condition, bool) {
+	var level preparedSelector
+	for _, m := range prepareSelector(matchers) {
+		if m.level {
+			level = append(level, m)
+		}
+	}
+	if len(level) == 0 {
+		return fetch.Condition{}, false
+	}
+
+	keep := make([]bool, maxSeverityNumber+1)
+	kept := 0
+	for n := int64(1); n <= maxSeverityNumber; n++ {
+		if !level.matchesLevel(logqlabels.Level(plog.SeverityNumber(n), "")) {
+			continue
+		}
+		keep[n] = true
+		kept++
+	}
+	if kept == int(maxSeverityNumber) {
+		return fetch.Condition{}, false
+	}
+
+	return fetch.Condition{
+		Column: siglog.ColSeverity,
+		Match: func(v signal.Value) bool {
+			n := v.Int()
+			if n < 1 || n > maxSeverityNumber {
+				return true
+			}
+			return keep[n]
+		},
+	}, true
+}
+
+// matchesLevel reports whether value satisfies every matcher, which must all be level matchers —
+// so [preparedMatcher.matches] resolves them case-insensitively, exactly as the per-record check
+// does.
+func (p preparedSelector) matchesLevel(value string) bool {
+	for _, m := range p {
+		if !m.matches(value) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/storagebackend/logs_level_pushdown_test.go
+++ b/internal/storagebackend/logs_level_pushdown_test.go
@@ -1,0 +1,105 @@
+package storagebackend_test
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/oteldb/oteldb/internal/logql"
+	"github.com/oteldb/oteldb/internal/logql/logqlengine"
+)
+
+// TestLogLevelPushdownSuperset pins the property that makes pushing a level matcher into the fetch
+// sound: the severity *number* does not decide a level on its own, so the pushed condition must let
+// every record the number cannot decide through to the in-memory re-check.
+//
+// The corpus is built out of exactly those records — a level spelled only in the severity text, a
+// text that disagrees with its number, a number OTLP does not name — so a condition that filtered
+// on the number alone would answer with fewer rows than the selector matches.
+func TestLogLevelPushdownSuperset(t *testing.T) {
+	b, ctx := newBackend(t)
+
+	ts := time.Now().Truncate(time.Second)
+
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "api")
+	sl := rl.ScopeLogs().AppendEmpty()
+	records := []struct {
+		body     string
+		severity plog.SeverityNumber
+		text     string
+		level    string
+	}{
+		{"numbered", plog.SeverityNumberError, "ERROR", "error"},
+		{"text only", plog.SeverityNumberUnspecified, "ERROR", "error"},
+		{"text only, unknown level", plog.SeverityNumberUnspecified, "NOTICE", "notice"},
+		// The number wins over a text that disagrees with it, so this is an info record.
+		{"number wins", plog.SeverityNumberInfo, "ERROR", "info"},
+		{"plain info", plog.SeverityNumberInfo, "INFO", "info"},
+		{"no level at all", plog.SeverityNumberUnspecified, "", ""},
+	}
+	for _, r := range records {
+		rec := sl.LogRecords().AppendEmpty()
+		rec.SetTimestamp(pcommon.Timestamp(ts.UnixNano()))
+		rec.Body().SetStr(r.body)
+		rec.SetSeverityNumber(r.severity)
+		rec.SetSeverityText(r.text)
+	}
+	require.NoError(t, b.ConsumeLogs(ctx, ld))
+
+	lq := b.Logs()
+	start, end := ts.Add(-time.Hour), ts.Add(time.Hour)
+
+	query := func(t *testing.T, matchers ...logql.LabelMatcher) []string {
+		t.Helper()
+		node, err := lq.Query(ctx, matchers)
+		require.NoError(t, err)
+		it, err := node.EvalPipeline(ctx, logqlengine.EvalParams{Start: start, End: end, Limit: -1})
+		require.NoError(t, err)
+
+		var bodies []string
+		for _, e := range drain(t, it) {
+			bodies = append(bodies, e.Line)
+		}
+		return bodies
+	}
+
+	service := logql.LabelMatcher{Label: "service_name", Op: logql.OpEq, Value: "api"}
+	for _, tc := range []struct {
+		name    string
+		matcher logql.LabelMatcher
+		want    []string
+	}{
+		{
+			"equal",
+			logql.LabelMatcher{Label: "level", Op: logql.OpEq, Value: "error"},
+			[]string{"numbered", "text only"},
+		},
+		{
+			"regexp",
+			logql.LabelMatcher{Label: "detected_level", Op: logql.OpRe, Value: "e.+", Re: regexp.MustCompile(`^(?:e.+)$`)},
+			[]string{"numbered", "text only"},
+		},
+		{
+			"not equal",
+			logql.LabelMatcher{Label: "level", Op: logql.OpNotEq, Value: "error"},
+			[]string{"text only, unknown level", "number wins", "plain info", "no level at all"},
+		},
+		{
+			// No severity number spells "notice", so the pushed set is empty — every match has to
+			// come from a record the number could not decide.
+			"text only level",
+			logql.LabelMatcher{Label: "level", Op: logql.OpEq, Value: "notice"},
+			[]string{"text only, unknown level"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.ElementsMatch(t, tc.want, query(t, service, tc.matcher))
+		})
+	}
+}


### PR DESCRIPTION
Closes #1360.

## What the measurement said

The issue's premise — push the level as a `fetch.Condition.AnyEqual` set so a part holding only
Info is skipped outright — **does not hold on storage v0.45.1**, and the PR does not do it:

- `severity` is a `KindInt64` column. `writeBlooms` builds a bloom only for the schema's *byte*
  columns, so `part.conditionMayMatch` finds `p.blooms["severity"] == nil` and returns "may match"
  before it ever looks at a hint. **No part is ever skipped by a severity condition.**
- In the row scan, `fetchPlan.compileCond` compiles an int column to `evalIntMemo`, which consults
  `Match` alone (memoized per distinct value) and never reads `AnyEqual`. Only the byte-column
  forms (`evalDict`, `evalSetScan`) use the set.
- A set hint would also be **unsound** here: it must contain every value `Match` accepts, and this
  `Match` accepts any severity number OTLP does not name — an unbounded set.

So no `AnyEqual`. What is left is still worth a lot: the condition drops non-matching records
*before materialization*, which is where the cost was.

## The shape

`levelCondition` compiles the selector's level matchers (case-insensitively, through the same
`preparedMatcher` the per-record check uses) into the set of severity numbers whose
`logqlabels.Level` name matches, and pushes a `Match` on the severity column. It is a **superset**:
`Unspecified` (0) and any number OTLP does not name pass through, so a text-only level
(`SeverityText: "NOTICE"`, no number) survives to `matchSelector` — the mistake #1359 describes.
The level still never counts as applied, so `selectorPushed` is unchanged.

`TestLogLevelPushdownSuperset` pins exactly that, over a corpus built from the records a naive
pushdown would drop. Reverting the escape hatch fails it (and `TestBackendLogLevels`).

## Numbers

`-benchtime 30x`, before/after interleaved over three rounds, n=12 each (AMD Ryzen 9 5950X).
`LogsQuerySkewedLevels` is a new corpus skewed the way telemetry is (90% info, 8% warn, 2% error);
the pre-existing even corpus is the pessimistic case.

```
                                               │    before    │                after                │
                                               │    sec/op    │   sec/op     vs base                │
LogsQuery/select_level-32                         33.33m ± 2%   10.02m ± 4%  -69.95% (p=0.000 n=12)
LogsQuery/select_level_regexp-32                  37.14m ± 1%   11.03m ± 2%  -70.30% (p=0.000 n=12)
LogsQuerySkewedLevels/select_level-32            31.300m ± 2%   3.494m ± 8%  -88.84% (p=0.000 n=12)
LogsQuerySkewedLevels/select_level_regexp-32     34.973m ± 2%   3.733m ± 4%  -89.32% (p=0.000 n=12)
LogsQuerySkewedLevels/metric_count_by_level-32    3.696m ± 3%   3.684m ± 2%        ~ (p=0.932 n=12)
geomean                                           21.87m        5.559m       -74.59%

                                               │  allocs/op   │  allocs/op    vs base                │
LogsQuery/select_level-32                         634.5k ± 1%   134.5k ±  4%  -78.80% (p=0.000 n=12)
LogsQuerySkewedLevels/select_level-32            605.17k ± 1%   17.19k ± 29%  -97.16% (p=0.000 n=12)
```

**What including `Unspecified` costs.** It costs pruning in proportion to the text-only fraction,
and nothing else. On a corpus where *every* record carries severity text and no number — the worst
case — the pushdown buys nothing and costs no time: 28.06m ± 3% → 28.56m ± 4% (p=0.089, ~), at
+7% B/op. In OTLP most records carry a number, so this is the tail, not the common case.

**The bucketed-sampling fast path is still unreachable** with a level matcher, by design: the level
is the number *or* the text, two columns, and a condition sees one — so it can never be exact and
`selectorPushed` must stay false. Note the Drilldown panel shape
`sum by (level) (count_over_time({service_name="api"}[1m]))` has no level *matcher* and already
takes the fast path; only a level-*filtered* panel falls back, and that fallback is now fed far
fewer records.

## Verification

- `go test ./internal/storagebackend/... -race`
- `E2E=1 go test ./integration/lokie2e/`
- `golangci-lint run ./internal/storagebackend/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)